### PR TITLE
fix: reflect changes on transactions page when the user edit an account label

### DIFF
--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -8,3 +8,5 @@ export const getAccountInstitutionLabel = account => {
 
   return label
 }
+
+export const getAccountLabel = account => account.shortLabel || account.label

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -8,6 +8,7 @@ import { Table, TdSecondary } from 'components/Table'
 import TransactionMenu from './TransactionMenu'
 import TransactionActions from './TransactionActions'
 import { getLabel } from './helpers'
+import { getAccountLabel } from 'ducks/account/helpers'
 import {
   getParentCategory,
   getCategoryName
@@ -75,7 +76,9 @@ const TableTrDesktop = compose(translate(), withDispatch, withUpdateCategory())(
             <Bd className="u-pl-1">
               <ListItemText
                 primaryText={getLabel(transaction)}
-                secondaryText={!filteringOnAccount && transaction.account.label}
+                secondaryText={
+                  !filteringOnAccount && getAccountLabel(transaction.account)
+                }
               />
             </Bd>
           </Media>
@@ -135,7 +138,9 @@ const TableTrNoDesktop = translate()(
             <Bd className="u-mr-half u-ellipsis">
               <ListItemText
                 primaryText={getLabel(transaction)}
-                secondaryText={!filteringOnAccount && transaction.account.label}
+                secondaryText={
+                  !filteringOnAccount && getAccountLabel(transaction.account)
+                }
               />
             </Bd>
             <Img style={{ flexBasis: '1rem' }}>


### PR DESCRIPTION
When the user edited the label of an account, this change was not reflected on the transaction page.