### PR TITLE
feat: add more conditions for showing virtual groups

### DIFF
--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -19,15 +19,15 @@ export const getAccounts = state => {
 export const getVirtualGroups = createSelector([getAccounts], accounts => {
   const accountsByType = groupBy(accounts, account => account.type)
 
-  const virtualGroups = Object.entries(accountsByType).map(
-    ([type, accounts]) => ({
+  const virtualGroups = Object.entries(accountsByType)
+    .filter(([, accounts]) => accounts.length > 1)
+    .map(([type, accounts]) => ({
       _id: type,
       _type: GROUP_DOCTYPE,
       label: type.toLowerCase(),
       accounts: accounts.map(account => account._id),
       virtual: true
-    })
-  )
+    }))
 
   return virtualGroups
 })

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -20,7 +20,7 @@ export const getVirtualGroups = createSelector([getAccounts], accounts => {
   const accountsByType = groupBy(accounts, account => account.type)
 
   const virtualGroups = Object.entries(accountsByType)
-    .filter(([, accounts]) => accounts.length > 1)
+    .filter(([type, accounts]) => type !== undefined && accounts.length > 1)
     .map(([type, accounts]) => ({
       _id: type,
       _type: GROUP_DOCTYPE,


### PR DESCRIPTION
Only show a virtual group if an account type has more than one account. And don't create a group for accounts that don't have a type.