### PR TITLE
fix(Categories): always show the chart even if there is no data

### DIFF
--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -40,12 +40,13 @@ class Categories extends Component {
     if (selectedCategory) {
       categories = [selectedCategory]
     }
+    const hasData =
+      categories.length > 0 && categories[0].transactionsNumber > 0
 
     return (
       <div>
-        {categories.length === 0 || categories[0].transactionsNumber === 0 ? (
-          <p>{t('Categories.title.empty_text')}</p>
-        ) : (
+        {isDesktop && !hasData && <p>{t('Categories.title.empty_text')}</p>}
+        {hasData && (
           <Table className={stTableCategory}>
             <thead>
               <tr>

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -56,23 +56,20 @@ const CategoriesHeader = ({
           </div>
         )}
       </div>
-      {!isFetching &&
-        hasData && (
-          <CategoriesChart
-            width={chartSize}
-            height={chartSize}
-            categories={
-              selectedCategory ? selectedCategory.subcategories : categories
-            }
-            selectedCategory={selectedCategory}
-            selectCategory={selectCategory}
-            total={
-              selectedCategory ? selectedCategory.amount : transactionsTotal
-            }
-            currency={globalCurrency}
-            label={t('Categories.title.total')}
-          />
-        )}
+      {!isFetching && (
+        <CategoriesChart
+          width={chartSize}
+          height={chartSize}
+          categories={
+            selectedCategory ? selectedCategory.subcategories : categories
+          }
+          selectedCategory={selectedCategory}
+          selectCategory={selectCategory}
+          total={selectedCategory ? selectedCategory.amount : transactionsTotal}
+          currency={globalCurrency}
+          label={t('Categories.title.total')}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Always show the categories chart, even if there is no data for the period.
On mobile, don't show the text indicating that there's no data