### PR TITLE
fix(date filter): going to next month with transactions was going to last month with transactions

### DIFF
--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -9,6 +9,7 @@ import {
   includes,
   findIndex,
   find,
+  findLast,
   uniq,
   maxBy
 } from 'lodash'
@@ -187,11 +188,8 @@ class TransactionsPage extends Component {
       const afterChosenMonth = x => x > month
       const inRightDirection =
         month < this.state.currentMonth ? beforeChosenMonth : afterChosenMonth
-      const orderedMonthsWithOperations =
-        month < this.state.currentMonth
-          ? monthsWithOperations.reverse()
-          : monthsWithOperations
-      const found = find(orderedMonthsWithOperations, inRightDirection)
+      const findFn = month < this.state.currentMonth ? findLast : find
+      const found = findFn(monthsWithOperations, inRightDirection)
       if (found) {
         month = found
         limitMin = findMonthIndex(month)

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -180,14 +180,18 @@ class TransactionsPage extends Component {
          in the future, we check if the chosen month is before or after the
          current month.
       */
-      const monthsWithOperations = uniq(transactions.map(x => getMonth(x.date)))
-        .sort()
-        .reverse()
+      const monthsWithOperations = uniq(
+        transactions.map(x => getMonth(x.date))
+      ).sort()
       const beforeChosenMonth = x => x < month
       const afterChosenMonth = x => x > month
       const inRightDirection =
         month < this.state.currentMonth ? beforeChosenMonth : afterChosenMonth
-      const found = find(monthsWithOperations, inRightDirection)
+      const orderedMonthsWithOperations =
+        month < this.state.currentMonth
+          ? monthsWithOperations.reverse()
+          : monthsWithOperations
+      const found = find(orderedMonthsWithOperations, inRightDirection)
       if (found) {
         month = found
         limitMin = findMonthIndex(month)


### PR DESCRIPTION
We already have a system that skip months without any transactions when we click on previous/next arrows in the date filters. But there was the following problem : 

Say we have these months that have some transactions : 

```
[
  "2018-04",
  "2018-01",
  "2017-08",
  "2017-07"
]
```

If we are currently on `2017-08` and click on the next arrow, then we should show `2018-01`. But we were showing `2018-04`. This is because we are looking for the first month greater than the current month in the previous array. But if it's sorted from the most recent to the oldest, then the first month greater than the current month is always the most recent month. Here `2018-04`.

To fix this, we should do the following : 

* If we want the previous month with transactions : sort the array of months from the most recent to the oldest
* If we want to next month with transactions : sort the array of months from the oldest to the most recent

That's the purpose of this PR, which is a lot lighter than this explanation of the bug, but I thought it was necessary to explain this :)