### PR TITLE
feat: Fetch initial data on resume

### DIFF
--- a/src/ducks/onboarding/ensureIsFirstSynced.js
+++ b/src/ducks/onboarding/ensureIsFirstSynced.js
@@ -80,6 +80,8 @@ class Wrapper extends Component {
       document.addEventListener('resume', () => {
         if (client.store.getState().mobile.syncOk) {
           this.props.dispatch(startSync())
+        } else {
+          this.fetchInitialData()
         }
       })
     }


### PR DESCRIPTION
On mobile app resume, fetch initial data, so when we accept TOS, when we come back on the app, we don't have the onboarding screen.