### PR TITLE
🐝 fix: merge deeply instead of shallowy to completely merge default settings

### DIFF
--- a/src/ducks/settings/services.js
+++ b/src/ducks/settings/services.js
@@ -1,5 +1,6 @@
 import { cozyClient, log } from 'cozy-konnector-libs'
 import { DEFAULTS_SETTINGS, DOCTYPE } from './constants'
+import merge from 'lodash/merge'
 
 const createSetting = setting => {
   log('info', 'Create setting')
@@ -12,7 +13,7 @@ export const readSetting = async () => {
   const settings = await cozyClient.data.findAll(DOCTYPE)
 
   if (settings.length > 0) {
-    return { ...DEFAULTS_SETTINGS, ...settings[0] }
+    return merge({}, DEFAULTS_SETTINGS, settings[0])
   }
 
   return DEFAULTS_SETTINGS


### PR DESCRIPTION
We had a settings like that : 

```
{
  notifications: {
    toto: true,
    /* no last seq*/
  },
  categorization: {
  }
}
```

If this setting was merged with the default, the existing notifications attribute would override the default notification settings and there would be no lastSeq.

`merge` is now used to deeply merge the default and the existing settings.