### PR TITLE
Added a title to the file opener modal

### DIFF
--- a/src/components/FileIntentDisplay.jsx
+++ b/src/components/FileIntentDisplay.jsx
@@ -28,9 +28,10 @@ class FileIntentDisplay extends Component {
     this.showModal()
   }
 
-  render ({ children }, { intent }) {
+  render ({ children, modalTitle }, { intent }) {
     return intent
       ? <FullscreenIntentModal
+        title={modalTitle}
         intent={intent}
         onIntentError={this.handleModalError}
         dismissAction={this.closeModal} />

--- a/src/components/FullscreenIntentModal/index.js
+++ b/src/components/FullscreenIntentModal/index.js
@@ -15,11 +15,11 @@ class FullscreenIntentModal extends Component {
     this.target = ref
   }
 
-  render ({ style }) {
+  render ({ style, title }) {
     return (
       <Portal into='body'>
         <div style={style} className={styles['modal--fullscreen']} >
-          <Modal overflowHidden dismissAction={this.props.dismissAction}>
+          <Modal title={title} overflowHidden dismissAction={this.props.dismissAction}>
             <div className={styles.content} ref={this.saveRef} />
           </Modal>
         </div>

--- a/src/ducks/transactions/FileOpener.jsx
+++ b/src/ducks/transactions/FileOpener.jsx
@@ -70,6 +70,7 @@ class FileOpener extends Component {
         {React.cloneElement(props.children, { onClick: this.displayFile })}
         {loading && <Spinner style={spinnerStyle} />}
         {fileId && <FileIntentDisplay
+          modalTitle={props.modalTitle}
           onClose={this.onCloseModal}
           onError={this.onCloseModal}
           fileId={fileId} />}

--- a/src/ducks/transactions/actions/BillAction.jsx
+++ b/src/ducks/transactions/actions/BillAction.jsx
@@ -54,7 +54,7 @@ export const Component = ({t, transaction, actionProps: { urls, bill, text }}) =
     bill = billCache[billId]
   }
   return (
-    <FileOpener getFileId={() => getBillInvoice(bill)}>
+    <FileOpener modalTitle={transaction.label} getFileId={() => getBillInvoice(bill)}>
       <ActionLink
         text={text || t('Transactions.actions.bill')}
       />


### PR DESCRIPTION
This PR changes this modal layout with the addition of a title so that the closing cross don't interfere with the PDF reader controls (see https://trello.com/c/Cb0SSEAe/911-1-supprimer-la-double-croix-dans-la-modale-inter-app)