### PR TITLE
feat(dates filter): apply a flex-grow ratio on month and year selects

### DIFF
--- a/src/ducks/filters/SelectDates.jsx
+++ b/src/ducks/filters/SelectDates.jsx
@@ -80,7 +80,7 @@ class DateYearSelector extends PureComponent {
             options={years.map(x => ({ value: x.year, name: x.yearF }))}
             onChange={this.onChangeYear}
             className={styles.SelectDates__Select}
-            wrappedClassName={styles.SelectDates__SelectRoot}
+            wrappedClassName={styles.SelectDates__SelectYear}
           />
           <Separator />
           <Select
@@ -89,7 +89,7 @@ class DateYearSelector extends PureComponent {
               styles.SelectDates__month,
               styles.SelectDates__Select
             )}
-            wrappedClassName={styles.SelectDates__SelectRoot}
+            wrappedClassName={styles.SelectDates__SelectMonth}
             value={selectedMonth}
             options={months.map(x => ({ value: x.month, name: x.monthF }))}
             onChange={this.onChangeMonth}

--- a/src/ducks/filters/SelectDates.styl
+++ b/src/ducks/filters/SelectDates.styl
@@ -103,8 +103,11 @@ select-date-height-small = 2.75rem
     .SelectDates__Select
         color inherit
 
-    .SelectDates__SelectRoot
+    .SelectDates__SelectYear
         flex-grow 1
+
+    .SelectDates__SelectMonth
+        flex-grow 2
 
 .SelectDates__Button
     cursor pointer


### PR DESCRIPTION
Year select takes 1/3 of the space, and month select 2/3.