### PR TITLE
Some fixes on categories page

### DIFF
--- a/src/components/Figure/Figure.jsx
+++ b/src/components/Figure/Figure.jsx
@@ -34,10 +34,13 @@ const Figure = props => {
   let { decimalNumbers } = props
   decimalNumbers = isNaN(decimalNumbers) ? 2 : decimalNumbers
 
-  const totalLocalized = total.toLocaleString('fr-FR', {
-    minimumFractionDigits: decimalNumbers,
-    maximumFractionDigits: decimalNumbers
-  })
+  const totalLocalized =
+    typeof total === 'number'
+      ? total.toLocaleString('fr-FR', {
+          minimumFractionDigits: decimalNumbers,
+          maximumFractionDigits: decimalNumbers
+        })
+      : total
   const isTotalPositive = total > 0
   const isTotalInLimit = total > warningLimit
   const isWarning = !isTotalPositive && !isTotalInLimit && coloredWarning
@@ -74,7 +77,7 @@ const Figure = props => {
 
 Figure.propTypes = {
   /** Number to display */
-  total: Types.number.isRequired,
+  total: Types.oneOfType([Types.number, Types.string]).isRequired,
   /** Class name applied to the element wrapping the number */
   totalClassName: Types.string,
   /** Currency to show */

--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -134,6 +134,7 @@ class Categories extends Component {
     const rowClass = stRow
     const onClick = subcategory || isCollapsed ? this.handleClick : () => {}
     const key = (subcategory || category).name
+    const total = credit + debit
     return [
       (subcategory || isCollapsed) && (
         <tr
@@ -187,8 +188,8 @@ class Categories extends Component {
           )}
           <TdSecondary className={stTotal}>
             <Figure
-              total={credit + debit}
-              currency={currency}
+              total={total || '－'}
+              currency={currency || '€'}
               coloredPositive
               signed
             />
@@ -225,6 +226,7 @@ class Categories extends Component {
     const isCollapsed = selectedCategoryName !== category.name
     const type = subcategory ? 'subcategories' : 'categories'
     const categoryName = (subcategory || category).name
+    const total = credit + debit
 
     return [
       (subcategory || isCollapsed) && (
@@ -260,8 +262,8 @@ class Categories extends Component {
               <Img className={cx('u-pl-half', stAmount)}>
                 <Figure
                   className={stCatTotalMobile}
-                  total={credit + debit}
-                  currency={currency}
+                  total={total || '－'}
+                  currency={currency || '€'}
                   coloredPositive
                   signed
                 />

--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -259,7 +259,7 @@ class Categories extends Component {
                     <span>
                       {`· ${transactionsNumber} ${t(
                         `Categories.headers.transactions.${
-                          transactionsNumber > 1 ? 'single' : 'plural'
+                          transactionsNumber > 1 ? 'plural' : 'single'
                         }`
                       )}`}
                     </span>

--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -32,23 +32,14 @@ class Categories extends Component {
 
   render({
     t,
-    categories,
+    categories: categoriesProps,
     selectedCategory,
     breakpoints: { isDesktop, isTablet }
   }) {
-    if (categories === undefined) categories = []
+    let categories = categoriesProps || []
     if (selectedCategory) {
       categories = [selectedCategory]
     }
-
-    // sort the categories for display
-    categories = categories.sort((a, b) => {
-      if (b.percentage !== a.percentage) {
-        return b.percentage - a.percentage
-      } else {
-        return a.amount - b.amount
-      }
-    })
 
     return (
       <div>

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -26,6 +26,8 @@ const CategoriesHeader = ({
   const globalCurrency = getGlobalCurrency(categories)
   const transactionsTotal = getTransactionsTotal(categories)
   const [previousItem] = breadcrumbItems.slice(-2, 1)
+  const hasData = categories.length > 0 && categories[0].transactionsNumber > 0
+  const showIncomeToggle = hasData && selectedCategory === undefined
 
   return (
     <div className={styles.CategoriesHeader}>
@@ -41,7 +43,7 @@ const CategoriesHeader = ({
             className={styles.CategoriesHeader__Breadcrumb}
           />
         ) : null}
-        {selectedCategory === undefined && (
+        {showIncomeToggle && (
           <div className={styles.CategoriesHeader__Toggle}>
             <Toggle
               id="withIncome"
@@ -54,20 +56,23 @@ const CategoriesHeader = ({
           </div>
         )}
       </div>
-      {!isFetching && (
-        <CategoriesChart
-          width={chartSize}
-          height={chartSize}
-          categories={
-            selectedCategory ? selectedCategory.subcategories : categories
-          }
-          selectedCategory={selectedCategory}
-          selectCategory={selectCategory}
-          total={selectedCategory ? selectedCategory.amount : transactionsTotal}
-          currency={globalCurrency}
-          label={t('Categories.title.total')}
-        />
-      )}
+      {!isFetching &&
+        hasData && (
+          <CategoriesChart
+            width={chartSize}
+            height={chartSize}
+            categories={
+              selectedCategory ? selectedCategory.subcategories : categories
+            }
+            selectedCategory={selectedCategory}
+            selectCategory={selectCategory}
+            total={
+              selectedCategory ? selectedCategory.amount : transactionsTotal
+            }
+            currency={globalCurrency}
+            label={t('Categories.title.total')}
+          />
+        )}
     </div>
   )
 }

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -20,5 +20,8 @@
         position absolute
         line-height 1.5rem
 
+    +small-screen()
+        padding-top 0
+
 .CategoriesHeader__Breadcrumb
     margin-top 2.375rem

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -8,7 +8,7 @@ import { fetchTransactions, getTransactions } from 'actions'
 import { transactionsByCategory, computeCategorieData } from './helpers'
 import Categories from './Categories'
 import styles from './CategoriesPage.styl'
-import { flowRight as compose } from 'lodash'
+import { flowRight as compose, sortBy } from 'lodash'
 import { withBreakpoints } from 'cozy-ui/react'
 import CategoriesHeader from './CategoriesHeader'
 
@@ -35,13 +35,15 @@ class CategoriesPage extends Component {
     this.setState({ withIncome })
   }
 
-  render({ t, categories, transactions, router }, { withIncome }) {
+  render(
+    { t, categories: categoriesProps, transactions, router },
+    { withIncome }
+  ) {
     const isFetching = transactions.fetchStatus !== 'loaded'
     const selectedCategoryName = router.params.categoryName
-    // compute the filter to use
-    if (!withIncome) {
-      categories = categories.filter(category => category.name !== 'incomeCat')
-    }
+    const categories = withIncome
+      ? categoriesProps
+      : categoriesProps.filter(category => category.name !== 'incomeCat')
     const breadcrumbItems = [{ name: t('Categories.title.general') }]
     if (selectedCategoryName) {
       breadcrumbItems[0].onClick = () => router.push('/categories')
@@ -52,6 +54,11 @@ class CategoriesPage extends Component {
     const selectedCategory = categories.find(
       category => category.name === selectedCategoryName
     )
+
+    const sortedCategories = sortBy(categories, cat =>
+      Math.abs(cat.amount)
+    ).reverse()
+
     return (
       <div className={styles['bnk-cat-page']}>
         <CategoriesHeader
@@ -59,7 +66,7 @@ class CategoriesPage extends Component {
           selectedCategory={selectedCategory}
           withIncome={withIncome}
           onWithIncomeToggle={this.filterWithInCome}
-          categories={categories}
+          categories={sortedCategories}
           selectCategory={this.selectCategory}
           isFetching={isFetching}
         />
@@ -67,7 +74,7 @@ class CategoriesPage extends Component {
           <Loading loadingType="categories" />
         ) : (
           <Categories
-            categories={categories}
+            categories={sortedCategories}
             selectedCategory={selectedCategory}
             selectedCategoryName={selectedCategoryName}
             selectCategory={this.selectCategory}


### PR DESCRIPTION
* Remove padding on income toggle on mobile
* Fix "transaction(s)" plural
* If a category has no data, then show "－ €" as its total
* When the selected period has no data, don't show the income toggle and the graph