### PR TITLE
feat: add virtual groups for each accounts types

### DIFF
--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -17,6 +17,7 @@ import { filterByDoc, getFilteringDoc, resetFilterByDoc } from 'ducks/filters'
 import styles from './AccountSwitch.styl'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { getAccountInstitutionLabel } from './helpers.js'
+import { getAllGroups } from 'selectors'
 
 const { BarRight } = cozy.bar
 
@@ -221,16 +222,21 @@ class AccountSwitch extends Component {
 
   render() {
     const {
+      t,
       filteringDoc,
       filterByDoc,
       resetFilterByDoc,
       breakpoints: { isMobile, isTablet, isDesktop }
     } = this.props
     const { open } = this.state
-    let { accounts, groups } = this.props
-    const isFetching = isLoading(accounts) || isLoading(groups)
+    let { accounts, groups, groupsDocs } = this.props
+    const isFetching = isLoading(accounts) || isLoading(groupsDocs)
+
     accounts = accounts.data
-    groups = groups.data
+    groups = groups.map(group => ({
+      ...group,
+      label: group.virtual ? t(`Data.accountTypes.${group.label}`) : group.label
+    }))
 
     if (!accounts || accounts.length === 0) {
       return
@@ -297,7 +303,8 @@ AccountSwitch.propTypes = {
 }
 
 const mapStateToProps = state => ({
-  filteringDoc: getFilteringDoc(state)
+  filteringDoc: getFilteringDoc(state),
+  groups: getAllGroups(state)
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -307,7 +314,7 @@ const mapDispatchToProps = dispatch => ({
 
 const mapDocumentsToProps = () => ({
   accounts: fetchCollection('accounts', ACCOUNT_DOCTYPE),
-  groups: fetchCollection('groups', GROUP_DOCTYPE)
+  groupsDocs: fetchCollection('groups', GROUP_DOCTYPE)
 })
 
 export default compose(

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -277,13 +277,10 @@ class Balance extends React.Component {
     const { t, settingsCollection, breakpoints: { isMobile } } = this.props
     let { accounts, groups } = this.props
     accounts = sortBy(accounts.data, ['institutionLabel', 'label'])
-    groups = groups.map(group => {
-      if (group.virtual) {
-        group.label = t(`Data.accountTypes.${group.label}`)
-      }
-
-      return group
-    })
+    groups = groups.map(group => ({
+      ...group,
+      label: group.virtual ? t(`Data.accountTypes.${group.label}`) : group.label
+    }))
 
     groups = sortBy(groups, 'label')
 

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -18,7 +18,8 @@ import CollectLink from 'ducks/settings/CollectLink'
 import { getSettings, fetchSettingsCollection } from 'ducks/settings'
 import { filterByDoc, getFilteringDoc } from 'ducks/filters'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
-import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
+import { ACCOUNT_DOCTYPE } from 'doctypes'
+import { getAllGroups } from 'selectors'
 
 import styles from './Balance.styl'
 import btnStyles from 'styles/buttons'
@@ -276,7 +277,15 @@ class Balance extends React.Component {
     const { t, settingsCollection, breakpoints: { isMobile } } = this.props
     let { accounts, groups } = this.props
     accounts = sortBy(accounts.data, ['institutionLabel', 'label'])
-    groups = sortBy(groups.data, 'label')
+    groups = groups.map(group => {
+      if (group.virtual) {
+        group.label = t(`Data.accountTypes.${group.label}`)
+      }
+
+      return group
+    })
+
+    groups = sortBy(groups, 'label')
 
     if (accounts === null || groups === null) {
       return <Loading />
@@ -331,13 +340,13 @@ class Balance extends React.Component {
   }
 }
 
-const mapStateToProps = () => ({
-  settingsCollection: fetchSettingsCollection()
+const mapStateToProps = state => ({
+  settingsCollection: fetchSettingsCollection(),
+  groups: getAllGroups(state)
 })
 
 const mapDocumentsToProps = () => ({
-  accounts: fetchCollection('accounts', ACCOUNT_DOCTYPE),
-  groups: fetchCollection('groups', GROUP_DOCTYPE)
+  accounts: fetchCollection('accounts', ACCOUNT_DOCTYPE)
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/ducks/filters/index.js
+++ b/src/ducks/filters/index.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux'
 import { createSelector } from 'reselect'
 import { parse, format, isWithinRange } from 'date-fns'
 import SelectDates from './SelectDates'
-import { getTransactions, getGroups, getAccounts } from 'selectors'
+import { getTransactions, getAllGroups, getAccounts } from 'selectors'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { sortBy, last, keyBy, find } from 'lodash'
 import { DESTROY_ACCOUNT } from 'actions/accounts'
@@ -34,13 +34,15 @@ export const getFilteredAccountIds = state => {
       return availableAccountIds
     }
   } else if (doctype === GROUP_DOCTYPE) {
-    const groups = getGroups(state)
+    const groups = getAllGroups(state)
     const group = find(groups, { _id: id })
     if (group) {
       return group.accounts
     } else {
       return availableAccountIds
     }
+  } else {
+    throw new Error('The filtering doc doesn\'t have any type. Please check it has a `_type` property')
   }
 }
 

--- a/src/ducks/filters/index.js
+++ b/src/ducks/filters/index.js
@@ -42,7 +42,9 @@ export const getFilteredAccountIds = state => {
       return availableAccountIds
     }
   } else {
-    throw new Error('The filtering doc doesn\'t have any type. Please check it has a `_type` property')
+    throw new Error(
+      "The filtering doc doesn't have any type. Please check it has a `_type` property"
+    )
   }
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -103,6 +103,16 @@
     "total-balance": "Total"
   },
   "Data": {
+    "accountTypes": {
+      "asset": "Assets accounts",
+      "bank": "Bank accounts",
+      "cash": "Cash accounts",
+      "checkings": "Checkings accounts",
+      "credit card": "Credit card accounts",
+      "liability": "Liability accounts",
+      "none": "None",
+      "savings": "Savings accounts"
+    },
     "categories": {
       "uncategorized": "To be categorized",
       "incomeCat": "Earnings",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -146,6 +146,16 @@
   },
 
   "Data": {
+    "accountTypes": {
+      "asset": "Comptes d'actif",
+      "bank": "Comptes bancaires",
+      "cash": "Comptes de caisse",
+      "checkings": "Comptes courant",
+      "credit card": "Cartes de crédit",
+      "liability": "Comptes de dettes",
+      "none": "Aucun type",
+      "savings": "Comptes d'épargne"
+    },
     "categories": {
       "uncategorized": "A catégoriser",
       "incomeCat": "Revenus",

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,6 +1,7 @@
 import { getCollection } from 'cozy-client'
 import { createSelector } from 'reselect'
 import groupBy from 'lodash/groupBy'
+import { GROUP_DOCTYPE } from 'doctypes'
 
 export const getTransactions = state => {
   const col = getCollection(state, 'transactions')
@@ -24,6 +25,7 @@ export const getVirtualGroups = createSelector(
       .entries(accountsByType)
       .map(([type, accounts]) => ({
         _id: type,
+        _type: GROUP_DOCTYPE,
         label: type.toLowerCase(),
         accounts: accounts.map(account => account._id),
         virtual: true

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,4 +1,6 @@
 import { getCollection } from 'cozy-client'
+import { createSelector } from 'reselect'
+import groupBy from 'lodash/groupBy'
 
 export const getTransactions = state => {
   const col = getCollection(state, 'transactions')
@@ -12,3 +14,25 @@ export const getAccounts = state => {
   const col = getCollection(state, 'accounts')
   return (col && col.data) || []
 }
+
+export const getVirtualGroups = createSelector(
+  [getAccounts],
+  accounts => {
+    const accountsByType = groupBy(accounts, account => account.type)
+
+    const virtualGroups = Object
+      .entries(accountsByType)
+      .map(([type, accounts]) => ({
+        label: type.toLowerCase(),
+        accounts: accounts.map(account => account._id),
+        virtual: true
+      }))
+
+    return virtualGroups
+  }
+)
+
+export const getAllGroups = createSelector(
+  [getGroups, getVirtualGroups],
+  (groups, virtualGroups) => [...groups, ...virtualGroups]
+)

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -16,24 +16,21 @@ export const getAccounts = state => {
   return (col && col.data) || []
 }
 
-export const getVirtualGroups = createSelector(
-  [getAccounts],
-  accounts => {
-    const accountsByType = groupBy(accounts, account => account.type)
+export const getVirtualGroups = createSelector([getAccounts], accounts => {
+  const accountsByType = groupBy(accounts, account => account.type)
 
-    const virtualGroups = Object
-      .entries(accountsByType)
-      .map(([type, accounts]) => ({
-        _id: type,
-        _type: GROUP_DOCTYPE,
-        label: type.toLowerCase(),
-        accounts: accounts.map(account => account._id),
-        virtual: true
-      }))
+  const virtualGroups = Object.entries(accountsByType).map(
+    ([type, accounts]) => ({
+      _id: type,
+      _type: GROUP_DOCTYPE,
+      label: type.toLowerCase(),
+      accounts: accounts.map(account => account._id),
+      virtual: true
+    })
+  )
 
-    return virtualGroups
-  }
-)
+  return virtualGroups
+})
 
 export const getAllGroups = createSelector(
   [getGroups, getVirtualGroups],

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -23,6 +23,7 @@ export const getVirtualGroups = createSelector(
     const virtualGroups = Object
       .entries(accountsByType)
       .map(([type, accounts]) => ({
+        _id: type,
         label: type.toLowerCase(),
         accounts: accounts.map(account => account._id),
         virtual: true


### PR DESCRIPTION
This adds a virtual groups that group the user's accounts by their types.

![image](https://user-images.githubusercontent.com/1606068/38604782-b77bec38-3d71-11e8-809e-3306884b0677.png)

![image](https://user-images.githubusercontent.com/1606068/38604791-bec3bb1a-3d71-11e8-8212-854e8df66a39.png)
