### PR TITLE
🐝 fix: use only one source of truth

### DIFF
--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -35,6 +35,9 @@ import iconCredit from 'assets/icons/icon-credit.svg'
 import iconArrowLeft from 'assets/icons/icon-arrow-left.svg'
 import iconCalendar from 'assets/icons/icon-calendar.svg'
 import { getAccountLabel } from 'ducks/account/helpers'
+import { connect } from 'react-redux'
+import { getDocument } from 'cozy-client'
+import { TRANSACTION_DOCTYPE } from 'doctypes'
 
 const Separator = () => <hr className={styles.TransactionModalSeparator} />
 
@@ -206,10 +209,15 @@ class TransactionModal extends Component {
 
 TransactionModal.propTypes = {
   showCategoryChoice: PropTypes.func.isRequired,
-  requestClose: PropTypes.func.isRequired
+  requestClose: PropTypes.func.isRequired,
+  transactionId: PropTypes.string.isRequired,
+  transaction: PropTypes.object.isRequired
 }
 
 export default compose(
+  connect((state, ownProps) => ({
+    transaction: getDocument(state, TRANSACTION_DOCTYPE, ownProps.transactionId)
+  })),
   withDispatch,
   withUpdateCategory(),
   translate(),

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -361,24 +361,22 @@ export class TransactionsWithSelection extends React.Component {
   }
 
   selectTransaction = transaction => {
-    this.setState({ transaction: transaction })
+    this.setState({ transactionId: transaction._id })
   }
 
   unselectTransaction = () => {
-    this.setState({ transaction: null })
+    this.setState({ transactionId: null })
   }
 
   render(props) {
-    const { transaction } = this.state
+    const { transactionId } = this.state
     return (
       <div>
         <Transactions selectTransaction={this.selectTransaction} {...props} />
-        {transaction && (
+        {transactionId && (
           <TransactionModal
             requestClose={this.unselectTransaction}
-            transaction={props.transactions.find(
-              t => t._id === transaction._id
-            )}
+            transactionId={transactionId}
             {...props}
           />
         )}


### PR DESCRIPTION
Fab has a hard to reproduce bug : while recategorizing transaction, at some
point the app breaks (exception in console). The app has to be restarted
to work again. This bug is not 100% reproducible which
 leads me to believe it is a race condition bug.

I suspect that it is to me caused by the fact
that we were finding the transaction, in the transaction list received
in props, by its transaction id. This means that if this list at some
point, loses this transaction, for one reason or another, the Transaction
modal is getting an undefined transaction.

To mitigate this, I propose that we rely on the document store to get
the transaction. This way we are more sure not to rely on a state/incomplete
source of data.