### PR TITLE
Adaptive date filter mobile

### DIFF
--- a/src/components/Select/index.jsx
+++ b/src/components/Select/index.jsx
@@ -13,8 +13,15 @@ const SmallArrow = () => (
   />
 )
 
-const Select = ({ name, value, options, onChange, className }) => (
-  <span>
+const Select = ({
+  name,
+  value,
+  options,
+  onChange,
+  className,
+  wrappedClassName
+}) => (
+  <span className={cx(wrappedClassName)}>
     <select
       className={cx(styles.Select, className)}
       name={name}

--- a/src/ducks/filters/SelectDates.jsx
+++ b/src/ducks/filters/SelectDates.jsx
@@ -79,11 +79,15 @@ class DateYearSelector extends PureComponent {
             value={selectedYear}
             options={years.map(x => ({ value: x.year, name: x.yearF }))}
             onChange={this.onChangeYear}
+            className={styles.SelectDates__Select}
           />
           <Separator />
           <Select
             name="month"
-            className={styles.SelectDates__month}
+            className={cx(
+              styles.SelectDates__month,
+              styles.SelectDates__Select
+            )}
             value={selectedMonth}
             options={months.map(x => ({ value: x.month, name: x.monthF }))}
             onChange={this.onChangeMonth}

--- a/src/ducks/filters/SelectDates.jsx
+++ b/src/ducks/filters/SelectDates.jsx
@@ -72,7 +72,7 @@ class DateYearSelector extends PureComponent {
     const months = this.props.options.filter(x => x.year === selectedYear)
 
     return (
-      <span>
+      <span className={styles.SelectDates__DateYearSelector}>
         <Chip className={cx(styles.SelectDates__chip)}>
           <Select
             name="year"
@@ -202,7 +202,7 @@ class SelectDatesDumb extends React.PureComponent {
             disabled={selected === options.length - 1}
             className={styles['SelectDates__Button--prev']}
           >
-            <Icon icon="back" />
+            <Icon icon="back" width={16} />
           </SelectDateButton>
 
           <SelectDateButton
@@ -210,7 +210,7 @@ class SelectDatesDumb extends React.PureComponent {
             disabled={selected === 0}
             className={styles['SelectDates__Button--next']}
           >
-            <Icon icon="forward" />
+            <Icon icon="forward" width={16} />
           </SelectDateButton>
         </span>
       </div>

--- a/src/ducks/filters/SelectDates.jsx
+++ b/src/ducks/filters/SelectDates.jsx
@@ -80,6 +80,7 @@ class DateYearSelector extends PureComponent {
             options={years.map(x => ({ value: x.year, name: x.yearF }))}
             onChange={this.onChangeYear}
             className={styles.SelectDates__Select}
+            wrappedClassName={styles.SelectDates__SelectRoot}
           />
           <Separator />
           <Select
@@ -88,6 +89,7 @@ class DateYearSelector extends PureComponent {
               styles.SelectDates__month,
               styles.SelectDates__Select
             )}
+            wrappedClassName={styles.SelectDates__SelectRoot}
             value={selectedMonth}
             options={months.map(x => ({ value: x.month, name: x.monthF }))}
             onChange={this.onChangeMonth}

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -49,6 +49,8 @@ select-date-height-small = 2.75rem
         right 0
         width auto
         height select-date-height-small
+        padding-left 1rem
+        padding-right 0.875rem
         position fixed
         background white
         z-index 2
@@ -57,17 +59,28 @@ select-date-height-small = 2.75rem
         align-content center
         border-bottom: 1px solid silver
 
+    .SelectDates__DateYearSelector
+        flex-grow 1
+
     .SelectDates__chip
         background-color transparent
         margin-bottom 0
         margin-right 0
         padding 0
         height 100%
+        width 100%
+
+        > span:not([class])
+            flex-grow 1
+
+        select
+            width 100%
+            margin-right -1.3rem
 
     .SelectDates__separator
         height 1.5rem
-        margin-left 0.75rem
-        margin-right 0.75rem
+        margin-left 0.875rem
+        margin-right 0.875rem
 
     .SelectDates__buttons
         display flex
@@ -78,10 +91,10 @@ select-date-height-small = 2.75rem
         background-color transparent
 
     .SelectDates__Button--prev
-        padding-right 0.75rem
+        padding-right 0.875rem
 
     .SelectDates__Button--next
-        padding-left 0.75rem
+        padding-left 0.875rem
 
 .SelectDates__Button
     cursor pointer

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -73,9 +73,6 @@ select-date-height-small = 2.75rem
         height 100%
         width 100%
 
-        > span:not([class])
-            flex-grow 1
-
         select
             width 100%
             margin-right -1.3rem
@@ -105,6 +102,9 @@ select-date-height-small = 2.75rem
 
     .SelectDates__Select
         color inherit
+
+    .SelectDates__SelectRoot
+        flex-grow 1
 
 .SelectDates__Button
     cursor pointer

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -41,6 +41,8 @@ select-date-height-small = 2.75rem
     width 9rem
 
 +small-screen()
+    elements-spacing = 0.875rem
+
     .SelectDates
         m = 0.75rem // size of the margin-top/bottom
         topbar-height = 3rem
@@ -50,7 +52,7 @@ select-date-height-small = 2.75rem
         width auto
         height select-date-height-small
         padding-left 1rem
-        padding-right 0.875rem
+        padding-right elements-spacing
         position fixed
         background white
         z-index 2
@@ -83,8 +85,8 @@ select-date-height-small = 2.75rem
 
     .SelectDates__separator
         height 1.5rem
-        margin-left 0.875rem
-        margin-right 0.875rem
+        margin-left elements-spacing
+        margin-right elements-spacing
 
     .SelectDates__buttons
         display flex
@@ -96,10 +98,10 @@ select-date-height-small = 2.75rem
         color coolGrey
 
     .SelectDates__Button--prev
-        padding-right 0.875rem
+        padding-right elements-spacing
 
     .SelectDates__Button--next
-        padding-left 0.875rem
+        padding-left elements-spacing
 
     .SelectDates__Select
         color inherit

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -58,6 +58,7 @@ select-date-height-small = 2.75rem
         justify-content center
         align-content center
         border-bottom: 1px solid silver
+        color slateGrey
 
     .SelectDates__DateYearSelector
         flex-grow 1
@@ -77,6 +78,9 @@ select-date-height-small = 2.75rem
             width 100%
             margin-right -1.3rem
 
+        svg
+            color coolGrey
+
     .SelectDates__separator
         height 1.5rem
         margin-left 0.875rem
@@ -89,12 +93,16 @@ select-date-height-small = 2.75rem
     .SelectDates__Button
         width auto
         background-color transparent
+        color coolGrey
 
     .SelectDates__Button--prev
         padding-right 0.875rem
 
     .SelectDates__Button--next
         padding-left 0.875rem
+
+    .SelectDates__Select
+        color inherit
 
 .SelectDates__Button
     cursor pointer
@@ -103,6 +111,3 @@ select-date-height-small = 2.75rem
 .SelectDates__Button--disabled
     color coolGrey
     cursor not-allowed
-
-.SelectDates__Icon
-    color slateGrey


### PR DESCRIPTION
Some adaptations on the mobile date filter : 

* Use the good colors for the text and the icons
* Make it always use the full width : both selects adapts their width, and the buttons have fixed width

![image](https://user-images.githubusercontent.com/1606068/40002135-136d83c0-5790-11e8-9cdb-5f03126c1a56.png)

![image](https://user-images.githubusercontent.com/1606068/40002140-19e2b824-5790-11e8-9c55-f7c111f5f62e.png)