### PR TITLE
🐝 fix: use before_deploy to decrypt ssh key, deploy phase is bypassed in pr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
   yarn: true
   directories:
     - node_modules
-before_install:
+before_deploy:
   - openssl aes-256-cbc -K $encrypted_5a663823105c_key -iv $encrypted_5a663823105c_iv -in ./scripts/id_rsa.enc -out /tmp/deploy_rsa -d
   - eval "$(ssh-agent -s)"
   - chmod 600 /tmp/deploy_rsa


### PR DESCRIPTION
In PR from forks, we cannot decrypt encrypted env var, so we cannot add our ssh agent.
This step is only necessary when deploying. Deploying is not done in pull request builds.

https://docs.travis-ci.com/user/deployment#Pull-Requests