### PR TITLE
feat: show transaction account on movements list

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "cozy-client": "0.4.2",
     "cozy-client-js": "0.8.0",
     "cozy-konnector-libs": "^3.0.13",
-    "cozy-ui": "git://github.com/cozy/cozy-ui.git",
+    "cozy-ui": "7.11.0",
     "date-fns": "^1.28.2",
     "hammerjs": "^2.0.8",
     "localforage": "^1.5.0",

--- a/src/components/PopupSelect/index.jsx
+++ b/src/components/PopupSelect/index.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import cx from 'classnames'
 import { Modal, Icon } from 'cozy-ui/react'
-import { ModalTitle, ModalDescription } from 'cozy-ui/react/Modal'
+import { ModalHeader, ModalDescription } from 'cozy-ui/react/Modal'
 import { Media, Bd, Img } from 'components/Media'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 
@@ -75,16 +75,18 @@ class PopupSelect extends Component {
               <Icon icon="back" color={palette['coolGrey']} />
             </Img>
           )}
-        <Bd>{item.title}</Bd>
+        <Bd>
+          <h2>{item.title}</h2>
+        </Bd>
       </Media>
     )
   }
 
   render() {
     return (
-      <Modal overflowHidden secondaryAction={this.props.onCancel}>
+      <Modal overflowHidden dismissAction={this.props.onCancel} into="body">
         <div className={styles.PopupSelect__title}>
-          <ModalTitle>{this.renderTitle()}</ModalTitle>
+          <ModalHeader>{this.renderTitle()}</ModalHeader>
         </div>
         <ModalDescription className="u-pb-0">
           {this.renderList()}

--- a/src/ducks/commons/Nav.jsx
+++ b/src/ducks/commons/Nav.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import {
   translate,
   Nav as UINav,
-  NavLink as UINavLink,
   NavItem,
   NavIcon,
-  NavText
+  NavText,
+  genNavLink
 } from 'cozy-ui/react'
 import { Link } from 'react-router'
 
@@ -14,15 +14,7 @@ import arrows from 'assets/icons/icon-arrow-left-right.svg'
 import graph from 'assets/icons/icon-graph.svg'
 import people from 'assets/icons/icon-people.svg'
 
-const NavLink = ({ to, children }) => (
-  <Link
-    to={to}
-    activeClassName={UINavLink.activeClassName}
-    className={UINavLink.className}
-  >
-    {children}
-  </Link>
-)
+const NavLink = genNavLink(Link)
 
 const Nav = ({ t }) => (
   <UINav>

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -63,8 +63,8 @@ select-date-height-small = 2.5rem
     border-bottom-left-radius 0
     border-left-width 0
 
-.next-icon
-    transform rotate(180deg)
+    .next-icon
+        transform rotate(180deg)
 
 +small-screen()
     .select-dates

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -45,7 +45,15 @@ const showComingSoon = t => {
 }
 
 const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
-  ({ t, f, transaction, isExtraLarge, showCategoryChoice, ...props }) => {
+  ({
+    t,
+    f,
+    transaction,
+    isExtraLarge,
+    showCategoryChoice,
+    filteringOnAccount,
+    ...props
+  }) => {
     const categoryId = getCategoryId(transaction)
     const categoryName = getCategoryName(categoryId)
     const categoryTitle = t(`Data.subcategories.${categoryName}`)
@@ -68,7 +76,7 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
             <Bd className="u-pl-1">
               <ListItemText
                 primaryText={getLabel(transaction)}
-                secondaryText={transaction.account.label}
+                secondaryText={!filteringOnAccount && transaction.account.label}
               />
             </Bd>
           </Media>
@@ -105,7 +113,7 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
 )
 
 const TableTrNoDesktop = translate()(
-  ({ t, transaction, selectTransaction, ...props }) => {
+  ({ t, transaction, selectTransaction, filteringOnAccount, ...props }) => {
     return (
       <tr
         onClick={() => selectTransaction(transaction)}
@@ -128,7 +136,7 @@ const TableTrNoDesktop = translate()(
             <Bd className="u-mr-half u-ellipsis">
               <ListItemText
                 primaryText={getLabel(transaction)}
-                secondaryText={transaction.account.label}
+                secondaryText={!filteringOnAccount && transaction.account.label}
               />
             </Bd>
             <Img style={{ flexBasis: '1rem' }}>
@@ -233,6 +241,7 @@ class Transactions extends React.Component {
                   <TableTrDesktop
                     transaction={transaction}
                     isExtraLarge={isExtraLarge}
+                    filteringOnAccount
                     {...props}
                   />
                 ) : (

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import cx from 'classnames'
 import format from 'date-fns/format'
-import { translate, withBreakpoints } from 'cozy-ui/react'
+import { translate, withBreakpoints, ListItemText } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
 import { flowRight as compose, toPairs, groupBy, sortBy } from 'lodash'
 import { Table, TdSecondary } from 'components/Table'
@@ -68,7 +68,12 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
                 className={styles['bnk-op-caticon']}
               />
             </Img>
-            <Bd className="u-pl-1">{getLabel(transaction)}</Bd>
+            <Bd className="u-pl-1">
+              <ListItemText
+                primaryText={getLabel(transaction)}
+                secondaryText={transaction.account.label}
+              />
+            </Bd>
           </Media>
         </td>
         <TdSecondary className={sAmount}>
@@ -120,7 +125,12 @@ const TableTrNoDesktop = translate()(
                 category={getParentCategory(getCategoryId(transaction))}
               />
             </Img>
-            <Bd className="u-mr-half u-ellipsis">{getLabel(transaction)}</Bd>
+            <Bd className="u-mr-half u-ellipsis">
+              <ListItemText
+                primaryText={getLabel(transaction)}
+                secondaryText={transaction.account.label}
+              />
+            </Bd>
             <Img style={{ flexBasis: '1rem' }}>
               <TransactionActions
                 transaction={transaction}

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -31,8 +31,8 @@ const sActions = styles['bnk-op-actions']
 const TableHeadDesktop = ({ t }) => (
   <thead>
     <tr>
-      <td className={sDate}>{t('Transactions.header.date')}</td>
       <td className={sDesc}>{t('Transactions.header.description')}</td>
+      <td className={sDate}>{t('Transactions.header.date')}</td>
       <td className={sAmount}>{t('Transactions.header.amount')}</td>
       <td className={sAction}>{t('Transactions.header.action')}</td>
       <td className={sActions}>&nbsp;</td>
@@ -57,9 +57,6 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
 
     return (
       <tr>
-        <TdSecondary className={sDate}>
-          {f(transaction.date, `DD ${isExtraLarge ? 'MMMM' : 'MMM'} YYYY`)}
-        </TdSecondary>
         <td className={cx(sDesc, 'u-pv-half', 'u-pl-1')}>
           <Media>
             <Img title={categoryTitle} onClick={showCategoryChoice}>
@@ -76,6 +73,9 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
             </Bd>
           </Media>
         </td>
+        <TdSecondary className={sDate}>
+          {f(transaction.date, `DD ${isExtraLarge ? 'MMMM' : 'MMM'} YYYY`)}
+        </TdSecondary>
         <TdSecondary className={sAmount}>
           <Figure
             total={transaction.amount}

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -9,6 +9,7 @@
     .bnk-op-date
         maxed-flex-basis 15%
         color coolGrey
+        text-align right
 
     .bnk-op-desc
         maxed-flex-basis 30%

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -26,7 +26,7 @@ import BackButton from 'components/BackButton'
 import { hydrateTransaction } from 'documents/transaction'
 import TransactionsWithSelection from './TransactionsWithSelection'
 import styles from './TransactionsPage.styl'
-import { TRIGGER_DOCTYPE } from 'doctypes'
+import { TRIGGER_DOCTYPE, ACCOUNT_DOCTYPE } from 'doctypes'
 import { getBrands } from 'ducks/brandDictionary'
 
 const isPendingOrLoading = function(col) {
@@ -64,7 +64,7 @@ class TransactionsPage extends Component {
   }
 
   render() {
-    const { t, urls, router, triggers } = this.props
+    const { t, urls, router, triggers, filteringDoc } = this.props
     let { filteredTransactions } = this.props
 
     if (this.state.fetching) {
@@ -119,6 +119,9 @@ class TransactionsPage extends Component {
       breadcrumbItems = [{ name: t('Transactions.title') }]
     }
 
+    const filteringOnAccount =
+      filteringDoc && filteringDoc._type === ACCOUNT_DOCTYPE
+
     const currency =
       filteredTransactions.length > 0 ? filteredTransactions[0].currency : null
     return (
@@ -163,6 +166,7 @@ class TransactionsPage extends Component {
             transactions={filteredTransactions}
             urls={urls}
             brands={brandsWithoutTrigger}
+            filteringOnAccount={filteringOnAccount}
           />
         )}
       </div>
@@ -182,6 +186,7 @@ const mapStateToProps = state => ({
   },
   accountIds: getFilteredAccountIds(state),
   accounts: getCollection(state, 'accounts'),
+  filteringDoc: state.filters.filteringDoc,
   filteredTransactions: getFilteredTransactions(state).map(transaction =>
     hydrateTransaction(state, transaction)
   )

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,6 +1,5 @@
 import { combineReducers } from 'redux'
 
-import alerterReducer from 'cozy-ui/react/Alerter'
 import * as sharingStatus from 'modules/SharingStatus'
 import filters from 'ducks/filters'
 import mobile, * as fromMobile from 'ducks/mobile'
@@ -8,7 +7,6 @@ import apps from 'ducks/apps'
 import { reducer } from 'cozy-client'
 
 export const reducers = {
-  alerts: alerterReducer,
   filters,
   mobile,
   apps,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1460,6 +1460,10 @@ boom@5.x.x:
   dependencies:
     hoek "4.x.x"
 
+bowser@^1.7.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/bowser/-/bowser-1.9.3.tgz#6643ae4d783f31683f6d23156976b74183862162"
+
 bplist-creator@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
@@ -1873,6 +1877,10 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
+
+chain-function@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
 
 chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
@@ -2701,9 +2709,9 @@ cozy-konnector-libs@^3.0.13:
     request-promise "^4.2.1"
     uuid "^3.1.0"
 
-"cozy-ui@git://github.com/cozy/cozy-ui.git":
-  version "6.0.1"
-  resolved "git://github.com/cozy/cozy-ui.git#082a03bc29a7927123fa668ef869332241791813"
+cozy-ui@7.11.0:
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-7.11.0.tgz#3838e383126b2bab397926bf5fdd1d967ccc87b4"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"
@@ -2711,6 +2719,8 @@ cozy-konnector-libs@^3.0.13:
     hammerjs "^2.0.8"
     md5 "^2.2.0"
     normalize.css "^7.0.0"
+    preact-portal "^1.1.2"
+    react-select "2.0.0-alpha.7"
     stylus "^0.54.5"
 
 create-ecdh@^4.0.0:
@@ -2791,6 +2801,13 @@ crypto-browserify@^3.0.0, crypto-browserify@^3.11.0:
 css-color-names@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
+
+css-in-js-utils@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz#3b472b398787291b47cfe3e44fecfdd9e914ba99"
+  dependencies:
+    hyphenate-style-name "^1.0.2"
+    isobject "^3.0.1"
 
 css-loader@0.28.11:
   version "0.28.11"
@@ -3248,6 +3265,10 @@ dom-converter@~0.1:
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.1.4.tgz#a45ef5727b890c9bffe6d7c876e7b19cb0e17f3b"
   dependencies:
     utila "~0.3"
+
+dom-helpers@^3.2.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.3.1.tgz#fc1a4e15ffdf60ddde03a480a9c0fece821dd4a6"
 
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
@@ -4474,6 +4495,13 @@ github-url-from-username-repo@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/github-url-from-username-repo/-/github-url-from-username-repo-1.0.2.tgz#7dd79330d2abe69c10c2cef79714c97215791dfa"
 
+glam@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/glam/-/glam-5.0.1.tgz#b965a46f1a7f9ba3a23d16430b2e706f63c80ee8"
+  dependencies:
+    fbjs "^0.8.16"
+    inline-style-prefixer "^3.0.8"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -5021,6 +5049,10 @@ hyperquest@~1.2.0:
     duplexer2 "~0.0.2"
     through2 "~0.6.3"
 
+hyphenate-style-name@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@^0.4.5, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -5176,6 +5208,13 @@ inline-source-map@~0.6.0:
   resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
   dependencies:
     source-map "~0.5.3"
+
+inline-style-prefixer@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-3.0.8.tgz#8551b8e5b4d573244e66a34b04f7d32076a2b534"
+  dependencies:
+    bowser "^1.7.3"
+    css-in-js-utils "^2.0.0"
 
 inquirer@3.2.1:
   version "3.2.1"
@@ -9226,6 +9265,12 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
+raf@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.0.tgz#a28876881b4bc2ca9117d4138163ddb80f781575"
+  dependencies:
+    performance-now "^2.1.0"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -9374,6 +9419,12 @@ react-icons@^2.2.7:
   dependencies:
     react-icon-base "2.1.0"
 
+react-input-autosize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-input-autosize/-/react-input-autosize-2.2.1.tgz#ec428fa15b1592994fb5f9aa15bb1eb6baf420f8"
+  dependencies:
+    prop-types "^15.5.8"
+
 react-markdown@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-2.5.1.tgz#f7a6c26a3a5faf5d4c2098155d9775e826fd56ee"
@@ -9381,6 +9432,10 @@ react-markdown@^2.5.0:
     commonmark "^0.24.0"
     commonmark-react-renderer "^4.3.4"
     prop-types "^15.5.1"
+
+react-node-resolver@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-node-resolver/-/react-node-resolver-1.0.1.tgz#1798a729c0e218bf2f0e8ddf79c550d4af61d83a"
 
 react-redux@^5.0.1, react-redux@^5.0.6:
   version "5.0.6"
@@ -9404,6 +9459,24 @@ react-router@^3.0.0:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-scroll-captor@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-scroll-captor/-/react-scroll-captor-1.0.1.tgz#3f912df72ab8e7f46d4fa27d8707131ffe59b353"
+  dependencies:
+    react-node-resolver "^1.0.1"
+
+react-select@2.0.0-alpha.7:
+  version "2.0.0-alpha.7"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-2.0.0-alpha.7.tgz#a806863af7e03e98adc79869cd0ae8042ae43d38"
+  dependencies:
+    classnames "^2.2.5"
+    glam "^5.0.1"
+    prop-types "^15.6.0"
+    raf "^3.4.0"
+    react-input-autosize "^2.2.1"
+    react-scroll-captor "^1.0.1"
+    react-transition-group "^2.2.1"
 
 react-styleguidist@6.0.33:
   version "6.0.33"
@@ -9476,6 +9549,16 @@ react-themeable@^1.1.0:
   resolved "https://registry.yarnpkg.com/react-themeable/-/react-themeable-1.1.0.tgz#7d4466dd9b2b5fa75058727825e9f152ba379a0e"
   dependencies:
     object-assign "^3.0.0"
+
+react-transition-group@^2.2.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.3.0.tgz#8dd1af58f6af284b19fd057f512e74f20438ad31"
+  dependencies:
+    chain-function "^1.0.0"
+    dom-helpers "^3.2.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.5.8"
+    warning "^3.0.0"
 
 react@15.6.2, react@^15.4.1, react@^15.4.2:
   version "15.6.2"


### PR DESCRIPTION
Show the account associated to each transaction on the movements list : 

![image](https://user-images.githubusercontent.com/1606068/38621040-4dbaed06-3da0-11e8-9078-5c5080155806.png)

![image](https://user-images.githubusercontent.com/1606068/38621053-56546e6a-3da0-11e8-92fb-e4fd8b682a0e.png)

If the user is filtering transactions on a particular account, we don't show this information anymore : 

![image](https://user-images.githubusercontent.com/1606068/38621140-7f962656-3da0-11e8-9df1-83b1ce0fbddc.png)

![image](https://user-images.githubusercontent.com/1606068/38621124-77910fde-3da0-11e8-96c9-b29c943af517.png)

Also, on desktop, the date column is now after the label column.