### PR TITLE
feat(mobile app): set custom user agent on app start

### DIFF
--- a/src/ducks/mobile/userAgent.js
+++ b/src/ducks/mobile/userAgent.js
@@ -1,0 +1,36 @@
+import { getDeviceName } from 'ducks/authentication/lib/client'
+
+const getUpdatedUserAgent = navigator => {
+  const deviceName = getDeviceName() || 'unknown device name'
+  const identifier = getIdentifier(navigator) || 'unknown identifier'
+  const version = getVersion(navigator) || 'unknown version'
+  const userAgent = getUserAgent(navigator) || 'unkown user-agent'
+
+  return `${deviceName} ${identifier}-${version} ${userAgent}`
+}
+
+const getIdentifier = navigator =>
+  navigator && navigator.appInfo && navigator.appInfo.identifier
+
+const getVersion = navigator =>
+  navigator && navigator.appInfo && navigator.appInfo.version
+
+const getUserAgent = navigator => navigator && navigator.userAgent
+
+export const updateUserAgent = () => {
+  try {
+    // Check if the userAgent is not already updated to avoid
+    // recursively update it
+    const currentUserAgent = window.navigator.userAgent
+    const needUpdate = !currentUserAgent.startsWith(getDeviceName())
+    if (needUpdate) {
+      window.UserAgent.set(getUpdatedUserAgent(window.navigator))
+    }
+  } catch (err) {
+    /* eslint-disable-next-line no-console */
+    console.error(
+      `Unable to update User-Agent with cordova plugin: ${err.message}`
+    )
+    throw err
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,10 +13,19 @@ import 'number-to-locale-string'
 import { setupHistory } from 'utils/history'
 import { getClient } from 'utils/client'
 import { fetchSettingsCollection, initSettings } from 'ducks/settings'
+import { updateUserAgent } from 'ducks/mobile/userAgent'
 import 'utils/flag'
 
 if (__TARGET__ === 'mobile') {
   require('styles/mobile.styl')
+
+  document.addEventListener('deviceready', () => {
+    try {
+      updateUserAgent()
+    } catch (err) {
+      // We do nothing with this exception handling
+    }
+  })
 }
 
 if (process.env.NODE_ENV === 'development') {

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -85,4 +85,6 @@
     <plugin name="phonegap-plugin-push" spec="^2.1.3">
         <variable name="FCM_VERSION" value="11.6.2" />
     </plugin>
+    <plugin name="cordova-plugin-useragent" spec="1.0.6" />
+    <plugin name="cordova-plugin-appinfo" spec="2.1.1" />
 </widget>


### PR DESCRIPTION
Set the user agent to a string `{DEVICE NAME} {APP IDENTIFIER}-{APP VERSION} {ORIGINAL USER AGENT}` when the app is started.