### PR TITLE
Update CollectLink

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -16,7 +16,7 @@ import { Table, TdSecondary } from 'components/Table'
 import { Figure, FigureBlock } from 'components/Figure'
 import PageTitle from 'components/PageTitle'
 
-import CollectLink from 'ducks/settings/CollectLink'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
 import { getSettings } from 'ducks/settings'
 import { filterByDoc, getFilteringDoc } from 'ducks/filters'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
@@ -256,12 +256,12 @@ const BalanceAccounts = translate()(
           </tbody>
         </Table>
         <p>
-          <CollectLink>
+          <AddAccountLink>
             <Button className={cx(btnStyles['btn--no-outline'], 'u-pv-1')}>
               <Icon icon={plus} className="u-mr-half" />
               {t('Accounts.add-account')}
             </Button>
-          </CollectLink>
+          </AddAccountLink>
         </p>
       </div>
     )

--- a/src/ducks/onboarding/Onboarding.jsx
+++ b/src/ducks/onboarding/Onboarding.jsx
@@ -9,7 +9,7 @@ import { isCollectionLoading } from 'utils/client'
 
 import Topbar from 'components/Topbar'
 import PageTitle from 'components/PageTitle'
-import CollectLink from 'ducks/settings/CollectLink'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
 
 import calculator from 'assets/icons/icon-calculator.svg'
 import watch from 'assets/icons/icon-watch.svg'
@@ -84,11 +84,11 @@ class Onboarding extends Component {
           )}
         </Sections>
         <CTA>
-          <CollectLink>
+          <AddAccountLink>
             <Button theme="regular">
               {t('Onboarding.connect-bank-account')}
             </Button>
-          </CollectLink>
+          </AddAccountLink>
         </CTA>
         {isTriggersLoaded &&
           hasTriggers && (

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -11,7 +11,7 @@ import { cozyConnect, fetchCollection } from 'cozy-client'
 import plus from 'assets/icons/16/plus.svg'
 import styles from './AccountsSettings.styl'
 import btnStyles from 'styles/buttons.styl'
-import CollectLink from 'ducks/settings/CollectLink'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
 import cx from 'classnames'
 import { getAccountInstitutionLabel } from '../account/helpers'
 
@@ -90,12 +90,12 @@ class AccountsSettings extends Component {
 
     return (
       <div>
-        <CollectLink>
+        <AddAccountLink>
           <Button className={cx(btnStyles['btn--no-outline'], 'u-pb-1')}>
             <Icon icon={plus} className="u-mr-half" />
             {t('Accounts.add-account')}
           </Button>
-        </CollectLink>
+        </AddAccountLink>
         {myAccounts ? (
           <AccountsTable accounts={myAccounts} t={t} />
         ) : (

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -54,11 +54,11 @@ class SameWindowLink extends Component {
 
 // Switch according to target
 
-const CollectLink = props => {
+const AddAccountLink = props => {
   // For now we redirect on collect on both mobile app and browsers
   // since this is not possible to show a waiting message
   // const Link = __TARGET__ === 'mobile' ? NewWindowLink : IntentLink
   return <SameWindowLink {...props} />
 }
 
-export default CollectLink
+export default AddAccountLink

--- a/src/ducks/settings/CollectLink.jsx
+++ b/src/ducks/settings/CollectLink.jsx
@@ -16,9 +16,9 @@ import React, { Component } from 'react'
 class SameWindowLink extends Component {
   redirect = async () => {
     const redirectionURL = await cozy.client.intents.getRedirectionURL(
-      'io.cozy.accounts',
+      'io.cozy.apps',
       {
-        dataType: 'bankAccounts'
+        category: 'banking'
       }
     )
 


### PR DESCRIPTION
Now the intent is made on `io.cozy.apps` and `banking` category.

Also, I renamed `CollectLink` to `AddAccountLink`, since it's not coupled to Collect anymore, and its functional purpose is to add an account.