### PR TITLE
🐝 fix: make the icon available when non authentificated

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -56,6 +56,10 @@
       "folder": "/",
       "index": "index.html",
       "public": false
+    },
+    "/safari-pinned-tab.svg": {
+      "folder": "/safari-pinned-tab.svg",
+      "public": true
     }
   },
   "services": {


### PR DESCRIPTION
Safari does not send cookies with the request for the icon so
the icon must be available publicly.