### PR TITLE
Fix wrong transaction

### DIFF
--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -66,7 +66,7 @@ class TransactionActions extends Component {
     actionProps: false
   }
 
-  async componentDidMount() {
+  findActions = async () => {
     const { transaction } = this.props
     if (transaction) {
       const { urls, brands, bill } = this.props
@@ -74,6 +74,10 @@ class TransactionActions extends Component {
       const actions = await findMatchingActions(transaction, actionProps)
       this.setState({ actions, actionProps })
     }
+  }
+
+  componentDidMount () {
+    this.findActions()
   }
 
   componentWillReceiveProps (nextProps) {
@@ -89,7 +93,7 @@ class TransactionActions extends Component {
       nextProps.brands !== this.props.brands ||
       nextProps.bill !== this.props.bill
     ) {
-      this.componentDidMount()
+      this.findActions()
     }
   }
 

--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -76,8 +76,15 @@ class TransactionActions extends Component {
     }
   }
 
-  componentDidUpdate(nextProps) {
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.transaction !== this.props.transaction) {
+      this.setState({actions: false})
+    }
+  }
+
+  componentDidUpdate (nextProps) {
     if (
+      nextProps.transaction !== this.props.transaction ||
       nextProps.urls !== this.props.urls ||
       nextProps.brands !== this.props.brands ||
       nextProps.bill !== this.props.bill

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -20,7 +20,6 @@ import flash from 'ducks/flash'
 
 import styles from './Transactions.styl'
 import { Media, Bd, Img } from 'components/Media'
-// import { HealthExpenseStatus, HealthExpenseStatusIcon, getVendors } from 'ducks/health-expense'
 
 const sDate = styles['bnk-op-date']
 const sDesc = styles['bnk-op-desc']


### PR DESCRIPTION
When component is updated a old action is display with the new transaction because `action` was already informed.