### PR TITLE
🐝 fix: supports legacy triggers

### DIFF
--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -43,6 +43,7 @@ import { TRIGGER_DOCTYPE, ACCOUNT_DOCTYPE } from 'doctypes'
 import { getBrands } from 'ducks/brandDictionary'
 import { AccountSwitch } from 'ducks/account'
 import { isIOSApp } from 'cozy-device-helper'
+import { getKonnectorFromTrigger } from 'utils/triggers'
 
 const { BarRight } = cozy.bar
 
@@ -130,7 +131,7 @@ class TransactionsPage extends Component {
   getKonnectorSlugs = triggers => {
     return triggers
       .filter(trigger => trigger.worker === 'konnector')
-      .map(trigger => trigger.message && trigger.message.konnector)
+      .map(getKonnectorFromTrigger)
       .filter(Boolean)
   }
 

--- a/src/utils/triggers.js
+++ b/src/utils/triggers.js
@@ -1,0 +1,11 @@
+const getKonnectorFromTrigger = trigger => {
+  if (trigger.message && trigger.message.konnector) {
+    return trigger.message.konnector
+  } else if (trigger.message.Data) {
+    // Legacy triggers
+    const message = JSON.parse(atob(trigger.message.Data))
+    return message.konnector
+  }
+}
+
+export { getKonnectorFromTrigger }

--- a/src/utils/triggers.js
+++ b/src/utils/triggers.js
@@ -1,8 +1,11 @@
+const { logInfo } = require('lib/sentry')
+
 const getKonnectorFromTrigger = trigger => {
   if (trigger.message && trigger.message.konnector) {
     return trigger.message.konnector
   } else if (trigger.message.Data) {
     // Legacy triggers
+    logInfo('Legacy trigger detected')
     const message = JSON.parse(atob(trigger.message.Data))
     return message.konnector
   }

--- a/src/utils/triggers.spec.js
+++ b/src/utils/triggers.spec.js
@@ -1,0 +1,40 @@
+const { getKonnectorFromTrigger } = require('./triggers')
+
+describe('getKonnectorFromTrigger', () => {
+  it('should work with normal triggers', () => {
+    const normalTrigger = {
+      _rev: '1-31eb8f0da1db0f3196ccf0d4329ea554',
+      prefix: 'toto.mycozy.cloud',
+      arguments: '0 35 0 * * 3',
+      message: {
+        account: '4cbfe8f3d89edf60542d5fe9cdcac7b1',
+        konnector: 'orangemobile'
+      },
+      _id: 'fa4c076914ce46a92fa3e7e5f0672ca5',
+      domain: 'claire.mycozy.cloud',
+      worker: 'konnector',
+      debounce: '',
+      options: null,
+      type: '@cron'
+    }
+    expect(getKonnectorFromTrigger(normalTrigger)).toBe('orangemobile')
+  })
+
+  it('should work with legacy triggers', () => {
+    const legacyTrigger = {
+      arguments: '37 42 0 * * 3',
+      domain: 'claire.mycozy.cloud',
+      _rev: '2-a9f7f0eb5ccc0871e10721797ef5dcf0',
+      worker: 'konnector',
+      _id: '3a7c363eea2ddb4d73bd11afa9bb4691',
+      type: '@cron',
+      options: null,
+      message: {
+        Data:
+          'eyJrb25uZWN0b3IiOiJhbWVsaSIsImFjY291bnQiOiIzYTdjMzYzZWVhMmRkYjRkNzNiZDExYWZhOWJiM2ViNiJ9',
+        Type: 'json'
+      }
+    }
+    expect(getKonnectorFromTrigger(legacyTrigger)).toBe('ameli')
+  })
+})


### PR DESCRIPTION
Claire has a legacy trigger whose content is encoded in base64. Banks did not recognize it as a konnector trigger and would display the "Install the connector" CTA, even if the konnector is already installed (and has a working trigger).