### PR TITLE
WIP 🚀 perf: add fastclick

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "cozy-konnector-libs": "^3.0.13",
     "cozy-ui": "git://github.com/cozy/cozy-ui.git#v9.0.1",
     "date-fns": "^1.28.2",
+    "fastclick": "^1.0.6",
     "hammerjs": "^2.0.8",
     "localforage": "^1.5.0",
     "lodash": "^4.17.4",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -15,6 +15,7 @@ import { getClient } from 'utils/client'
 import { fetchSettingsCollection, initSettings } from 'ducks/settings'
 import { updateUserAgent } from 'ducks/mobile/userAgent'
 import 'utils/flag'
+import FastClick from 'fastclick'
 
 if (__TARGET__ === 'mobile') {
   require('styles/mobile.styl')
@@ -31,6 +32,10 @@ if (__TARGET__ === 'mobile') {
 if (process.env.NODE_ENV === 'development') {
   require('preact/debug')
 }
+
+window.addEventListener('load', () => {
+  FastClick.attach(document.body)
+})
 
 const renderAppWithPersistedState = persistedState => {
   const root = document.querySelector('[role=application]')

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,6 +4297,10 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
+fastclick@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/fastclick/-/fastclick-1.0.6.tgz#161625b27b1a5806405936bda9a2c1926d06be6a"
+
 fastparse@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.1.tgz#d1e2643b38a94d7583b479060e6c4affc94071f8"


### PR DESCRIPTION
Yay, no delay when we click. Vastly improves the mobile experience.

https://github.com/ftlabs/fastclick

> FastClick is a simple, easy-to-use library for eliminating the 300ms delay between a physical tap and the firing of a click event on mobile browsers. The aim is to make your application feel less laggy and more responsive while avoiding any interference with your current logic.