### PR TITLE
Informative modal health

### DIFF
--- a/src/ducks/transactions/TransactionActions.spec.jsx
+++ b/src/ducks/transactions/TransactionActions.spec.jsx
@@ -60,7 +60,7 @@ const tests = [
   ['salaireisa1', null, 'Accéder à votre paie', 'openwith', 'url'],
   ['fnac', null, 'Accéder au site Fnac', 'openwith', 'url'],
   ['edf', null, 'EDF', null, 'app'],
-  ['remboursementcomplementaire', null, 'My invoices', 'plus', 'konnector', {
+  ['remboursementcomplementaire', null, 'My reimbursements', 'plus', 'konnector', {
     brands: brands.filter(x => x.name == 'Malakoff Mederic')
   }, 'remboursementcomplementaire konnector not installed'],
   ['remboursementcomplementaire', null, '1 invoice', null, 'bill', {

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -28,7 +28,15 @@ import iconCollectAccount from 'assets/icons/icon-collect-account.svg'
 
 const name = 'konnector'
 
-const _InformativeModal = ({ brandName, onCancel, onConfirm, t }) => (
+const InformativeModal = ({
+  onCancel,
+  onConfirm,
+  title,
+  description,
+  caption,
+  cancelText,
+  confirmText
+}) => (
   <Modal into="body" mobileFullscreen dismissAction={onCancel}>
     <ModalDescription className={styles.InformativeModal__content}>
       <Icon
@@ -38,37 +46,33 @@ const _InformativeModal = ({ brandName, onCancel, onConfirm, t }) => (
         className={styles.InformativeModal__illustration}
       />
       <Title tag="h2" className={cx('u-mt-1-half', 'u-mb-0', 'u-text-center')}>
-        {t('Transactions.actions.informativeModal.title')}
+        {title}
       </Title>
-      <Text tag="p">
-        {t('Transactions.actions.informativeModal.description', {
-          brandName
-        })}
-      </Text>
+      <Text tag="p">{description}</Text>
       <div className={styles.InformativeModal__bottom}>
         <Caption tag="p" className={cx('u-mt-0', 'u-mb-1')}>
-          {t('Transactions.actions.informativeModal.caption')}
+          {caption}
         </Caption>
         <div className={styles.InformativeModal__buttons}>
           <Button onClick={onCancel} theme="secondary">
-            {t('Transactions.actions.informativeModal.cancel')}
+            {cancelText}
           </Button>
-          <Button onClick={onConfirm}>
-            {t('Transactions.actions.informativeModal.confirm')}
-          </Button>
+          <Button onClick={onConfirm}>{confirmText}</Button>
         </div>
       </div>
     </ModalDescription>
   </Modal>
 )
 
-_InformativeModal.propTypes = {
-  brandName: PropTypes.string.isRequired,
+InformativeModal.propTypes = {
   onCancel: PropTypes.func.isRequired,
-  onConfirm: PropTypes.func.isRequired
+  onConfirm: PropTypes.func.isRequired,
+  title: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  caption: PropTypes.string.isRequired,
+  cancelText: PropTypes.string.isRequired,
+  confirmText: PropTypes.string.isRequired
 }
-
-const InformativeModal = translate()(_InformativeModal)
 
 class Component extends React.Component {
   state = {

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -142,9 +142,20 @@ class Component extends React.Component {
           )}
           {this.state.showInformativeModal && (
             <InformativeModal
-              brandName={brand.name}
               onCancel={this.hideInformativeModal}
               onConfirm={this.onInformativeModalConfirm}
+              title={t('Transactions.actions.informativeModal.generic.title')}
+              description={t(
+                'Transactions.actions.informativeModal.generic.description',
+                {
+                  brandName: brand.name
+                }
+              )}
+              caption={t(
+                'Transactions.actions.informativeModal.generic.caption'
+              )}
+              cancelText={t('Transactions.actions.informativeModal.cancel')}
+              confirmText={t('Transactions.actions.informativeModal.confirm')}
             />
           )}
           {this.state.showIntentModal && (

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -118,6 +118,9 @@ class Component extends React.Component {
     if (!brand) return
 
     const label = t('Transactions.actions.konnector', { vendor: brand.name })
+    const translationKey = `Transactions.actions.informativeModal.${
+      brand.health ? 'health' : 'generic'
+    }`
 
     if (__TARGET__ === 'browser') {
       return (
@@ -144,16 +147,11 @@ class Component extends React.Component {
             <InformativeModal
               onCancel={this.hideInformativeModal}
               onConfirm={this.onInformativeModalConfirm}
-              title={t('Transactions.actions.informativeModal.generic.title')}
-              description={t(
-                'Transactions.actions.informativeModal.generic.description',
-                {
-                  brandName: brand.name
-                }
-              )}
-              caption={t(
-                'Transactions.actions.informativeModal.generic.caption'
-              )}
+              title={t(`${translationKey}.title`)}
+              description={t(`${translationKey}.description`, {
+                brandName: brand.name
+              })}
+              caption={t('Transactions.actions.informativeModal.caption')}
               cancelText={t('Transactions.actions.informativeModal.cancel')}
               confirmText={t('Transactions.actions.informativeModal.confirm')}
             />

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -117,10 +117,9 @@ class Component extends React.Component {
     const brand = findMatchingBrand(brands, transaction.label)
     if (!brand) return
 
-    const label = t('Transactions.actions.konnector', { vendor: brand.name })
-    const translationKey = `Transactions.actions.informativeModal.${
-      brand.health ? 'health' : 'generic'
-    }`
+    const healthOrGeneric = brand.health ? 'health' : 'generic'
+    const label = t(`Transactions.actions.konnector.${healthOrGeneric}`)
+    const translationKey = `Transactions.actions.informativeModal.${healthOrGeneric}`
 
     if (__TARGET__ === 'browser') {
       return (

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -28,7 +28,7 @@ import iconCollectAccount from 'assets/icons/icon-collect-account.svg'
 
 const name = 'konnector'
 
-const _InformativeModal = ({ brand, onCancel, onConfirm, t }) => (
+const _InformativeModal = ({ brandName, onCancel, onConfirm, t }) => (
   <Modal into="body" mobileFullscreen dismissAction={onCancel}>
     <ModalDescription className={styles.InformativeModal__content}>
       <Icon
@@ -42,7 +42,7 @@ const _InformativeModal = ({ brand, onCancel, onConfirm, t }) => (
       </Title>
       <Text tag="p">
         {t('Transactions.actions.informativeModal.description', {
-          brand: brand.name
+          brandName
         })}
       </Text>
       <div className={styles.InformativeModal__bottom}>
@@ -61,6 +61,12 @@ const _InformativeModal = ({ brand, onCancel, onConfirm, t }) => (
     </ModalDescription>
   </Modal>
 )
+
+_InformativeModal.propTypes = {
+  brandName: PropTypes.string.isRequired,
+  onCancel: PropTypes.func.isRequired,
+  onConfirm: PropTypes.func.isRequired
+}
 
 const InformativeModal = translate()(_InformativeModal)
 
@@ -132,7 +138,7 @@ class Component extends React.Component {
           )}
           {this.state.showInformativeModal && (
             <InformativeModal
-              brand={brand}
+              brandName={brand.name}
               onCancel={this.hideInformativeModal}
               onConfirm={this.onInformativeModalConfirm}
             />

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -299,7 +299,7 @@
         },
         "caption": "Your Cozy is totally private: nobody but you can access its content.",
         "cancel": "Cancel",
-        "confirm": "Start"
+        "confirm": "Connect"
       }
     },
     "infos": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -289,9 +289,15 @@
       "healthExpenseBill": "%{vendor} Statement",
       "vendorsGlue": "and",
       "informativeModal": {
-        "title": "Automatic fetching of my bills",
-        "description": "Connect your %{brandName} account to your Cozy to automatically fetch your bills.",
-        "caption": "Your Cozy is totally private: nobody but you can access its content.",
+        "health": {
+          "title": "Automatic monitoring of your reimbursements",
+          "description": "Connect your %{brandName} account to your Cozy to automatically fetch your reimbursements."
+        },
+        "generic": {
+          "title": "Automatic fetching of my bills",
+          "description": "Connect your %{brandName} account to your Cozy to automatically fetch your bills.",
+          "caption": "Your Cozy is totally private: nobody but you can access its content."
+        },
         "cancel": "Cancel",
         "confirm": "Start"
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -295,9 +295,9 @@
         },
         "generic": {
           "title": "Automatic fetching of my bills",
-          "description": "Connect your %{brandName} account to your Cozy to automatically fetch your bills.",
-          "caption": "Your Cozy is totally private: nobody but you can access its content."
+          "description": "Connect your %{brandName} account to your Cozy to automatically fetch your bills."
         },
+        "caption": "Your Cozy is totally private: nobody but you can access its content.",
         "cancel": "Cancel",
         "confirm": "Start"
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -279,7 +279,10 @@
       "bill": "1 invoice",
       "alert": "Create an alert",
       "attach": "Attach a document",
-      "konnector": "My invoices",
+      "konnector": {
+        "health": "My reimbursements",
+        "generic": "My invoices"
+      },
       "more": "More",
       "healthExpenseProcessed": {
         "single": "1 reimbursement",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -290,7 +290,7 @@
       "vendorsGlue": "and",
       "informativeModal": {
         "title": "Automatic fetching of my bills",
-        "description": "Connect your %{brand} account to your Cozy to automatically fetch your bills.",
+        "description": "Connect your %{brandName} account to your Cozy to automatically fetch your bills.",
         "caption": "Your Cozy is totally private: nobody but you can access its content.",
         "cancel": "Cancel",
         "confirm": "Start"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -106,7 +106,10 @@
       "app": "Application %{appName}",
       "refund": "Vérifier vos remboursements",
       "attach": "Attacher un document",
-      "konnector": "Mes factures",
+      "konnector": {
+        "health": "Mes remboursements",
+        "generic": "Mes factures"
+      },
       "alert": "Créer une alerte",
       "comment": "Commentaire - Bientôt disponible",
       "healthExpenseProcessed": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -127,7 +127,7 @@
         },
         "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu.",
         "cancel": "Annuler",
-        "confirm": "Démarrer"
+        "confirm": "Connecter"
       }
     },
     "infos": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -123,9 +123,9 @@
         },
         "generic": {
           "title": "Récupération automatique de mes factures",
-          "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos factures automatiquement.",
-          "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu."
+          "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos factures automatiquement."
         },
+        "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu.",
         "cancel": "Annuler",
         "confirm": "Démarrer"
       }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -118,7 +118,7 @@
       "vendorsGlue": "et",
       "informativeModal": {
         "title": "Récupération automatique de mes factures",
-        "description": "Connectez votre compte %{brand.name} à votre Cozy pour récupérer vos factures automatiquement.",
+        "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos factures automatiquement.",
         "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu.",
         "cancel": "Annuler",
         "confirm": "Démarrer"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -117,9 +117,15 @@
       "healthExpenseBill": "Relevé %{vendor}",
       "vendorsGlue": "et",
       "informativeModal": {
-        "title": "Récupération automatique de mes factures",
-        "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos factures automatiquement.",
-        "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu.",
+        "health": {
+          "title": "Surveillance automatique de mes remboursements",
+          "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos remboursements automatiquement."
+        },
+        "generic": {
+          "title": "Récupération automatique de mes factures",
+          "description": "Connectez votre compte %{brandName} à votre Cozy pour récupérer vos factures automatiquement.",
+          "caption": "Votre Cozy est totalement privé : personne d'autre que vous ne peut accéder à son contenu."
+        },
         "cancel": "Annuler",
         "confirm": "Démarrer"
       }


### PR DESCRIPTION
This add a variation of the informative modal for health connectors : 

A different label for the CTA : 
![image](https://user-images.githubusercontent.com/1606068/41720902-c075dbd4-7564-11e8-88cc-a8e2a485f0ce.png)

A different content : 
![image](https://user-images.githubusercontent.com/1606068/41720952-db1dc618-7564-11e8-88e6-071df3e1bb39.png)

For that, I made `InformativeModal` more generic by passing its content to its props.
