### PR TITLE
🐝 fix: bump cozy-authetnication to 1.2.0-beta.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "classificator": "0.3.0",
     "classnames": "^2.2.0",
     "cordova": "^7.1.0",
-    "cozy-authentication": "1.1.4",
+    "cozy-authentication": "1.3.0-beta.1",
     "cozy-bar": "5.0.6",
     "cozy-client": "0.5.0",
     "cozy-client-js": "0.9.0",

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="70805" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.7.8.5" version="0.7.8" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="70807" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.7.8.7" version="0.7.8" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2911,9 +2911,9 @@ cozy-app-publish@0.3.6:
     node-fetch "2.1.2"
     prompt "1.0.0"
 
-cozy-authentication@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/cozy-authentication/-/cozy-authentication-1.1.4.tgz#5081351fa819f29629bc16072f3385bb206679c3"
+cozy-authentication@1.3.0-beta.1:
+  version "1.3.0-beta.1"
+  resolved "https://registry.yarnpkg.com/cozy-authentication/-/cozy-authentication-1.3.0-beta.1.tgz#793841e1a7d6d11dc68457d099eed1c4645c9b73"
   dependencies:
     url-polyfill "1.0.11"
 


### PR DESCRIPTION
This bumps `cozy-authentication` to a version that does not set bad global styles for html/body. Fixes the blank page.