### PR TITLE
🐝 fix: only show 1 onboarding section on mobile

### DIFF
--- a/src/ducks/onboarding/Onboarding.jsx
+++ b/src/ducks/onboarding/Onboarding.jsx
@@ -41,16 +41,22 @@ class Onboarding extends Component {
             <Subtitle>{t('Onboarding.manage-budget.title')}</Subtitle>
             <Paragraph>{t('Onboarding.manage-budget.description')}</Paragraph>
           </Section>
-          <Section>
-            <Icon color={palette.portage} icon={watch} />
-            <Subtitle>{t('Onboarding.save-time.title')}</Subtitle>
-            <Paragraph>{t('Onboarding.save-time.description')}</Paragraph>
-          </Section>
-          <Section>
-            <Icon color={palette['dodgerBlue']} icon={cozy} />
-            <Subtitle>{t('Onboarding.cozy-assistant.title')}</Subtitle>
-            <Paragraph>{t('Onboarding.cozy-assistant.description')}</Paragraph>
-          </Section>
+          {!isMobile ? (
+            <Section>
+              <Icon color={palette.portage} icon={watch} />
+              <Subtitle>{t('Onboarding.save-time.title')}</Subtitle>
+              <Paragraph>{t('Onboarding.save-time.description')}</Paragraph>
+            </Section>
+          ) : null}
+          {!isMobile ? (
+            <Section>
+              <Icon color={palette['dodgerBlue']} icon={cozy} />
+              <Subtitle>{t('Onboarding.cozy-assistant.title')}</Subtitle>
+              <Paragraph>
+                {t('Onboarding.cozy-assistant.description')}
+              </Paragraph>
+            </Section>
+          ) : null}
         </Sections>
         <CTA>
           <CollectLink>


### PR DESCRIPTION
In aeb0a471ffbceca245ba8f1be40750519b382b0c, we replaced the internal Hero component
by the one from cozy-ui, but there was custom code in the Hero styl to remove the last
two sections on mobile.