### PR TITLE
feat(Categories): persist the show incomes toggle state in the settings

### DIFF
--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -11,7 +11,12 @@ import styles from './CategoriesPage.styl'
 import { flowRight as compose, sortBy } from 'lodash'
 import { withBreakpoints } from 'cozy-ui/react'
 import CategoriesHeader from './CategoriesHeader'
-import { getSettings, fetchSettingsCollection } from 'ducks/settings'
+import {
+  getSettings,
+  fetchSettingsCollection,
+  updateSettings,
+  createSettings
+} from 'ducks/settings'
 import { cozyConnect } from 'cozy-client'
 
 class CategoriesPage extends Component {
@@ -29,8 +34,14 @@ class CategoriesPage extends Component {
     }
   }
 
-  filterWithInCome = withIncome => {
-    this.setState({ withIncome })
+  onWithIncomeToggle = checked => {
+    const { settingsCollection, dispatch } = this.props
+    const settings = getSettings(settingsCollection)
+    const updateOrCreate = settings._id ? updateSettings : createSettings
+
+    settings.showIncomeCategory = checked
+
+    dispatch(updateOrCreate(settings))
   }
 
   render({
@@ -67,7 +78,7 @@ class CategoriesPage extends Component {
           breadcrumbItems={breadcrumbItems}
           selectedCategory={selectedCategory}
           withIncome={showIncomeCategory}
-          onWithIncomeToggle={this.filterWithInCome}
+          onWithIncomeToggle={this.onWithIncomeToggle}
           categories={sortedCategories}
           selectCategory={this.selectCategory}
           isFetching={isFetching}

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -11,12 +11,10 @@ import styles from './CategoriesPage.styl'
 import { flowRight as compose, sortBy } from 'lodash'
 import { withBreakpoints } from 'cozy-ui/react'
 import CategoriesHeader from './CategoriesHeader'
+import { getSettings, fetchSettingsCollection } from 'ducks/settings'
+import { cozyConnect } from 'cozy-client'
 
 class CategoriesPage extends Component {
-  state = {
-    withIncome: true
-  }
-
   componentDidMount() {
     this.props.fetchTransactions()
   }
@@ -35,13 +33,17 @@ class CategoriesPage extends Component {
     this.setState({ withIncome })
   }
 
-  render(
-    { t, categories: categoriesProps, transactions, router },
-    { withIncome }
-  ) {
+  render({
+    t,
+    categories: categoriesProps,
+    transactions,
+    router,
+    settingsCollection
+  }) {
     const isFetching = transactions.fetchStatus !== 'loaded'
+    const { showIncomeCategory } = getSettings(settingsCollection)
     const selectedCategoryName = router.params.categoryName
-    const categories = withIncome
+    const categories = showIncomeCategory
       ? categoriesProps
       : categoriesProps.filter(category => category.name !== 'incomeCat')
     const breadcrumbItems = [{ name: t('Categories.title.general') }]
@@ -64,7 +66,7 @@ class CategoriesPage extends Component {
         <CategoriesHeader
           breadcrumbItems={breadcrumbItems}
           selectedCategory={selectedCategory}
-          withIncome={withIncome}
+          withIncome={showIncomeCategory}
           onWithIncomeToggle={this.filterWithInCome}
           categories={sortedCategories}
           selectCategory={this.selectCategory}
@@ -78,7 +80,7 @@ class CategoriesPage extends Component {
             selectedCategory={selectedCategory}
             selectedCategoryName={selectedCategoryName}
             selectCategory={this.selectCategory}
-            withIncome={withIncome}
+            withIncome={showIncomeCategory}
             filterWithInCome={this.filterWithInCome}
           />
         )}
@@ -98,9 +100,14 @@ const mapDispatchToProps = dispatch => ({
   fetchTransactions: () => dispatch(fetchTransactions())
 })
 
+const mapDocumentsToProps = () => ({
+  settingsCollection: fetchSettingsCollection()
+})
+
 export default compose(
   withRouter,
   withBreakpoints(),
   connect(mapStateToProps, mapDispatchToProps),
+  cozyConnect(mapDocumentsToProps),
   translate()
 )(CategoriesPage)

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -26,5 +26,6 @@ export const DEFAULTS_SETTINGS = {
   },
   categorization: {
     lastSeq: 0
-  }
+  },
+  showIncomeCategory: true
 }


### PR DESCRIPTION
When the user changes the state of the "show incomes" toggle, we persist it in the settings. So the next time the user goes on the categorization page, his/her preference is still here.