### PR TITLE
🐝 fix: disable next button when months after have no transactions

### DIFF
--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -20,7 +20,7 @@ import Chip from 'cozy-ui/react/Chip'
 import Select from 'components/Select'
 import cx from 'classnames'
 import scrollAware from './scrollAware'
-
+import { rangedSome } from './utils'
 const start2016 = new Date(2015, 11, 31)
 
 const getDefaultOptions = () => {
@@ -81,6 +81,11 @@ const SelectDateButton = ({ children, disabled, className, ...props }) => {
 }
 
 const isFullYearValue = value => value && value.length === 4
+
+const isOptionEnabled = option => option && !option.isDisabled
+const allDisabledFrom = (options, maxIndex) => {
+  return !rangedSome(options, isOptionEnabled, maxIndex, 0)
+}
 
 class SelectDatesDumb extends React.PureComponent {
   getSelectedIndex = () => {
@@ -241,6 +246,7 @@ class SelectDatesDumb extends React.PureComponent {
       availableYears = this.getAvailableYears()
       yearIndex = availableYears.indexOf(value)
     }
+
     return (
       <div
         className={cx(
@@ -302,7 +308,11 @@ class SelectDatesDumb extends React.PureComponent {
 
           <SelectDateButton
             onClick={this.handleChooseNext}
-            disabled={yearMode ? yearIndex === 0 : index === 0}
+            disabled={
+              yearMode
+                ? yearIndex === 0
+                : allDisabledFrom(monthsOptions, index - 1)
+            }
             className={styles['SelectDates__Button--next']}
           >
             <Icon icon="forward" />

--- a/src/components/SelectDates/utils.js
+++ b/src/components/SelectDates/utils.js
@@ -1,0 +1,16 @@
+const rangedSome = (arr, predicate, start, end) => {
+  start = Math.max(start, 0)
+  end = Math.min(end, arr.length)
+  const step = start > end ? -1 : 1
+  if (!arr || arr.length === 0) {
+    return false
+  }
+  for (let i = start; i !== end; i = i + step) {
+    if (predicate(arr[i])) {
+      return true
+    }
+  }
+  return false
+}
+
+export { rangedSome }

--- a/src/components/SelectDates/utils.spec.js
+++ b/src/components/SelectDates/utils.spec.js
@@ -1,0 +1,16 @@
+import { rangedSome } from './utils'
+
+describe('ranged some', () => {
+  const numbers = [1, 1, 3, 5, 4, 6, 2, 8]
+  it('should execute a predicate on an array bounded by start/end', () => {
+    const isPair = x => x % 2 === 0
+    const superiorToThree = x => x > 3
+    expect(rangedSome(numbers, isPair, 0, numbers.length)).toBe(true)
+    expect(rangedSome(numbers, isPair, 0, 4)).toBe(false)
+    expect(rangedSome(numbers, isPair, 4, numbers.length + 5)).toBe(true)
+    expect(rangedSome(numbers, isPair, numbers.length + 5, 4)).toBe(true)
+    expect(rangedSome(numbers, superiorToThree, -5, 3)).toBe(false)
+    expect(rangedSome(numbers, isPair, 4, 4)).toBe(false)
+    expect(rangedSome(numbers, superiorToThree, 4, 4)).toBe(false)
+  })
+})


### PR DESCRIPTION
The next button is disabled if all options after it are disabled.