### PR TITLE
fix add account link

### DIFF
--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -3,6 +3,7 @@
 // reducers
 export const getApps = state => state.apps
 
+/* TODO always use getAppUrlByID instead of getAppUrlBySource */
 export const getAppUrlById = (state, id) => {
   const apps = getApps(state)
   for (const app of apps) {

--- a/src/ducks/apps/index.js
+++ b/src/ducks/apps/index.js
@@ -2,10 +2,11 @@
 
 // reducers
 export const getApps = state => state.apps
-export const getAppUrlBySource = (state, source) => {
+
+export const getAppUrlById = (state, id) => {
   const apps = getApps(state)
   for (const app of apps) {
-    if (app.attributes.source.indexOf(source) !== -1) {
+    if (app._id === id) {
       return app.links.related
     }
   }

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -22,7 +22,7 @@ import { flowRight as compose } from 'lodash'
 import { destroyAccount } from 'actions'
 import spinner from 'assets/icons/icon-spinner.svg'
 import { getAccountInstitutionLabel } from '../account/helpers'
-import { getAppUrlBySource, fetchApps } from 'ducks/apps'
+import { getAppUrlById, fetchApps } from 'ducks/apps'
 
 const DeleteConfirm = ({
   cancel,
@@ -194,7 +194,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mapStateToProps = state => ({
-  collectUrl: getAppUrlBySource(state, 'github.com/cozy/cozy-collect')
+  collectUrl: getAppUrlById(state, 'io.cozy.apps/collect')
 })
 
 const GeneralSettings = compose(

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import { translate, Button, Icon } from 'cozy-ui/react'
 import { getSharingInfo } from 'reducers'
 import { groupBy, flowRight as compose, sortBy } from 'lodash'
-import { getAppUrlBySource, fetchApps } from 'ducks/apps'
+import { getAppUrlById, fetchApps } from 'ducks/apps'
 import Table from 'components/Table'
 import Loading from 'components/Loading'
 import { cozyConnect, fetchCollection } from 'cozy-client'
@@ -122,7 +122,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mapStateToProps = state => ({
-  collectUrl: getAppUrlBySource(state, 'github.com/cozy/cozy-collect'),
+  collectUrl: getAppUrlById(state, 'io.cozy.apps/collect'),
   getSharingInfo: (doctype, id) => {
     return getSharingInfo(state, doctype, id)
   }

--- a/src/ducks/settings/CollectLink.jsx
+++ b/src/ducks/settings/CollectLink.jsx
@@ -29,14 +29,17 @@ const SameWindowLink = compose(connect(mapStateToProps, mapDispatchToProps))(
     }
 
     render() {
-      const url = this.props.collectUrl + '#/providers/banking'
+      const collectUrl = this.props.collectUrl
+      const url = collectUrl + '#/providers/banking'
       return (
         <span
           onClick={() => {
-            window.location = url
+            if (collectUrl) {
+              window.location = url
+            }
           }}
         >
-          {this.props.children}
+          {collectUrl && this.props.children}
         </span>
       )
     }

--- a/src/ducks/settings/CollectLink.jsx
+++ b/src/ducks/settings/CollectLink.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { flowRight as compose } from 'lodash'
-import { getAppUrlBySource, fetchApps } from 'ducks/apps'
+import { getAppUrlById, fetchApps } from 'ducks/apps'
 // import { IntentOpener } from 'cozy-ui/react'
 
 /*
@@ -19,7 +19,7 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mapStateToProps = state => ({
-  collectUrl: getAppUrlBySource(state, 'github.com/cozy/cozy-collect')
+  collectUrl: getAppUrlById(state, 'io.cozy.apps/collect')
 })
 
 const SameWindowLink = compose(connect(mapStateToProps, mapDispatchToProps))(

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -14,7 +14,7 @@ import {
   getFilteredAccountIds
 } from 'ducks/filters'
 import { fetchTransactions } from 'actions/transactions'
-import { getAppUrlBySource, fetchApps } from 'ducks/apps'
+import { getAppUrlById, fetchApps } from 'ducks/apps'
 import { getCategoryIdFromName } from 'ducks/categories/categoriesMap'
 import { getCategoryId } from 'ducks/categories/helpers'
 
@@ -194,10 +194,10 @@ const mapStateToProps = state => ({
     // this keys are used on Transactions.jsx to:
     // - find transaction label
     // - display appName in translate `Transactions.actions.app`
-    MAIF: getAppUrlBySource(state, 'gitlab.cozycloud.cc/labs/cozy-maif'),
-    HEALTH: getAppUrlBySource(state, 'gitlab.cozycloud.cc/labs/cozy-sante'),
-    EDF: getAppUrlBySource(state, 'gitlab.cozycloud.cc/labs/cozy-edf'),
-    COLLECT: getAppUrlBySource(state, 'github.com/cozy/cozy-collect')
+    MAIF: getAppUrlById(state, 'io.cozy.apps/maif'),
+    HEALTH: getAppUrlById(state, 'io.cozy.apps/sante'),
+    EDF: getAppUrlById(state, 'io.cozy.apps/edf'),
+    COLLECT: getAppUrlById(state, 'io.cozy.apps/collect')
   },
   accountIds: getFilteredAccountIds(state),
   accounts: getCollection(state, 'accounts'),


### PR DESCRIPTION
Collect was identified by its source in order to provide a direct deep link (the "Add an account" link in account settings). Since collect is now in the registry, we have to identify it via its _id.