### PR TITLE
fix: reset push object on logout

### DIFF
--- a/src/ducks/mobile/push.js
+++ b/src/ducks/mobile/push.js
@@ -47,8 +47,9 @@ export const registerPushNotifications = () => async (dispatch, getState) => {
 export const stopPushNotifications = () => {
   if (push) {
     push.unregister(
-      // eslint-disable-next-line no-console
-      () => console.log('unregister push notifications'),
+      () => {
+        push = null
+      },
       error => {
         throw new Error('error while unregistering notifications: ' + error)
       }


### PR DESCRIPTION
We had an issue with the push notifications : 

* On login, push object was initialized and push notifications were shown
* On logout, push notifications were stopped, but the push object was not resetted
* On new login, we already had a push object so we didn't reinitialized it => no push notification could be received