### PR TITLE
fix: increase cozy-bar drawer z-index on mobile so it is above the footer

### DIFF
--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -12,3 +12,7 @@ html, body
     +small-screen()
         overflow-y scroll // necessary for momentum scroll on ios
         -webkit-overflow-scrolling touch // necessary for momentum scroll on ios
+
++small-screen()
+    [role='banner'][data-drawer-visible='true']
+        z-index 90


### PR DESCRIPTION
We had the following problem since I increased the footer z-index to make it visible even when we have a transaction modal opened : 

![image](https://user-images.githubusercontent.com/1606068/40004002-08337910-5795-11e8-9ed2-aea48cee9e6a.png)
