### PR TITLE
chore: fix services build

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -23,7 +23,7 @@ module.exports = {
     rules: [
       {
         test: /^((?!min).)*\.jsx?$/, // all js, jsx, exclude minified
-        include: SRC_DIR,
+        include: [SRC_DIR],
         loader: 'eslint-loader',
         enforce: 'pre',
         options: {
@@ -36,7 +36,11 @@ module.exports = {
       },
       {
         test: /\.jsx?$/,
-        include: [SRC_DIR, path.dirname(require.resolve('cozy-client'))],
+        include: [
+          SRC_DIR,
+          path.dirname(require.resolve('cozy-client')),
+          path.dirname(require.resolve('cozy-konnector-libs'))
+        ],
         loader: 'babel-loader',
         options: {
           cacheDirectory: true


### PR DESCRIPTION
Services build is broken because cozy-konnector-libs is using a spread operator that needs to be transpiled. See https://travis-ci.org/cozy/cozy-banks/builds/368619692#L766