### PR TITLE
fix(TransactionSelectDates): show all the months of the transactions

### DIFF
--- a/src/ducks/transactions/TransactionSelectDates.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.jsx
@@ -6,7 +6,7 @@ import { subMonths, format, parse, differenceInCalendarMonths } from 'date-fns'
 const rangeMonth = (startDate, endDate) => {
   const options = []
 
-  for (let i = 0; i < differenceInCalendarMonths(endDate, startDate); i++) {
+  for (let i = 0; i <= differenceInCalendarMonths(endDate, startDate); i++) {
     options.push(subMonths(endDate, i))
   }
 


### PR DESCRIPTION
Currently, a month is missing on the date selector. Eg. if I have transactions from 03/2018 to 06/2018, I see april, may and june in the month select, but not march.

This fixes it.