### PR TITLE
fix(account switcher): can be closed by clicking below

### DIFF
--- a/src/ducks/account/AccountSwitch.styl
+++ b/src/ducks/account/AccountSwitch.styl
@@ -53,10 +53,10 @@
     position fixed
     top 78px
     left 0
-    bottom 10px
     width 440px
     overflow auto
     z-index: 60
+    max-height: "calc(100vh - %s)" % @top
 
 .account-switch-menu
     margin 20px
@@ -137,11 +137,10 @@
         z-index 61
         position fixed
         top 58px
-        bottom 10px
         left 50%
         margin-left -200px
         width 400px
-        max-height inherit
+        max-height "calc(100vh - %s)" % @top
         overflow auto
 
     .account-switch-menu


### PR DESCRIPTION
Fixing the bug in which clicking below the account switcher (green areas in following screenshots) modal didn't close it.

![desktop](https://user-images.githubusercontent.com/1606068/38503399-475877d8-3c12-11e8-9a4f-a88350f069dc.png)
![mobile](https://user-images.githubusercontent.com/1606068/38503402-478d43a0-3c12-11e8-9a10-bc0903c85ad2.png)
