### PR TITLE
Use native selects on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-banks",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "main": "src/main.jsx",
   "scripts": {
     "build": "npm run build:browser && npm run build:services",

--- a/src/components/Select/index.jsx
+++ b/src/components/Select/index.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import Icon from 'cozy-ui/react/Icon'
 import styles from './styles.styl'
 import SelectBox, { SelectBoxWithFixedOptions } from 'cozy-ui/react/SelectBox'
@@ -114,21 +115,25 @@ class DesktopSelect extends React.Component {
 
 class MobileSelect extends Component {
   render() {
-    const { options, onChange, ...props } = this.props
+    const { options, onChange, className, ...props } = this.props
 
     return (
-      <select
-        onChange={event => {
-          onChange(event.target.value)
-        }}
-        {...props}
-      >
-        {options.map(opt => (
-          <option key={opt.value} value={opt.value} disabled={opt.isDisabled}>
-            {opt.name}
-          </option>
-        ))}
-      </select>
+      <div className={cx(styles.Select, className)}>
+        <select
+          className={cx(styles.Select__control)}
+          onChange={event => {
+            onChange(event.target.value)
+          }}
+          {...props}
+        >
+          {options.map(opt => (
+            <option key={opt.value} value={opt.value} disabled={opt.isDisabled}>
+              {opt.name}
+            </option>
+          ))}
+        </select>
+        <SmallArrow />
+      </div>
     )
   }
 }

--- a/src/components/Select/index.jsx
+++ b/src/components/Select/index.jsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import Icon from 'cozy-ui/react/Icon'
 import styles from './styles.styl'
 import SelectBox, { SelectBoxWithFixedOptions } from 'cozy-ui/react/SelectBox'
+import withBreakpoints from 'cozy-ui/react/helpers/withBreakpoints'
 import find from 'lodash/find'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 import { components } from 'react-select'
@@ -48,7 +50,7 @@ const menuStyle = base => ({ ...base, minWidth: '9.375rem' })
 
 const optionIsFixed = option => option.fixed
 
-class Select extends React.Component {
+class DesktopSelect extends React.Component {
   constructor(props) {
     super(props)
     this.updateComponent(props)
@@ -109,5 +111,43 @@ class Select extends React.Component {
     )
   }
 }
+
+class MobileSelect extends Component {
+  render() {
+    const { options, onChange, ...props } = this.props
+
+    return (
+      <select
+        onChange={event => {
+          onChange(event.target.value)
+        }}
+        {...props}
+      >
+        {options.map(opt => (
+          <option key={opt.value} value={opt.value} disabled={opt.isDisabled}>
+            {opt.name}
+          </option>
+        ))}
+      </select>
+    )
+  }
+}
+
+MobileSelect.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string,
+      name: PropTypes.string,
+      isDisabled: PropTypes.bool
+    })
+  ).isRequired
+}
+
+const Select = withBreakpoints()(({ breakpoints: { isMobile }, ...props }) => {
+  const T = isMobile ? MobileSelect : DesktopSelect
+  return <T {...props} />
+})
 
 export default Select

--- a/src/components/Select/styles.styl
+++ b/src/components/Select/styles.styl
@@ -4,14 +4,17 @@
 select-date-height-small=2.75rem
 
 .Select
+    position relative
+
+.Select__control
     appearance none
     border 0
     outline 0
     background transparent
+    color inherit
 
     // So that you can click on arrow icon to open the select
     padding-right 2rem
-    margin-right -2rem
     cursor pointer
 
 .Select::-ms-expand
@@ -23,14 +26,13 @@ select-date-height-small=2.75rem
     cursor pointer
     color coolGrey
 
+.Select .Select__Icon
+    position absolute
+    top 50%
+    transform translateY(-50%)
+    right 0.875rem
+
 /* target Internet Explorer 9 to undo the custom arrow */
 @media screen and (min-width:0\0)
     .Select__Icon
         display none
-
-:global
-    +small-screen()
-        .cz__indicators
-            height select-date-height-small
-            justify-content center
-            padding-right 1rem

--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -50,31 +50,6 @@ const Separator = () => (
 
 const constrain = (val, min, max) => Math.min(Math.max(val, min), max)
 
-const yearContainerMobileStyle = base => ({
-  ...base,
-  flexGrow: 1,
-  flexBasis: '5.5rem',
-  flexShrink: 0,
-  padding: 0
-})
-const mobileMonthContainerStyle = base => ({
-  ...base,
-  flexGrow: 6,
-  padding: 0
-})
-
-const mobileControlStyle = () => ({
-  paddingLeft: '0.875rem'
-})
-
-const mobileMenuStyle = base => ({
-  ...base,
-  marginLeft: '0.5rem',
-  marginRight: '0.5rem',
-  width: '90%',
-  minWidth: 'auto'
-})
-
 const SelectDateButton = ({ children, disabled, className, ...props }) => {
   return (
     <Chip.Round
@@ -283,38 +258,20 @@ class SelectDatesDumb extends React.PureComponent {
               name="year"
               className={styles.SelectDates__SelectYear}
               searchable={false}
-              width={isMobile ? 'auto' : '6rem'}
+              width="6rem"
               value={selectedYear}
               options={years.map(x => ({ value: x.year, name: x.yearF }))}
               onChange={this.handleChangeYear}
-              styles={
-                isMobile
-                  ? {
-                      container: yearContainerMobileStyle,
-                      control: mobileControlStyle,
-                      menu: mobileMenuStyle
-                    }
-                  : {}
-              }
             />
             <Separator />
             <Select
               searchable={false}
               name="month"
-              width={isMobile ? 'auto' : '10rem'}
+              width="10rem"
               className={styles.SelectDates__SelectMonth}
               value={selectedMonth}
               options={monthsOptions}
               onChange={this.handleChangeMonth}
-              styles={
-                isMobile
-                  ? {
-                      container: mobileMonthContainerStyle,
-                      control: mobileControlStyle,
-                      menu: mobileMenuStyle
-                    }
-                  : {}
-              }
             />
           </Chip>
         </span>

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -63,8 +63,9 @@ select-date-height-small = 2.75rem
         width 100%
 
         select
+            padding-left 0.875rem
             width 100%
-            margin-right -1.3rem
+            height 100%
 
         svg
             color coolGrey
@@ -96,6 +97,10 @@ select-date-height-small = 2.75rem
 
     .SelectDates__SelectMonth
         flex-grow 2
+
+    .SelectDates__SelectYear,
+    .SelectDates__SelectMonth
+        height 100%
 
 .SelectDates__Button
     cursor pointer

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="71008" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.7.10.8" version="0.7.10" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="71101" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.7.11.1" version="0.7.11" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>


### PR DESCRIPTION
The cozy-ui select has a problem on Android: when we click on the (transparent) overlay to close the select without interacting with elements on the page, the first time acts like if there was no overlay, then everything is normal on next tries.

Since we have been searching why we have this behaviour for a long time, without any success, and since we have another problem with the cozy-ui select, on iOS this time (the click handler is not triggered everywhere), I think it's better for us to just use native selects on mobile.

The advantages are:

* Better UX : options are large enough to click on it easily, whereas cozy-ui select's options are very small
* No more bugs : Android and iOS bugs are past

The disadvantage is: the design of the options is platform-dependent. But to me it's actually an advantage, because the UX is way better with it.