### PR TITLE
feat: Compute balance history

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["cozy-app"],
-  "plugins": ["babel-plugin-lodash"]
+  "plugins": ["babel-plugin-lodash", "babel-plugin-date-fns"]
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "babel-eslint": "8.2.6",
     "babel-jest": "23.0.1",
     "babel-loader": "7.1.5",
+    "babel-plugin-date-fns": "^0.2.1",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-object-rest-spread": "6.26.0",
     "babel-plugin-transform-react-jsx": "6.24.1",

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -18,7 +18,13 @@ import PageTitle from 'components/PageTitle'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
 import { filterByDoc, getFilteringDoc } from 'ducks/filters'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
-import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
+import {
+  ACCOUNT_DOCTYPE,
+  GROUP_DOCTYPE,
+  SETTINGS_DOCTYPE,
+  TRANSACTION_DOCTYPE
+} from 'doctypes'
+import { getBalanceHistories } from './helpers'
 
 import styles from './Balance.styl'
 import btnStyles from 'styles/buttons.styl'
@@ -279,7 +285,8 @@ class Balance extends React.Component {
       breakpoints: { isMobile },
       accounts: accountsCollection,
       groups: groupsCollection,
-      settings: settingsCollection
+      settings: settingsCollection,
+      transactions: transactionsCollection
     } = this.props
     if (
       isCollectionLoading(accountsCollection) ||
@@ -299,6 +306,11 @@ class Balance extends React.Component {
     const accounts = accountsCollection.data
     const groups = groupsCollection.data
     const settings = settingsCollection.data
+    const transactions = transactionsCollection.data
+
+    const balanceHistories = getBalanceHistories(accounts, transactions)
+    // eslint-disable-next-line
+    console.log(balanceHistories)
 
     const accountsSorted = sortBy(accounts, ['institutionLabel', 'label'])
     const groupsSorted = sortBy(
@@ -369,6 +381,10 @@ export default compose(
   queryConnect({
     accounts: { query: client => client.all(ACCOUNT_DOCTYPE), as: 'accounts' },
     groups: { query: client => client.all(GROUP_DOCTYPE), as: 'groups' },
-    settings: { query: client => client.all(SETTINGS_DOCTYPE), as: 'settings' }
+    settings: { query: client => client.all(SETTINGS_DOCTYPE), as: 'settings' },
+    transactions: {
+      query: client => client.all(TRANSACTION_DOCTYPE),
+      as: 'transactions'
+    }
   })
 )(Balance)

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -1,4 +1,4 @@
-import { groupBy, sumBy } from 'lodash'
+import { groupBy, memoize, sumBy } from 'lodash'
 import {
   min as getEarliestDate,
   isAfter as isDateAfter,
@@ -8,7 +8,7 @@ import {
   format as formatDate
 } from 'date-fns'
 
-export const getBalanceHistories = (accounts, transactions) => {
+const _getBalanceHistories = (accounts, transactions) => {
   if (accounts.length === 0 || transactions.length === 0) {
     return null
   }
@@ -25,6 +25,8 @@ export const getBalanceHistories = (accounts, transactions) => {
 
   return balances
 }
+
+export const getBalanceHistories = memoize(_getBalanceHistories)
 
 const getTransactionsForAccount = (account, transactions) =>
   transactions.filter(t => t.account === account.id)

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -1,11 +1,12 @@
-import groupBy from 'lodash/groupBy'
-import sumBy from 'lodash/sumBy'
-import getEarliestDate from 'date-fns/min'
-import isDateAfter from 'date-fns/is_after'
-import isDateEqual from 'date-fns/is_equal'
-import subDays from 'date-fns/sub_days'
-import startOfToday from 'date-fns/start_of_today'
-import formatDate from 'date-fns/format'
+import { groupBy, sumBy } from 'lodash'
+import {
+  min as getEarliestDate,
+  isAfter as isDateAfter,
+  isEqual as isDateEqual,
+  subDays,
+  startOfToday,
+  format as formatDate
+} from 'date-fns'
 
 export const getBalanceHistories = (accounts, transactions) => {
   if (accounts.length === 0 || transactions.length === 0) {

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -1,0 +1,61 @@
+import groupBy from 'lodash/groupBy'
+import sumBy from 'lodash/sumBy'
+import getEarliestDate from 'date-fns/min'
+import isDateAfter from 'date-fns/is_after'
+import isDateEqual from 'date-fns/is_equal'
+import subDays from 'date-fns/sub_days'
+import startOfToday from 'date-fns/start_of_today'
+import formatDate from 'date-fns/format'
+
+export const getBalanceHistories = (accounts, transactions) => {
+  if (accounts.length === 0 || transactions.length === 0) {
+    return null
+  }
+
+  const balances = accounts.reduce((balances, account) => {
+    balances[account.id] = getBalanceHistory(
+      account,
+      getTransactionsForAccount(account, transactions),
+      startOfToday()
+    )
+
+    return balances
+  }, {})
+
+  return balances
+}
+
+const getTransactionsForAccount = (account, transactions) =>
+  transactions.filter(t => t.account === account.id)
+
+export const getBalanceHistory = (account, transactions, from) => {
+  const DATE_FORMAT = 'YYYY-MM-DD'
+
+  const transactionsByDate = groupBy(transactions, t =>
+    formatDate(t.date, DATE_FORMAT)
+  )
+  const mostDistantDay =
+    Object.keys(transactionsByDate).length > 0
+      ? getEarliestDate(...Object.keys(transactionsByDate))
+      : from
+
+  const balances = []
+
+  for (
+    let day = from, balance = account.balance;
+    isDateAfter(day, mostDistantDay) || isDateEqual(day, mostDistantDay);
+    day = subDays(day, 1)
+  ) {
+    const transactions = transactionsByDate[formatDate(day, DATE_FORMAT)]
+    balance = transactions
+      ? balance - sumBy(transactions, t => t.amount)
+      : balance
+
+    balances.push({
+      date: formatDate(day, DATE_FORMAT),
+      balance
+    })
+  }
+
+  return balances
+}

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -1,0 +1,31 @@
+import { getBalanceHistory } from './helpers'
+
+describe('getBalanceHistory', () => {
+  it('should return only the current balance if there is no transactions', () => {
+    const account = { id: 'test', balance: 8000 }
+    const transactions = []
+    const history = getBalanceHistory(account, transactions, new Date())
+
+    expect(history).toHaveLength(1)
+    expect(history[0].balance).toBe(8000)
+  })
+
+  it('should return the right balances if there are transactions', () => {
+    const account = { id: 'test', balance: 8000 }
+    const transactions = [
+      { date: new Date(2018, 5, 25), amount: 100 },
+      { date: new Date(2018, 5, 24), amount: 10 },
+      { date: new Date(2018, 5, 23), amount: -300 },
+      { date: new Date(2018, 5, 22), amount: -15 }
+    ]
+
+    const history = getBalanceHistory(
+      account,
+      transactions,
+      new Date(2018, 5, 26)
+    )
+
+    expect(history).toHaveLength(5)
+    expect(history.map(h => h.balance)).toEqual([8000, 7900, 7890, 8190, 8205])
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-date-fns@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-date-fns/-/babel-plugin-date-fns-0.2.1.tgz#17b6e4666a05411857ac04af4318ff5fb72895f2"
+  dependencies:
+    lodash.snakecase "^4.1.1"
+
 babel-plugin-emotion@^9.2.0:
   version "9.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-9.2.0.tgz#43543dd02c7b5cd89d464aeedef864edb754b852"
@@ -7727,6 +7733,10 @@ lodash.reject@^4.4.0:
 lodash.rest@^4.0.0:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/lodash.rest/-/lodash.rest-4.0.5.tgz#954ef75049262038c96d1fc98b28fdaf9f0772aa"
+
+lodash.snakecase@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz#39d714a35357147837aefd64b5dcbb16becd8f8d"
 
 lodash.some@^4.4.0:
   version "4.6.0"


### PR DESCRIPTION
Compute the balance history for each account when the user hits the Balances page.

The result is an object indexed by the account ID. And for each account, an array of objects with the shape:

```
{
  "date": Date,
  "balance": Number
}
```