### PR TITLE
feat(TransactionModal): use Page component on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "cozy-client": "0.4.3",
     "cozy-client-js": "0.9.0",
     "cozy-konnector-libs": "^3.0.13",
-    "cozy-ui": "git://github.com/cozy/cozy-ui.git#v9.0.1",
+    "cozy-ui": "9.1.0",
     "date-fns": "^1.28.2",
     "hammerjs": "^2.0.8",
     "localforage": "^1.5.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -7,14 +7,13 @@ import { Sidebar } from 'cozy-ui/react'
 import Nav from 'ducks/commons/Nav'
 import { Warnings } from 'ducks/warnings'
 import FlagSwitcher from 'components/FlagSwitcher'
-import styles from './App.styl'
 
 const ReactHint = ReactHintFactory(React)
 
 const App = ({ children }) => (
   <Layout>
     {__DEVELOPMENT__ ? <FlagSwitcher /> : null}
-    <Sidebar className={styles.AppSidebar}>
+    <Sidebar>
       <Nav />
     </Sidebar>
 

--- a/src/components/App.styl
+++ b/src/components/App.styl
@@ -1,9 +1,0 @@
-@require 'settings/breakpoints'
-
-.AppSidebar
-    +small-screen()
-        // We want the navigation to be visible even when a fullscreen modal
-        // is open. So we set a higher z-index. The drawback is that we can't
-        // have a real fullscreen modal if we want one. The navigation will
-        // always be on top of it
-        z-index 80 !important

--- a/src/ducks/transactions/Page.jsx
+++ b/src/ducks/transactions/Page.jsx
@@ -1,0 +1,46 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import Icon from 'cozy-ui/react/Icon'
+import Modal, { ModalHeader, ModalContent } from 'cozy-ui/react/Modal'
+import palette from 'cozy-ui/stylus/settings/palette.json'
+import styles from './Page.styl'
+import iconArrowLeft from 'assets/icons/icon-arrow-left.svg'
+
+const BackButton = ({ onClick }) => (
+  <button type="button" onClick={onClick} className={styles.Page__BackButton}>
+    <Icon icon={iconArrowLeft} width={16} color={palette.coolGrey} />
+  </button>
+)
+
+class Page extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    dismissAction: PropTypes.func.isRequired,
+    title: PropTypes.node.isRequired
+  }
+
+  render() {
+    return (
+      <Modal
+        mobileFullscreen
+        dismissAction={this.props.dismissAction}
+        closable={false}
+        into="body"
+        className={cx(styles.Page, this.props.className)}
+        overlayClassName={styles.Page__Overlay}
+        wrapperClassName={styles.Page__Wrapper}
+      >
+        <ModalHeader className={styles.Page__title}>
+          <BackButton onClick={this.props.dismissAction} />
+          {this.props.title}
+        </ModalHeader>
+        <ModalContent className={styles.Page__content}>
+          {this.props.children}
+        </ModalContent>
+      </Modal>
+    )
+  }
+}
+
+export default Page

--- a/src/ducks/transactions/Page.styl
+++ b/src/ducks/transactions/Page.styl
@@ -1,0 +1,32 @@
+.Page__BackButton
+    background-color transparent
+    border-width 0
+    position absolute
+    top 0
+    left 0
+    height 100%
+    width 3rem
+    cursor pointer
+    display flex
+    align-items center
+    justify-content center
+
+.Page
+    .Page__title
+        position relative
+        height 3rem
+        display flex
+        align-items center
+        justify-content center
+        border-bottom 1px solid silver
+        padding 0 3rem
+        margin-bottom 0
+
+    .Page__content
+        padding 0
+
+headerHeight = 49px
+
+.Page__Overlay,
+.Page__Wrapper
+    height 'calc(100% - %s)' % headerHeight

--- a/src/ducks/transactions/TransactionModal.styl
+++ b/src/ducks/transactions/TransactionModal.styl
@@ -1,21 +1,20 @@
 @require 'settings/breakpoints'
 
-.TransactionModalHeader
-    position relative
-
 .TransactionModal
     .TransactionModalHeader
-        +small-screen()
-            min-height 3rem
-            padding-top 0
-            margin-bottom 0
+        position relative
+        border-bottom 1px solid silver
+        margin-bottom 0
+        padding-top 0
+        padding-bottom 0
+        height 5rem
+        display flex
+        align-items center
+        justify-content center
 
 .TransactionModalHeading
     text-align center
     padding-top 4px
-
-    +small-screen()
-        padding-top 14px
 
 .TransactionModalContent
     padding 0
@@ -77,15 +76,4 @@
     width 16px
     height 16px
     z-index 1
-
-    +small-screen()
-        display none
-
-.TransactionModalCloseButton
-    background-color transparent
-    border-width 0
-    position absolute
-    top 1rem
-    left 1rem
-    padding 0
-    cursor pointer
+    top 1.4rem

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,9 +2885,9 @@ cozy-logger@^1.0.4:
   dependencies:
     json-stringify-safe "5.0.1"
 
-"cozy-ui@git://github.com/cozy/cozy-ui.git#v9.0.1":
-  version "9.0.1"
-  resolved "git://github.com/cozy/cozy-ui.git#68a3d92dd4145b6cbc7445ee88681129fd2da629"
+cozy-ui@9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-9.1.0.tgz#479a7fba54614a62d6c2b4a94ae68ebc2b098a17"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     classnames "^2.2.5"


### PR DESCRIPTION
This introduce a `Page` component that is 99% like a `Modal`, but shows the footer. It could be extracted in Cozy UI if it's needed. But maybe it needs a cleaning step before.

With that, we don't have problems with the footer being above modals anymore.