### PR TITLE
🐝 fix: need to use helper to print institution label to remove secure key part

### DIFF
--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -32,7 +32,10 @@ import iconGraph from 'assets/icons/icon-graph.svg'
 import iconComment from 'assets/icons/actions/icon-comment.svg'
 import iconCredit from 'assets/icons/icon-credit.svg'
 import iconCalendar from 'assets/icons/icon-calendar.svg'
-import { getAccountLabel } from 'ducks/account/helpers'
+import {
+  getAccountLabel,
+  getAccountInstitutionLabel
+} from 'ducks/account/helpers'
 import { connect } from 'react-redux'
 import { getDocument } from 'cozy-client'
 import { TRANSACTION_DOCTYPE, ACCOUNT_DOCTYPE } from 'doctypes'
@@ -138,7 +141,7 @@ class TransactionModal extends Component {
               },
               {
                 label: t('Transactions.infos.institution'),
-                value: account.institutionLabel
+                value: getAccountInstitutionLabel(account)
               }
             ]}
           />


### PR DESCRIPTION
> quand j'ouvre le détail d'une opération je vois le détail de l'opérations avec le champ banque notamment : dans ce champ est présent la notion "sans secure key"

