### PR TITLE
fix(KonnectorAction): Replace konnector option by slug in intent

### DIFF
--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -108,7 +108,7 @@ class Component extends React.Component {
       const intentWindow = await cozy.client.intents.redirect(
         'io.cozy.accounts',
         {
-          konnector: brand.konnectorSlug
+          slug: brand.konnectorSlug
         },
         open
       )


### PR DESCRIPTION
We were using `slug` for one intent and `konnector` for the other. The platformers told us that `slug` is the good one.