### PR TITLE
Increase clickable areas on mobile

### DIFF
--- a/src/components/BackButton/index.jsx
+++ b/src/components/BackButton/index.jsx
@@ -38,7 +38,7 @@ const BackButton = ({
   const handleClick = (onClick = onClick || (() => to && router.push(to)))
   return isMobile ? (
     <BarLeft>
-      <button className="coz-bar-btn" onClick={handleClick}>
+      <button className="coz-bar-btn coz-bar-burger" onClick={handleClick}>
         <Icon icon={arrowLeft} color={palette['coolGrey']} />
       </button>
     </BarLeft>

--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -48,8 +48,16 @@ const Separator = () => (
 
 const constrain = (val, min, max) => Math.min(Math.max(val, min), max)
 
-const selectYearContainerStyle = base => ({ ...base, flexGrow: 1 })
-const selectMonthContainerStyle = base => ({ ...base, flexGrow: 6 })
+const selectYearContainerStyle = base => ({
+  ...base,
+  flexGrow: 1,
+  paddingLeft: '0.875rem'
+})
+const selectMonthContainerStyle = base => ({
+  ...base,
+  flexGrow: 6,
+  paddingLeft: '0.875rem'
+})
 
 const SelectDateButton = ({ children, disabled, className, ...props }) => {
   return (

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -36,8 +36,6 @@ select-date-height-small = 2.75rem
     margin-right 0.5rem
 
 +small-screen()
-    elements-spacing = 0.875rem
-
     .SelectDates
         m = 0.75rem // size of the margin-top/bottom
         topbar-height = 3rem
@@ -46,8 +44,6 @@ select-date-height-small = 2.75rem
         right 0
         width auto
         height select-date-height-small
-        padding-left 1rem
-        padding-right elements-spacing
         position fixed
         background white
         z-index 2
@@ -78,26 +74,23 @@ select-date-height-small = 2.75rem
 
     .SelectDates__separator
         height 1.5rem
-        margin-left elements-spacing
-        margin-right elements-spacing
+        margin-left 0
+        margin-right 0
 
     .SelectDates__buttons
         display flex
         align-items center
+        margin-left 0.375rem
 
     .SelectDates__Button
         width auto
         background-color transparent
         color coolGrey
+        padding-left 0.875rem
+        padding-right 0.875rem
 
     .SelectDates__Button--disabled svg
         color silver
-
-    .SelectDates__Button--prev
-        padding-right elements-spacing
-
-    .SelectDates__Button--next
-        padding-left elements-spacing
 
     .SelectDates__Select
         color inherit


### PR DESCRIPTION
This increases some clickable area on mobile. Mostly on the mobile date select. It also adds a margin to the back button (the same as the cozy bar menu button), so the page title don't jump anymore.