### PR TITLE
feat(CategoriesChart): always sort parts in reverse order

### DIFF
--- a/src/ducks/categories/CategoriesChart.jsx
+++ b/src/ducks/categories/CategoriesChart.jsx
@@ -3,6 +3,7 @@ import { translate } from 'cozy-ui/react/I18n'
 import Chart from './Chart'
 import styles from './CategoriesChart.styl'
 import FigureBlock from 'components/Figure/FigureBlock'
+import sortBy from 'lodash/sortBy'
 
 const hexToRGBA = (hex, a) => {
   const cutHex = hex.substring(1)
@@ -23,6 +24,44 @@ class CategoriesChart extends Component {
     }
   }
 
+  getCategoriesToSort() {
+    const { categories, selectedCategory } = this.props
+
+    if (selectedCategory === undefined) {
+      return categories
+    }
+
+    const category = categories.find(
+      category => category.name === selectedCategory
+    )
+
+    return category.subcategories
+  }
+
+  getSortedCategories() {
+    let categoriesToSort = this.getCategoriesToSort()
+
+    const sortedCategories = sortBy(categoriesToSort, category =>
+      Math.abs(category.amount)
+    ).reverse()
+
+    return sortedCategories
+  }
+
+  getCategoriesColors(categories) {
+    const { selectedCategory } = this.props
+
+    if (selectedCategory === undefined) {
+      return categories.map(category => category.color)
+    }
+
+    const alphaDiff = 0.7 / categories.length
+
+    return categories.map((category, index) =>
+      hexToRGBA(category.color, 1 - alphaDiff * index)
+    )
+  }
+
   render({
     t,
     categories,
@@ -35,29 +74,19 @@ class CategoriesChart extends Component {
   }) {
     if (categories.length === 0) return
 
-    const labels = []
-    const data = []
-    const colors = []
+    const sortedCategories = this.getSortedCategories()
 
-    if (selectedCategory === undefined) {
-      for (const category of categories) {
-        labels.push(t(`Data.categories.${category.name}`))
-        data.push(Math.abs(category.amount).toFixed(2)) // use positive values
-        colors.push(category.color)
-      }
-    } else {
-      const category = categories.find(
-        category => category.name === selectedCategory
+    const labels = sortedCategories.map(category =>
+      t(
+        `Data.${selectedCategory ? 'subcategories' : 'categories'}.${
+          category.name
+        }`
       )
-      let alpha = 1
-      const alphaDiff = 0.7 / category.subcategories.length
-      for (const subcategory of category.subcategories) {
-        labels.push(t(`Data.subcategories.${subcategory.name}`))
-        data.push(Math.abs(subcategory.amount).toFixed(2)) // use positive values
-        colors.push(hexToRGBA(category.color, alpha))
-        alpha -= alphaDiff
-      }
-    }
+    )
+    const data = sortedCategories.map(category =>
+      Math.abs(category.amount).toFixed(2)
+    )
+    const colors = sortedCategories.map(category => category.color)
 
     return (
       <div className={styles.CategoriesChart}>


### PR DESCRIPTION
The colors were not sorted in the right order in the categories chart. It's now the case.

https://testbanksfixcategorieschart-banks.cozy.works/#/categories