### PR TITLE
fix: create cozy url

### DIFF
--- a/src/ducks/authentication/steps/Welcome.jsx
+++ b/src/ducks/authentication/steps/Welcome.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { translate, Button } from 'cozy-ui/react'
 
 import styles from '../styles'
-import { getDevicePlatform } from '../lib/client';
+import { getDevicePlatform } from '../lib/client'
 
 export class Welcome extends Component {
   render () {


### PR DESCRIPTION
We changed the webpage's URL where users are redirected if they want to create a cozy.

Related to https://github.com/cozy/cozy-drive/pull/855 (see https://trello.com/c/TMNxeLZO/917-1-changer-les-urls-pour-la-cr%C3%A9ation-de-cozy)