### PR TITLE
Balance history chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch:services": "NODE_ENV=services:development npm run commons:services -- --watch",
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
-    "styleguide:deploy": "git-directory-deploy --directory styleguide --branch master --repo docs",
+    "styleguide:deploy": "git-directory-deploy --directory ./docs/build/styleguide --branch master --repo docs",
     "postmerge": "yarnhook",
     "postcheckout": "yarnhook",
     "postrewrite": "yarnhook",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "redux-thunk": "^2.1.0",
     "reselect": "^3.0.1",
     "shebang-loader": "^0.0.1",
+    "sma": "^0.1.0",
     "splashicon-generator": "^0.2.12",
     "stats-webpack-plugin": "^0.6.1",
     "string-replace-webpack-plugin": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "cozy-pouch-link": "^1.0.0-beta.21",
     "cozy-stack-client": "^1.0.0-beta.21",
     "cozy-ui": "^10.4.4",
+    "d3": "^5.5.0",
     "date-fns": "^1.28.2",
     "fastclick": "^1.0.6",
     "hammerjs": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "cozy-client": "^1.0.0-beta.26",
     "cozy-client-js": "0.11.0",
     "cozy-device-helper": "1.2.1",
+    "cozy-flags": "^1.0.2",
     "cozy-konnector-libs": "^3.0.13",
     "cozy-pouch-link": "^1.0.0-beta.21",
     "cozy-stack-client": "^1.0.0-beta.21",

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -1,0 +1,113 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import * as d3 from 'd3'
+
+class LineChart extends Component {
+  componentDidMount() {
+    this.createChart()
+  }
+
+  componentDidUpdate() {
+    this.createChart()
+  }
+
+  empty() {
+    this.root.innerHTML = ''
+  }
+
+  createChart() {
+    this.empty()
+
+    const {
+      data,
+      width,
+      height,
+      margin,
+      lineWidth,
+      lineColor,
+      nbTicks = data.length,
+      tickFormat,
+      tickPadding,
+      xScale,
+      yScale
+    } = this.props
+
+    const innerWidth = width - margin.left - margin.right
+    const innerHeight = height - margin.top - margin.bottom
+
+    const x = xScale().range([0, innerWidth])
+    const y = yScale().range([innerHeight, 0])
+
+    x.domain([d3.min(data, d => d.x), d3.max(data, d => d.x)])
+    y.domain([d3.min(data, d => d.y), d3.max(data, d => d.y)])
+
+    const svg = d3
+      .select(this.root)
+      .append('g')
+      .attr('transform', `translate(${margin.left}, ${margin.top})`)
+
+    const line = d3
+      .line()
+      .x(d => x(d.x))
+      .y(d => y(d.y))
+
+    svg
+      .append('path')
+      .datum(data)
+      .attr('stroke', lineColor)
+      .attr('stroke-width', lineWidth)
+      .attr('fill', 'none')
+      .attr('d', line)
+
+    const xAxisGenerator = d3.axisBottom(x).ticks(nbTicks)
+
+    if (tickPadding !== undefined) {
+      xAxisGenerator.tickPadding(tickPadding)
+    }
+
+    if (tickFormat) {
+      xAxisGenerator.tickFormat(tickFormat)
+    }
+
+    svg
+      .append('g')
+      .attr('transform', `translate(0, ${innerHeight})`)
+      .call(xAxisGenerator)
+  }
+
+  render() {
+    const { width, height } = this.props
+
+    return (
+      <svg ref={node => (this.root = node)} width={width} height={height} />
+    )
+  }
+}
+
+LineChart.propTypes = {
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  margin: PropTypes.shape({
+    top: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number
+  }),
+  lineWidth: PropTypes.number,
+  lineColor: PropTypes.string,
+  nbTicks: PropTypes.number,
+  tickFormat: PropTypes.func,
+  tickPadding: PropTypes.number,
+  xScale: PropTypes.func,
+  yScale: PropTypes.func
+}
+
+LineChart.defaultProps = {
+  margin: { top: 0, bottom: 0, left: 0, right: 0 },
+  lineWidth: 2,
+  lineColor: 'black',
+  xScale: d3.scaleLinear,
+  yScale: d3.scaleLinear
+}
+
+export default LineChart

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -32,7 +32,8 @@ class LineChart extends Component {
       yScale,
       axisColor,
       labelsColor,
-      onUpdate
+      onUpdate,
+      axisMargin
     } = this.props
 
     const innerWidth = width - margin.left - margin.right
@@ -74,7 +75,7 @@ class LineChart extends Component {
 
     const axis = svg
       .append('g')
-      .attr('transform', `translate(0, ${innerHeight})`)
+      .attr('transform', `translate(0, ${innerHeight + axisMargin})`)
       .call(xAxisGenerator)
 
     axis.selectAll('.domain').attr('stroke', axisColor)
@@ -117,7 +118,8 @@ LineChart.propTypes = {
   xScale: PropTypes.func,
   yScale: PropTypes.func,
   axisColor: PropTypes.string,
-  onUpdate: PropTypes.func
+  onUpdate: PropTypes.func,
+  axisMargin: PropTypes.number
 }
 
 LineChart.defaultProps = {
@@ -127,7 +129,8 @@ LineChart.defaultProps = {
   xScale: d3.scaleLinear,
   yScale: d3.scaleLinear,
   axisColor: 'black',
-  labelsColor: 'black'
+  labelsColor: 'black',
+  axisMargin: 0
 }
 
 export default LineChart

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -29,7 +29,9 @@ class LineChart extends Component {
       tickFormat,
       tickPadding,
       xScale,
-      yScale
+      yScale,
+      axisColor,
+      labelsColor
     } = this.props
 
     const innerWidth = width - margin.left - margin.right
@@ -69,10 +71,19 @@ class LineChart extends Component {
       xAxisGenerator.tickFormat(tickFormat)
     }
 
-    svg
+    const axis = svg
       .append('g')
       .attr('transform', `translate(0, ${innerHeight})`)
       .call(xAxisGenerator)
+
+    axis.selectAll('.domain').attr('stroke', axisColor)
+    axis.selectAll('.tick line').attr('stroke', axisColor)
+    axis
+      .selectAll('.tick text')
+      .attr('fill', labelsColor)
+      .attr('font-family', 'Lato, sans-serif')
+      .attr('font-size', '0.75rem')
+      .attr('style', 'text-transform: uppercase')
   }
 
   render() {
@@ -99,7 +110,8 @@ LineChart.propTypes = {
   tickFormat: PropTypes.func,
   tickPadding: PropTypes.number,
   xScale: PropTypes.func,
-  yScale: PropTypes.func
+  yScale: PropTypes.func,
+  axisColor: PropTypes.string
 }
 
 LineChart.defaultProps = {
@@ -107,7 +119,9 @@ LineChart.defaultProps = {
   lineWidth: 2,
   lineColor: 'black',
   xScale: d3.scaleLinear,
-  yScale: d3.scaleLinear
+  yScale: d3.scaleLinear,
+  axisColor: 'black',
+  labelsColor: 'black'
 }
 
 export default LineChart

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -25,7 +25,7 @@ class LineChart extends Component {
       margin,
       lineWidth,
       lineColor,
-      nbTicks = data.length,
+      nbTicks,
       tickFormat,
       tickPadding,
       xScale,
@@ -63,7 +63,11 @@ class LineChart extends Component {
       .attr('fill', 'none')
       .attr('d', line)
 
-    const xAxisGenerator = d3.axisBottom(x).ticks(nbTicks)
+    const xAxisGenerator = d3.axisBottom(x)
+
+    if (nbTicks !== undefined) {
+      xAxisGenerator.ticks(nbTicks)
+    }
 
     if (tickPadding !== undefined) {
       xAxisGenerator.tickPadding(tickPadding)

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -31,7 +31,8 @@ class LineChart extends Component {
       xScale,
       yScale,
       axisColor,
-      labelsColor
+      labelsColor,
+      onUpdate
     } = this.props
 
     const innerWidth = width - margin.left - margin.right
@@ -84,6 +85,10 @@ class LineChart extends Component {
       .attr('font-family', 'Lato, sans-serif')
       .attr('font-size', '0.75rem')
       .attr('style', 'text-transform: uppercase')
+
+    if (onUpdate && typeof onUpdate === 'function') {
+      this.props.onUpdate()
+    }
   }
 
   render() {
@@ -111,7 +116,8 @@ LineChart.propTypes = {
   tickPadding: PropTypes.number,
   xScale: PropTypes.func,
   yScale: PropTypes.func,
-  axisColor: PropTypes.string
+  axisColor: PropTypes.string,
+  onUpdate: PropTypes.func
 }
 
 LineChart.defaultProps = {

--- a/src/components/Chart/LineChart.md
+++ b/src/components/Chart/LineChart.md
@@ -1,0 +1,42 @@
+```jsx
+<LineChart
+  width={300}
+  height={150}
+  data={[
+    { x: 0, y: 0 },
+    { x: 1, y: 2 },
+    { x: 2, y: 4 },
+    { x: 3, y: 6 }
+  ]}
+  margin={{
+    top: 0,
+    bottom: 20,
+    left: 10,
+    right: 10
+  }}
+/>
+```
+
+```jsx
+const d3 = require('d3');
+
+<LineChart
+  width={300}
+  height={150}
+  data={[
+    { x: new Date(2018, 7, 3), y: 0 },
+    { x: new Date(2018, 7, 2), y: 2 },
+    { x: new Date(2018, 7, 1), y: 4 },
+    { x: new Date(2018, 6, 31), y: 6 }
+  ]}
+  margin={{
+    top: 0,
+    bottom: 20,
+    left: 10,
+    right: 10
+  }}
+  nbTicks={2}
+  tickFormat={d3.timeFormat('%b')}
+  xScale={d3.scaleTime}
+/>
+```

--- a/src/components/Figure/Figure.jsx
+++ b/src/components/Figure/Figure.jsx
@@ -28,6 +28,7 @@ const Figure = props => {
     className,
     total,
     totalClassName,
+    currencyClassName,
     size
   } = props
 
@@ -64,9 +65,13 @@ const Figure = props => {
       </span>
       {currency && (
         <span
-          className={cx(styles['Figure-currency'], {
-            [styles['Figure__currency--withSpacing']]: withCurrencySpacing
-          })}
+          className={cx(
+            styles['Figure-currency'],
+            {
+              [styles['Figure__currency--withSpacing']]: withCurrencySpacing
+            },
+            currencyClassName
+          )}
         >
           {currencySigns[currency] || currency}
         </span>
@@ -82,6 +87,7 @@ Figure.propTypes = {
   totalClassName: Types.string,
   /** Currency to show */
   currency: Types.string,
+  currencyClassName: Types.string,
   /** Colors positive numbers in green */
   coloredPositive: Types.bool,
   /** Colors negative numbers in red */

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -11,9 +11,6 @@
 .Balance__section-title
     margin-top 2rem
 
-.Balance__kpi
-    margin 0 0 1em 0
-
 .Balance__row
     cursor pointer
     composes mobile-row from '../../components/Table/styles.styl'
@@ -79,6 +76,15 @@
             &.alert
                 color pomegranate
 
+.Balance__history
+    margin-left -2rem
+    margin-right -2rem
+
+    +small-screen()
+        margin-left -1rem
+        margin-right -1rem
+        margin-top -1rem
+
 +small-screen()
     td.Balance__account_name
         maxed-flex-basis 60%
@@ -94,4 +100,3 @@
 
     .Balance__bank
         maxed-flex-basis 60%
-

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -58,7 +58,10 @@ class History extends Component {
         <div className={styles.History__subtitle}>
           {t('BalanceHistory.subtitle')}
         </div>
-        <div className={styles.History__chartContainer}>
+        <div
+          className={styles.History__chartContainer}
+          ref={node => (this.chartContainer = node)}
+        >
           <LineChart
             width={nbTicks * this.INTERVAL_BETWEEN_TICKS}
             height={150}
@@ -75,6 +78,9 @@ class History extends Component {
             lineColor="white"
             axisColor="white"
             labelsColor="#a2c4f9"
+            onUpdate={() =>
+              this.chartContainer.scrollTo(this.chartContainer.scrollWidth, 0)
+            }
           />
         </div>
       </div>

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -81,6 +81,7 @@ class History extends Component {
             onUpdate={() =>
               this.chartContainer.scrollTo(this.chartContainer.scrollWidth, 0)
             }
+            axisMargin={10}
           />
         </div>
       </div>

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -1,0 +1,32 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import cx from 'classnames'
+import { translate } from 'cozy-ui/react'
+import { Figure } from 'components/Figure'
+import styles from './History.styl'
+
+class History extends Component {
+  render() {
+    const { className, currentBalance, t } = this.props
+    return (
+      <div className={cx(styles.History, className)}>
+        <Figure
+          className={styles.History__currentBalance}
+          currencyClassName={styles.History__currentBalanceCurrency}
+          total={currentBalance}
+          currency="€"
+        />
+        <div className={styles.History__subtitle}>
+          {t('BalanceHistory.subtitle')}
+        </div>
+      </div>
+    )
+  }
+}
+
+History.propTypes = {
+  className: PropTypes.string,
+  currentBalance: PropTypes.number.isRequired
+}
+
+export default translate()(History)

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -6,6 +6,7 @@ import { translate } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
 import { groupBy, sumBy, uniq } from 'lodash'
 import { format as formatDate, parse as parseDate } from 'date-fns'
+import sma from 'sma'
 import LineChart from 'components/Chart/LineChart'
 import { getBalanceHistories } from './helpers'
 import styles from './History.styl'
@@ -40,9 +41,22 @@ class History extends Component {
     return balanceHistory
   }
 
+  getChartData() {
+    const history = this.getBalanceHistory()
+    const WINDOW_SIZE = 15
+
+    const balancesSma = sma(history.map(h => h.y), WINDOW_SIZE, n => n)
+    const data = balancesSma.map((balance, i) => ({
+      ...history[i],
+      y: balance
+    }))
+
+    return data
+  }
+
   render() {
     const { className, t } = this.props
-    const chartData = this.getBalanceHistory()
+    const chartData = this.getChartData()
     const nbTicks = uniq(
       Object.keys(groupBy(chartData, i => formatDate(i.x, 'YYYY-MM')))
     ).length

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -1,23 +1,77 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+import * as d3 from 'd3'
 import { translate } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
+import { groupBy, sumBy, uniq } from 'lodash'
+import { format as formatDate, parse as parseDate } from 'date-fns'
+import LineChart from 'components/Chart/LineChart'
+import { getBalanceHistories } from './helpers'
 import styles from './History.styl'
 
 class History extends Component {
+  getCurrentBalance() {
+    return sumBy(this.props.accounts, a => a.balance)
+  }
+
+  getBalanceHistory() {
+    const { accounts, transactions } = this.props
+    const balanceHistories = getBalanceHistories(accounts, transactions)
+    const balanceHistory = Object.entries(balanceHistories.all)
+      .sort((a, b) => {
+        if (a[0] < b[0]) {
+          return 1
+        }
+
+        if (a[0] > b[0]) {
+          return -1
+        }
+
+        return 0
+      })
+      .map(([date, balance]) => ({
+        x: parseDate(date),
+        y: balance
+      }))
+
+    return balanceHistory
+  }
+
   render() {
-    const { className, currentBalance, t } = this.props
+    const { className, t } = this.props
+    const chartData = this.getBalanceHistory()
+    const nbTicks = uniq(
+      Object.keys(groupBy(chartData, i => formatDate(i.x, 'YYYY-MM')))
+    ).length
+
     return (
       <div className={cx(styles.History, className)}>
         <Figure
           className={styles.History__currentBalance}
           currencyClassName={styles.History__currentBalanceCurrency}
-          total={currentBalance}
+          total={this.getCurrentBalance()}
           currency="€"
         />
         <div className={styles.History__subtitle}>
           {t('BalanceHistory.subtitle')}
+        </div>
+        <div>
+          <LineChart
+            width={800}
+            height={150}
+            data={chartData}
+            margin={{
+              top: 0,
+              bottom: 20,
+              left: 10,
+              right: 10
+            }}
+            nbTicks={nbTicks}
+            tickFormat={d3.timeFormat('%b')}
+            xScale={d3.scaleTime}
+            lineColor="white"
+          />
         </div>
       </div>
     )
@@ -25,8 +79,9 @@ class History extends Component {
 }
 
 History.propTypes = {
+  accounts: PropTypes.array.isRequired,
   className: PropTypes.string,
-  currentBalance: PropTypes.number.isRequired
+  transactions: PropTypes.array.isRequired
 }
 
 export default translate()(History)

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -11,6 +11,8 @@ import { getBalanceHistories } from './helpers'
 import styles from './History.styl'
 
 class History extends Component {
+  INTERVAL_BETWEEN_TICKS = 57
+
   getCurrentBalance() {
     return sumBy(this.props.accounts, a => a.balance)
   }
@@ -56,9 +58,9 @@ class History extends Component {
         <div className={styles.History__subtitle}>
           {t('BalanceHistory.subtitle')}
         </div>
-        <div>
+        <div className={styles.History__chartContainer}>
           <LineChart
-            width={800}
+            width={nbTicks * this.INTERVAL_BETWEEN_TICKS}
             height={150}
             data={chartData}
             margin={{

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import * as d3 from 'd3'
 import { translate } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
-import { groupBy, sumBy, uniq } from 'lodash'
+import { groupBy, sortBy, sumBy, uniq } from 'lodash'
 import { format as formatDate, parse as parseDate } from 'date-fns'
 import sma from 'sma'
 import LineChart from 'components/Chart/LineChart'
@@ -18,25 +18,21 @@ class History extends Component {
     return sumBy(this.props.accounts, a => a.balance)
   }
 
-  getBalanceHistory() {
-    const { accounts, transactions } = this.props
-    const balanceHistories = getBalanceHistories(accounts, transactions)
-    const balanceHistory = Object.entries(balanceHistories.all)
-      .sort((a, b) => {
-        if (a[0] < b[0]) {
-          return 1
-        }
-
-        if (a[0] > b[0]) {
-          return -1
-        }
-
-        return 0
-      })
+  sortBalanceHistoryByDate(history) {
+    const balanceHistory = sortBy(Object.entries(history), ([date]) => date)
+      .reverse()
       .map(([date, balance]) => ({
         x: parseDate(date),
         y: balance
       }))
+
+    return balanceHistory
+  }
+
+  getBalanceHistory() {
+    const { accounts, transactions } = this.props
+    const balanceHistories = getBalanceHistories(accounts, transactions)
+    const balanceHistory = this.sortBalanceHistoryByDate(balanceHistories.all)
 
     return balanceHistory
   }

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -62,8 +62,8 @@ class History extends Component {
             height={150}
             data={chartData}
             margin={{
-              top: 0,
-              bottom: 20,
+              top: 20,
+              bottom: 40,
               left: 10,
               right: 10
             }}
@@ -71,6 +71,8 @@ class History extends Component {
             tickFormat={d3.timeFormat('%b')}
             xScale={d3.scaleTime}
             lineColor="white"
+            axisColor="white"
+            labelsColor="#a2c4f9"
           />
         </div>
       </div>

--- a/src/ducks/balance/History.md
+++ b/src/ducks/balance/History.md
@@ -1,3 +1,3 @@
 ```jsx
-<History currentBalance={8655.58}/>
+<History currentBalance={8655.58} />
 ```

--- a/src/ducks/balance/History.md
+++ b/src/ducks/balance/History.md
@@ -1,0 +1,3 @@
+```jsx
+<History currentBalance={8655.58}/>
+```

--- a/src/ducks/balance/History.md
+++ b/src/ducks/balance/History.md
@@ -1,3 +1,8 @@
 ```jsx
-<History currentBalance={8655.58} />
+const data = require('./history_data.json');
+
+<History
+  accounts={data['io.cozy.bank.accounts']}
+  transactions={data['io.cozy.bank.operations']}
+/>
 ```

--- a/src/ducks/balance/History.styl
+++ b/src/ducks/balance/History.styl
@@ -18,3 +18,6 @@
     font-size 0.85rem
     font-weight bold
     color #a2c4f9
+
+.History__chartContainer
+    overflow-y auto

--- a/src/ducks/balance/History.styl
+++ b/src/ducks/balance/History.styl
@@ -1,0 +1,20 @@
+.History
+    background-color dodgerBlue
+    padding-top: 1.5rem
+    padding-bottom: 1.5rem
+    text-align center
+    color white
+
+.History__currentBalance
+    text-align center
+    font-size 1.5rem
+
+.History__currentBalanceCurrency
+    color inherit
+
+.History__subtitle
+    margin-top 0.25rem
+    text-transform uppercase
+    font-size 0.85rem
+    font-weight bold
+    color #a2c4f9

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -14,7 +14,7 @@ export const getBalanceHistories = (accounts, transactions) => {
   }
 
   const balances = accounts.reduce((balances, account) => {
-    balances[account.id] = getBalanceHistory(
+    balances[account._id] = getBalanceHistory(
       account,
       getTransactionsForAccount(account, transactions),
       startOfToday()
@@ -29,7 +29,7 @@ export const getBalanceHistories = (accounts, transactions) => {
 }
 
 const getTransactionsForAccount = (account, transactions) =>
-  transactions.filter(t => t.account === account.id)
+  transactions.filter(t => t.account === account._id)
 
 export const getBalanceHistory = (account, transactions, from) => {
   const DATE_FORMAT = 'YYYY-MM-DD'

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -1,31 +1,41 @@
 import { getBalanceHistory } from './helpers'
+import { parse as parseDate } from 'date-fns'
 
 describe('getBalanceHistory', () => {
   it('should return only the current balance if there is no transactions', () => {
     const account = { id: 'test', balance: 8000 }
     const transactions = []
-    const history = getBalanceHistory(account, transactions, new Date())
+    const date = '2018-08-01'
+    const from = parseDate(date)
+    const history = getBalanceHistory(account, transactions, from)
 
-    expect(history).toHaveLength(1)
-    expect(history[0].balance).toBe(8000)
+    expect(Object.keys(history)).toEqual([date])
+    expect(history[date]).toBe(8000)
   })
 
   it('should return the right balances if there are transactions', () => {
     const account = { id: 'test', balance: 8000 }
+    const dates = [
+      '2018-06-26',
+      '2018-06-25',
+      '2018-06-24',
+      '2018-06-23',
+      '2018-06-22'
+    ]
     const transactions = [
-      { date: new Date(2018, 5, 25), amount: 100 },
-      { date: new Date(2018, 5, 24), amount: 10 },
-      { date: new Date(2018, 5, 23), amount: -300 },
-      { date: new Date(2018, 5, 22), amount: -15 }
+      { date: parseDate(dates[1]), amount: 100 },
+      { date: parseDate(dates[2]), amount: 10 },
+      { date: parseDate(dates[3]), amount: -300 },
+      { date: parseDate(dates[4]), amount: -15 }
     ]
 
     const history = getBalanceHistory(
       account,
       transactions,
-      new Date(2018, 5, 26)
+      parseDate(dates[0])
     )
 
-    expect(history).toHaveLength(5)
-    expect(history.map(h => h.balance)).toEqual([8000, 7900, 7890, 8190, 8205])
+    expect(Object.keys(history)).toEqual(dates)
+    expect(Object.values(history)).toEqual([8000, 7900, 7890, 8190, 8205])
   })
 })

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -3,7 +3,7 @@ import { parse as parseDate } from 'date-fns'
 
 describe('getBalanceHistory', () => {
   it('should return only the current balance if there is no transactions', () => {
-    const account = { id: 'test', balance: 8000 }
+    const account = { _id: 'test', balance: 8000 }
     const transactions = []
     const date = '2018-08-01'
     const from = parseDate(date)
@@ -14,7 +14,7 @@ describe('getBalanceHistory', () => {
   })
 
   it('should return the right balances if there are transactions', () => {
-    const account = { id: 'test', balance: 8000 }
+    const account = { _id: 'test', balance: 8000 }
     const dates = [
       '2018-06-26',
       '2018-06-25',

--- a/src/ducks/balance/history_data.json
+++ b/src/ducks/balance/history_data.json
@@ -1,0 +1,7857 @@
+{
+  "io.cozy.bank.operations": [
+    {
+      "_id": "6c294f99a71c00283c8036e62cefd21b",
+      "account": "account3",
+      "amount": -41.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.064Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cefdb97",
+      "account": "account3",
+      "amount": -25,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-08-01T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.032Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cefea77",
+      "account": "account3",
+      "amount": -76.07,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.039Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62ceff84a",
+      "account": "account3",
+      "amount": 2871.92,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.043Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf006aa",
+      "account": "account3",
+      "amount": -42.75,
+      "automaticCategoryId": "400250",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.044Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf00732",
+      "account": "account3",
+      "amount": -10,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.061Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf00f01",
+      "account": "account3",
+      "amount": -18.93,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.034Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0102f",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-07-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.056Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf01116",
+      "account": "account3",
+      "amount": 500,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-20T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.063Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf01665",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.061Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf01f25",
+      "account": "account3",
+      "amount": -36.36,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.050Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf023ac",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.051Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0286f",
+      "account": "account3",
+      "amount": 37.46,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.062Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf034b8",
+      "account": "account3",
+      "amount": -35,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.060Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf03e71",
+      "account": "account3",
+      "amount": -4.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.072Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf04293",
+      "account": "account3",
+      "amount": -30,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-07-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.071Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0437d",
+      "account": "account3",
+      "amount": -39.98,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.070Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf04d33",
+      "account": "account3",
+      "amount": -5.3,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.067Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf05867",
+      "account": "account3",
+      "amount": -27.27,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.069Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf05f77",
+      "account": "account3",
+      "amount": 186,
+      "automaticCategoryId": "400500",
+      "currency": "EUR",
+      "date": "2018-07-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.072Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0683b",
+      "account": "account3",
+      "amount": -19.6,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-07-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.070Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf06bee",
+      "account": "account3",
+      "amount": -14.7,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.074Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf075ae",
+      "account": "account3",
+      "amount": -14.57,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.069Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf07f18",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-10T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.073Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf086ec",
+      "account": "account3",
+      "amount": -96.92,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.073Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf08edd",
+      "account": "account3",
+      "amount": -644,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.068Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf08ffb",
+      "account": "account3",
+      "amount": -90.34,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.069Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf09892",
+      "account": "account3",
+      "amount": -38.98,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-10T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.073Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf09fc0",
+      "account": "account3",
+      "amount": -9.12,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.075Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0a174",
+      "account": "account3",
+      "amount": -9.85,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.075Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0a51f",
+      "account": "account3",
+      "amount": -21.97,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-07-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.076Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0ae34",
+      "account": "account3",
+      "amount": -30,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-07-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.076Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0afef",
+      "account": "account3",
+      "amount": -3.62,
+      "automaticCategoryId": "600140",
+      "currency": "EUR",
+      "date": "2018-07-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.077Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0b92e",
+      "account": "account3",
+      "amount": -26,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-06-29T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.081Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0c66f",
+      "account": "account1",
+      "amount": 900,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.081Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0c9ea",
+      "account": "account3",
+      "amount": -17.88,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.076Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0cefb",
+      "account": "account3",
+      "amount": -21.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.081Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0d567",
+      "account": "account3",
+      "amount": -3.6,
+      "automaticCategoryId": "400720",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.076Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0de99",
+      "account": "account3",
+      "amount": 2721.4,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-06-29T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.082Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0ea60",
+      "account": "account3",
+      "amount": -28,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-06-27T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.083Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf0f9d2",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.079Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf10482",
+      "account": "account3",
+      "amount": 75.2,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-07-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.077Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf10993",
+      "account": "account3",
+      "amount": -499,
+      "automaticCategoryId": "400740",
+      "currency": "EUR",
+      "date": "2018-06-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.082Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf11027",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-06-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.083Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf11a83",
+      "account": "account3",
+      "amount": -12.98,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-06-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.084Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf12007",
+      "account": "account3",
+      "amount": -11.78,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.086Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf121b4",
+      "account": "account3",
+      "amount": -32.42,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.086Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf12640",
+      "account": "account3",
+      "amount": -117,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.085Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf13440",
+      "account": "account3",
+      "amount": -94.94,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.086Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf13563",
+      "account": "account3",
+      "amount": 665.63,
+      "automaticCategoryId": "200110",
+      "currency": "EUR",
+      "date": "2018-06-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.084Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1409a",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-06-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.088Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf14173",
+      "account": "account3",
+      "amount": -20.7,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-15T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.090Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf150d8",
+      "account": "account3",
+      "amount": -51.97,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-06-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.089Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf151ef",
+      "account": "account3",
+      "amount": 81,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-06-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.091Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf15fbf",
+      "account": "account3",
+      "amount": -18,
+      "automaticCategoryId": "200",
+      "currency": "EUR",
+      "date": "2018-06-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.091Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "check",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf162f2",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.088Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf16a21",
+      "account": "account3",
+      "amount": -25.4,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-06-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.091Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf16b92",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.092Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf17638",
+      "account": "account3",
+      "amount": -40.2,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-06-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.089Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf17b68",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-06-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.091Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf17fa6",
+      "account": "account3",
+      "amount": -40,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-06-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.092Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1858e",
+      "account": "account3",
+      "amount": -34.81,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.093Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf18f61",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-06-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.093Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf19ac4",
+      "account": "account3",
+      "amount": -8.65,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-06-08T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.093Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf19e78",
+      "account": "account3",
+      "amount": -8.43,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.096Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf19fb5",
+      "account": "account3",
+      "amount": -48.5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.096Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1aa92",
+      "account": "account3",
+      "amount": -30,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-06-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.095Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1ac09",
+      "account": "account1",
+      "amount": 1500,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-06-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.095Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1ba4c",
+      "account": "account3",
+      "amount": -83.18,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-06-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.094Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1c702",
+      "account": "account3",
+      "amount": -1500,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-06-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.094Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1d230",
+      "account": "account3",
+      "amount": -25.24,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.094Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1ddb6",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.095Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1e796",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.098Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1f4e2",
+      "account": "account3",
+      "amount": -17.8,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-05-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.101Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1fc21",
+      "account": "account3",
+      "amount": 2768.6,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-06-01T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.098Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf1fd67",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.100Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf203db",
+      "account": "account3",
+      "amount": -4.1,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.097Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf21031",
+      "account": "account3",
+      "amount": -6.5,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.101Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf21825",
+      "account": "account3",
+      "amount": -17.9,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-01T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.098Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf21855",
+      "account": "account3",
+      "amount": -36.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.100Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf22739",
+      "account": "account3",
+      "amount": -7.56,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.100Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf22ee5",
+      "account": "account3",
+      "amount": -49,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.099Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf23de5",
+      "account": "account3",
+      "amount": -21.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.098Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2411e",
+      "account": "account3",
+      "amount": 76,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-05-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.102Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf24c59",
+      "account": "account3",
+      "amount": -55,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-05-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.102Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf254e3",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-05-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.102Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf25e2e",
+      "account": "account3",
+      "amount": -54.5,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.104Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf265d3",
+      "account": "account3",
+      "amount": -9.75,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.104Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf27035",
+      "account": "account3",
+      "amount": -8.72,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.105Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2774d",
+      "account": "account3",
+      "amount": -10.3,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.105Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf277a5",
+      "account": "account3",
+      "amount": 70.85,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-15T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.109Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf27c88",
+      "account": "account3",
+      "amount": -14.9,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-05-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.107Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf281c7",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-05-15T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.109Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2879b",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-05-14T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.110Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf295a8",
+      "account": "account3",
+      "amount": -23.33,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.108Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf29b87",
+      "account": "account3",
+      "amount": -5.47,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.109Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2a289",
+      "account": "account1",
+      "amount": 1000,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-05-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.109Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2a47a",
+      "account": "account3",
+      "amount": -217.2,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-05-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.106Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2a740",
+      "account": "account3",
+      "amount": -7.5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.105Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2b61f",
+      "account": "account3",
+      "amount": -1000,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-05-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.108Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2c575",
+      "account": "account3",
+      "amount": -12.8,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-14T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.111Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2c6b6",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.111Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2d43d",
+      "account": "account3",
+      "amount": -29.99,
+      "automaticCategoryId": "400740",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.114Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2d896",
+      "account": "account3",
+      "amount": -10,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.114Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2e5b7",
+      "account": "account3",
+      "amount": -2.61,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.112Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2ea0b",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.111Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf2f648",
+      "account": "account3",
+      "amount": -5.95,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.112Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf300e0",
+      "account": "account3",
+      "amount": -37,
+      "automaticCategoryId": "400720",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.113Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3109e",
+      "account": "account3",
+      "amount": -9.99,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.114Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf31912",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.117Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf31968",
+      "account": "account3",
+      "amount": -15,
+      "automaticCategoryId": "400112",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.118Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf31dac",
+      "account": "account3",
+      "amount": -350,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.117Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf31ec9",
+      "account": "account3",
+      "amount": -41.02,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.115Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf321c2",
+      "account": "account3",
+      "amount": -45,
+      "automaticCategoryId": "200",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.115Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "check",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf33191",
+      "account": "account3",
+      "amount": -13.5,
+      "automaticCategoryId": "400820",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.118Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf339b2",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.119Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3481b",
+      "account": "account3",
+      "amount": -2.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.114Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf34ac8",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.117Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf35400",
+      "account": "account3",
+      "amount": -59.9,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.119Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf36000",
+      "account": "account3",
+      "amount": -3.4,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.121Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf36166",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.121Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf36a0d",
+      "account": "account3",
+      "amount": -27.86,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.123Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf36c65",
+      "account": "account3",
+      "amount": -10,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.123Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf37032",
+      "account": "account3",
+      "amount": -41.4,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.122Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf374cc",
+      "account": "account3",
+      "amount": -18.1,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.120Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf38113",
+      "account": "account3",
+      "amount": -8,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.120Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf38a40",
+      "account": "account3",
+      "amount": -36.87,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.128Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf39341",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-04-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.124Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3959a",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-04-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.124Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf39af6",
+      "account": "account3",
+      "amount": -16.3,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-04-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.124Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf39b72",
+      "account": "account3",
+      "amount": -40,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-04-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.125Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3a7c6",
+      "account": "account3",
+      "amount": -38.43,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.127Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3a7fe",
+      "account": "account3",
+      "amount": -9.75,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-04-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.126Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3b025",
+      "account": "account3",
+      "amount": -7.24,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.126Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3b6d2",
+      "account": "account3",
+      "amount": -21,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.129Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3c3e8",
+      "account": "account3",
+      "amount": -41.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-04-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.131Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3cdfd",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.131Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3d1cb",
+      "account": "account3",
+      "amount": -9.32,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.131Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3d97c",
+      "account": "account3",
+      "amount": -32.32,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.136Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3e359",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-04-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.133Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3eb05",
+      "account": "account3",
+      "amount": -6,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-04-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.141Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3f491",
+      "account": "account3",
+      "amount": -37.31,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.134Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3f89e",
+      "account": "account3",
+      "amount": -38.74,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.140Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf3feab",
+      "account": "account3",
+      "amount": -38.83,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.140Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf408d9",
+      "account": "account3",
+      "amount": -8.9,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-04-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.141Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf40ba8",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-04-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.132Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf41a37",
+      "account": "account3",
+      "amount": -16,
+      "automaticCategoryId": "400820",
+      "currency": "EUR",
+      "date": "2018-04-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.134Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf41d7d",
+      "account": "account3",
+      "amount": -11.66,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.142Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf420b4",
+      "account": "account3",
+      "amount": -8.9,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-04-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.142Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf42929",
+      "account": "account3",
+      "amount": -2.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-04-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.142Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf42f32",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-03-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.150Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf43ee4",
+      "account": "account3",
+      "amount": -31.57,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.147Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4463e",
+      "account": "account3",
+      "amount": -193,
+      "automaticCategoryId": "200",
+      "currency": "EUR",
+      "date": "2018-03-27T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.148Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "check",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4504d",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.148Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf45e4b",
+      "account": "account3",
+      "amount": -39.4,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-03-29T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.147Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4628a",
+      "account": "account3",
+      "amount": -196,
+      "automaticCategoryId": "200",
+      "currency": "EUR",
+      "date": "2018-03-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.149Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "check",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf465b4",
+      "account": "account3",
+      "amount": -6.25,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.146Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf46e76",
+      "account": "account3",
+      "amount": -60.99,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.149Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf46ff3",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-03-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.150Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf47ca1",
+      "account": "account3",
+      "amount": -10,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-03-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.146Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf47e7d",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-03-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.148Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf48c77",
+      "account": "account3",
+      "amount": -13.5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-22T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.149Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf490c0",
+      "account": "account1",
+      "amount": -100,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.146Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf49ace",
+      "account": "account3",
+      "amount": -14.55,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-03-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.146Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4a21e",
+      "account": "account3",
+      "amount": -58.73,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.144Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4a672",
+      "account": "account3",
+      "amount": -41.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-03-20T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.150Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4aabe",
+      "account": "account3",
+      "amount": -5.8,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.157Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4b0be",
+      "account": "account3",
+      "amount": -6.3,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.152Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4ba2f",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-03-15T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.153Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4bcec",
+      "account": "account3",
+      "amount": -44.89,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-13T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.154Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4cafb",
+      "account": "account3",
+      "amount": -4.45,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.152Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4d0d3",
+      "account": "account3",
+      "amount": -40.76,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.151Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4d6ad",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-03-15T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.153Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4e097",
+      "account": "account3",
+      "amount": 20,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.151Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4ead3",
+      "account": "account3",
+      "amount": -38.94,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-03-13T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.154Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4f58b",
+      "account": "account3",
+      "amount": -17,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.155Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf4ff4b",
+      "account": "account3",
+      "amount": -43.3,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.151Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf504fa",
+      "account": "account3",
+      "amount": -20.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-14T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.154Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf507ef",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.155Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf50fd1",
+      "account": "account3",
+      "amount": -4.79,
+      "automaticCategoryId": "600140",
+      "currency": "EUR",
+      "date": "2018-03-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.158Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf51545",
+      "account": "account3",
+      "amount": -121,
+      "automaticCategoryId": "200",
+      "currency": "EUR",
+      "date": "2018-03-08T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.158Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "check",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5175b",
+      "account": "account3",
+      "amount": -11.34,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-08T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.158Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf521db",
+      "account": "account3",
+      "amount": -5.71,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.161Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5267d",
+      "account": "account3",
+      "amount": -28.63,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.161Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf52b8e",
+      "account": "account3",
+      "amount": -8.1,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.161Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf53a19",
+      "account": "account3",
+      "amount": 2623.64,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-03-01T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.162Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf53d7c",
+      "account": "account3",
+      "amount": -24.84,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-08T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.158Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf54845",
+      "account": "account3",
+      "amount": -5.32,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.161Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf54ef2",
+      "account": "account3",
+      "amount": -48.91,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.164Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf55933",
+      "account": "account3",
+      "amount": 100,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-28T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.162Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf560ef",
+      "account": "account1",
+      "amount": -800,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-27T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.163Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf56f13",
+      "account": "account3",
+      "amount": -81.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-02T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.162Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf574d0",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-02-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.165Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf57e7b",
+      "account": "account3",
+      "amount": -7.95,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-02-22T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.165Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf581e5",
+      "account": "account3",
+      "amount": -10,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.159Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5891b",
+      "account": "account3",
+      "amount": -380,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.164Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf59392",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-03-01T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.162Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf59a27",
+      "account": "account1",
+      "amount": -100,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-28T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.163Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5a6d1",
+      "account": "account3",
+      "amount": -41.55,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.166Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5b4ba",
+      "account": "account3",
+      "amount": -25.9,
+      "automaticCategoryId": "400740",
+      "currency": "EUR",
+      "date": "2018-02-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.169Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5bf0b",
+      "account": "account3",
+      "amount": -4.37,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.167Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5c66d",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.167Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5d5e8",
+      "account": "account3",
+      "amount": -10.89,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-07T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.170Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5e556",
+      "account": "account3",
+      "amount": -0.8,
+      "automaticCategoryId": "400310",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.167Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5ea59",
+      "account": "account3",
+      "amount": -5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.170Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5f04e",
+      "account": "account3",
+      "amount": -11.34,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.167Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5f678",
+      "account": "account3",
+      "amount": -9.66,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.178Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf5fa9d",
+      "account": "account1",
+      "amount": 1822,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.179Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf604cc",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-02-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.169Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf60632",
+      "account": "account3",
+      "amount": -21.07,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-08T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.170Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf60c2a",
+      "account": "account3",
+      "amount": -2.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.177Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf614c2",
+      "account": "account3",
+      "amount": -0.15,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-02-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.171Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf617ce",
+      "account": "account3",
+      "amount": -16.85,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.171Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf61b0a",
+      "account": "account2",
+      "amount": 0.12,
+      "automaticCategoryId": "200130",
+      "currency": "EUR",
+      "date": "2018-01-03T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.180Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf62a90",
+      "account": "account1",
+      "amount": -500,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-12-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.180Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf6330e",
+      "account": "account1",
+      "amount": -600,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-11-20T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.185Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf6364a",
+      "account": "account1",
+      "amount": 1173.32,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-12-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.180Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "6c294f99a71c00283c8036e62cf64061",
+      "account": "account1",
+      "amount": -150,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-11-02T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.185Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b556f849",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.042Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b556ffb5",
+      "account": "account3",
+      "amount": -28.48,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.051Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5570c72",
+      "account": "account3",
+      "amount": -52.2,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.049Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5571b35",
+      "account": "account3",
+      "amount": -4.1,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.064Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55722a4",
+      "account": "account3",
+      "amount": -58,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.056Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5572e1e",
+      "account": "account1",
+      "amount": 1000,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.040Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557360d",
+      "account": "account3",
+      "amount": -250,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-08-01T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.029Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55741b5",
+      "account": "account3",
+      "amount": -37.7,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.062Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55746fc",
+      "account": "account3",
+      "amount": 7.5,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-07-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.036Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5574d77",
+      "account": "account3",
+      "amount": -105,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.064Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5574ff0",
+      "account": "account1",
+      "amount": -500,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-20T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.063Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557501f",
+      "account": "account3",
+      "amount": -5.63,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.062Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5575391",
+      "account": "account3",
+      "amount": -1000,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-31T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.033Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5576025",
+      "account": "account3",
+      "amount": -37,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.064Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5576e7b",
+      "account": "account3",
+      "amount": -29,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-07-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.061Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5577374",
+      "account": "account3",
+      "amount": -36.62,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.050Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5577be3",
+      "account": "account3",
+      "amount": -13.47,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.075Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5577fa9",
+      "account": "account3",
+      "amount": -81.98,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.074Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5578c48",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-07-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.071Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5578e20",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.066Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55790c1",
+      "account": "account3",
+      "amount": -15.9,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.075Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55796d4",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.068Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5579d02",
+      "account": "account3",
+      "amount": -45,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.071Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557a86b",
+      "account": "account3",
+      "amount": -4.5,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.067Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557adb7",
+      "account": "account3",
+      "amount": -20.4,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-07-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.071Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557bb74",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-07-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.070Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557c670",
+      "account": "account3",
+      "amount": 600,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.068Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557cb9d",
+      "account": "account3",
+      "amount": -4.8,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.072Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557cfbf",
+      "account": "account3",
+      "amount": -13.6,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-07-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.073Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557cfc0",
+      "account": "account3",
+      "amount": -41.2,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-07-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.074Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557d189",
+      "account": "account3",
+      "amount": -2,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-07-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.067Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557e104",
+      "account": "account1",
+      "amount": -600,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.069Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557eadc",
+      "account": "account3",
+      "amount": -300,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.080Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557ef39",
+      "account": "account3",
+      "amount": -92,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-07-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.079Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557fb01",
+      "account": "account3",
+      "amount": -2.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-07-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.078Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b557fe37",
+      "account": "account3",
+      "amount": -27.2,
+      "automaticCategoryId": "400820",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.080Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55804c6",
+      "account": "account3",
+      "amount": -6.99,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-07-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.077Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55807a8",
+      "account": "account3",
+      "amount": -94.99,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.078Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5580bab",
+      "account": "account3",
+      "amount": -2.8,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-07-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.078Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5581690",
+      "account": "account3",
+      "amount": -3.59,
+      "automaticCategoryId": "600140",
+      "currency": "EUR",
+      "date": "2018-07-05T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.078Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5581770",
+      "account": "account3",
+      "amount": -15.8,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-06-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.083Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5581bb7",
+      "account": "account3",
+      "amount": -900,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.080Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5582abf",
+      "account": "account3",
+      "amount": -19.8,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.080Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558312f",
+      "account": "account3",
+      "amount": -9.75,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-07-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.081Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5583dfc",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-07-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.079Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55847c2",
+      "account": "account3",
+      "amount": -8.9,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-06-29T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.082Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5584f5d",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-06-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.083Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5585e54",
+      "account": "account3",
+      "amount": -11.28,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-06-21T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.087Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558671d",
+      "account": "account3",
+      "amount": -7.57,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-26T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.084Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558731c",
+      "account": "account3",
+      "amount": 300,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.085Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "deposit",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5587f55",
+      "account": "account3",
+      "amount": -11.73,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.086Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5588b17",
+      "account": "account3",
+      "amount": -7,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.085Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5589308",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-06-21T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.087Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558983f",
+      "account": "account3",
+      "amount": -41.92,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.085Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5589ed1",
+      "account": "account3",
+      "amount": -27.97,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.087Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558a8fe",
+      "account": "account3",
+      "amount": -3.29,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.088Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558b50d",
+      "account": "account3",
+      "amount": -9.25,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-06-14T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.090Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558b5b6",
+      "account": "account3",
+      "amount": -41.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-06-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.088Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558c35e",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-06-15T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.089Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558d22e",
+      "account": "account3",
+      "amount": -45,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.089Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558dd94",
+      "account": "account3",
+      "amount": -24,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-13T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.090Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558de68",
+      "account": "account3",
+      "amount": -4.5,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-06-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.092Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558eb0c",
+      "account": "account3",
+      "amount": -10.57,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.093Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558ecbf",
+      "account": "account3",
+      "amount": -3.33,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.095Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b558f692",
+      "account": "account3",
+      "amount": -43.07,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.096Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55902cf",
+      "account": "account3",
+      "amount": -12.77,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.096Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5590d94",
+      "account": "account3",
+      "amount": -300,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-06-01T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.097Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5591330",
+      "account": "account3",
+      "amount": -2.25,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-06-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.097Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5591c2b",
+      "account": "account3",
+      "amount": -8.79,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-05-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.099Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5591d0d",
+      "account": "account3",
+      "amount": -37.78,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.101Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5592874",
+      "account": "account3",
+      "amount": -59.78,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.099Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55928b0",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-05-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.100Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559334d",
+      "account": "account3",
+      "amount": -18.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.101Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5593d76",
+      "account": "account3",
+      "amount": 1000,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.103Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55944d6",
+      "account": "account3",
+      "amount": -47.98,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.103Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5594687",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.104Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55949ac",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.104Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55952d2",
+      "account": "account3",
+      "amount": 249,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.103Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5596204",
+      "account": "account3",
+      "amount": -28.96,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.107Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5596795",
+      "account": "account1",
+      "amount": -249,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.106Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5596d2f",
+      "account": "account3",
+      "amount": -48,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-05-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.106Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5596e9b",
+      "account": "account3",
+      "amount": -51.93,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-15T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.110Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5597b32",
+      "account": "account3",
+      "amount": -6.68,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-22T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.105Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5598acc",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-05-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.108Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5599155",
+      "account": "account3",
+      "amount": -15.9,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-05-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.107Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b5599c08",
+      "account": "account3",
+      "amount": -1,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-14T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.110Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559a08f",
+      "account": "account3",
+      "amount": -15.23,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.113Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559a356",
+      "account": "account3",
+      "amount": -50.32,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-05-14T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.111Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559ada3",
+      "account": "account3",
+      "amount": -50.1,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-05-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.113Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559adb3",
+      "account": "account3",
+      "amount": -16.3,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-05-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.112Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559bafa",
+      "account": "account3",
+      "amount": -28.17,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-05-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.116Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559c91d",
+      "account": "account3",
+      "amount": -150,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.115Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559d771",
+      "account": "account3",
+      "amount": 7.5,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.119Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559ddd8",
+      "account": "account3",
+      "amount": -7,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.116Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559e4cf",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.118Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559f3c2",
+      "account": "account3",
+      "amount": -22.5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.118Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559f970",
+      "account": "account3",
+      "amount": -2.5,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-05-07T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.116Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b559fca6",
+      "account": "account3",
+      "amount": -13.37,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-05-04T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.116Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a0a19",
+      "account": "account3",
+      "amount": 2815.01,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.121Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a11a5",
+      "account": "account3",
+      "amount": -40.8,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.122Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a1ff3",
+      "account": "account3",
+      "amount": -17.7,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.121Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a24c2",
+      "account": "account3",
+      "amount": -22.1,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.119Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a2c3b",
+      "account": "account3",
+      "amount": 85,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.122Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a38f2",
+      "account": "account3",
+      "amount": -19.9,
+      "automaticCategoryId": "400270",
+      "currency": "EUR",
+      "date": "2018-05-02T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.120Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a3c4b",
+      "account": "account3",
+      "amount": -13.46,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.123Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a4c2b",
+      "account": "account3",
+      "amount": 26.16,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-04-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.126Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a4daf",
+      "account": "account3",
+      "amount": -829.31,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-24T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.125Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a4f3a",
+      "account": "account3",
+      "amount": -6.03,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.123Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a5ec9",
+      "account": "account3",
+      "amount": -29.9,
+      "automaticCategoryId": "400130",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.128Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a6668",
+      "account": "account3",
+      "amount": -39.95,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.127Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a6a97",
+      "account": "account3",
+      "amount": 133.13,
+      "automaticCategoryId": "200110",
+      "currency": "EUR",
+      "date": "2018-04-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.125Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a6b4e",
+      "account": "account3",
+      "amount": -104.94,
+      "automaticCategoryId": "400840",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.126Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a6e39",
+      "account": "account3",
+      "amount": 24.58,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-04-25T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.125Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a7c61",
+      "account": "account3",
+      "amount": -26.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-20T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.130Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a848f",
+      "account": "account3",
+      "amount": -5.49,
+      "automaticCategoryId": "400760",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.129Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a8e8e",
+      "account": "account3",
+      "amount": -9.5,
+      "automaticCategoryId": "400720",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.130Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55a9a0d",
+      "account": "account3",
+      "amount": -24.31,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2018-04-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.135Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aa253",
+      "account": "account3",
+      "amount": -29.81,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-18T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.132Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aa297",
+      "account": "account3",
+      "amount": -56.77,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-23T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.130Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aa4b7",
+      "account": "account3",
+      "amount": -6.8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-04-19T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.131Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aad11",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-10T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.139Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ab1d9",
+      "account": "account3",
+      "amount": 34.45,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-04-17T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.132Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55abede",
+      "account": "account3",
+      "amount": -18.25,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-04-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.141Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ac47a",
+      "account": "account3",
+      "amount": -67.4,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.140Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55acf62",
+      "account": "account3",
+      "amount": -17.58,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-06T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.141Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ad17d",
+      "account": "account3",
+      "amount": 70.7,
+      "automaticCategoryId": "400620",
+      "currency": "EUR",
+      "date": "2018-04-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.139Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ad71d",
+      "account": "account3",
+      "amount": -73.46,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-09T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.140Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ae42c",
+      "account": "account3",
+      "amount": -8,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-04-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.136Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aebf7",
+      "account": "account3",
+      "amount": -47.79,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-04-12T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.135Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55af3e0",
+      "account": "account3",
+      "amount": 35,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.142Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55af548",
+      "account": "account3",
+      "amount": -56.61,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.144Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55aff1c",
+      "account": "account3",
+      "amount": -7.5,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-27T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.148Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b0355",
+      "account": "account3",
+      "amount": 2771.65,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.144Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b04c7",
+      "account": "account3",
+      "amount": -48.3,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-03-22T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.149Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b116c",
+      "account": "account3",
+      "amount": -14.8,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.145Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b172e",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.143Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b220f",
+      "account": "account3",
+      "amount": -14,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.145Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b2832",
+      "account": "account3",
+      "amount": -15.14,
+      "automaticCategoryId": "400250",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.145Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b30f4",
+      "account": "account3",
+      "amount": -48.65,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.145Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b3f58",
+      "account": "account3",
+      "amount": 78.49,
+      "automaticCategoryId": "400610",
+      "currency": "EUR",
+      "date": "2018-03-28T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.147Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b413c",
+      "account": "account3",
+      "amount": -7.4,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.145Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b436c",
+      "account": "account3",
+      "amount": -260,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.143Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b4404",
+      "account": "account3",
+      "amount": 100,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-04-03T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.143Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b51ad",
+      "account": "account3",
+      "amount": -19,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-03-20T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.150Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b577f",
+      "account": "account3",
+      "amount": -22,
+      "automaticCategoryId": "400820",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.155Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b66ec",
+      "account": "account3",
+      "amount": -24,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-14T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.154Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b6ca6",
+      "account": "account3",
+      "amount": -1.5,
+      "automaticCategoryId": "400310",
+      "currency": "EUR",
+      "date": "2018-03-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.158Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b7a7e",
+      "account": "account3",
+      "amount": -8.95,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.152Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b7aea",
+      "account": "account3",
+      "amount": -42.4,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-03-16T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.153Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b7d7f",
+      "account": "account3",
+      "amount": -22.31,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-03-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.157Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b803c",
+      "account": "account3",
+      "amount": -14.25,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.155Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b85b6",
+      "account": "account3",
+      "amount": -25,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.156Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55b94bd",
+      "account": "account3",
+      "amount": -8.7,
+      "automaticCategoryId": "400820",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.156Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ba1cb",
+      "account": "account3",
+      "amount": -55.82,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.156Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55baa53",
+      "account": "account3",
+      "amount": -35.5,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-03-15T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.153Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bad58",
+      "account": "account3",
+      "amount": -2,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.152Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bbae6",
+      "account": "account3",
+      "amount": -10.99,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.151Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bc224",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.157Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bc613",
+      "account": "account3",
+      "amount": -7.99,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-03-09T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.157Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bcdf7",
+      "account": "account3",
+      "amount": -9.12,
+      "automaticCategoryId": "401050",
+      "currency": "EUR",
+      "date": "2018-03-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.159Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bd8c4",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.160Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bdae7",
+      "account": "account3",
+      "amount": -0.15,
+      "automaticCategoryId": "400340",
+      "currency": "EUR",
+      "date": "2018-03-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.160Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55be477",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-02-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.166Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bf35f",
+      "account": "account3",
+      "amount": -35,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.164Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55bfa5d",
+      "account": "account3",
+      "amount": -14.99,
+      "automaticCategoryId": "400750",
+      "currency": "EUR",
+      "date": "2018-02-21T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.166Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c0950",
+      "account": "account3",
+      "amount": -10.6,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.165Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c0c47",
+      "account": "account3",
+      "amount": -724,
+      "automaticCategoryId": "400500",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.163Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c1bc5",
+      "account": "account3",
+      "amount": 800,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-27T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.163Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c2122",
+      "account": "account3",
+      "amount": -3.54,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-03-06T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.159Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c293a",
+      "account": "account3",
+      "amount": -25.25,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-26T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.165Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c298c",
+      "account": "account3",
+      "amount": -14.3,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-03-08T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.159Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c2f4e",
+      "account": "account3",
+      "amount": -41.63,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-03-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.160Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c396e",
+      "account": "account3",
+      "amount": -41.99,
+      "automaticCategoryId": "400150",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.166Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c3ab7",
+      "account": "account3",
+      "amount": -20,
+      "automaticCategoryId": "300",
+      "currency": "EUR",
+      "date": "2018-02-19T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.167Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "cash",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c469e",
+      "account": "account3",
+      "amount": -653.89,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.169Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c46fb",
+      "account": "account3",
+      "amount": -29.1,
+      "automaticCategoryId": "400810",
+      "currency": "EUR",
+      "date": "2018-02-16T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.168Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c4adb",
+      "account": "account3",
+      "amount": -11.34,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.178Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c53bd",
+      "account": "account3",
+      "amount": -20.15,
+      "automaticCategoryId": "400230",
+      "currency": "EUR",
+      "date": "2018-02-15T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.168Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c58a2",
+      "account": "account3",
+      "amount": -8.69,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-13T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.169Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c669a",
+      "account": "account1",
+      "amount": 58.09,
+      "automaticCategoryId": "200130",
+      "currency": "EUR",
+      "date": "2018-01-03T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.179Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "financial fee",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c6e27",
+      "account": "account1",
+      "amount": 1069.21,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-02-01T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.179Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c73fd",
+      "account": "account3",
+      "amount": -1822,
+      "automaticCategoryId": "600110",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.177Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "internal transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c784e",
+      "account": "account3",
+      "amount": 1486.8,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2018-02-02T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.179Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c81c2",
+      "account": "account3",
+      "amount": -63.92,
+      "automaticCategoryId": "400110",
+      "currency": "EUR",
+      "date": "2018-02-15T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.168Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c844a",
+      "account": "account3",
+      "amount": -75.2,
+      "automaticCategoryId": "400280",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.177Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "debit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c877c",
+      "account": "account3",
+      "amount": -5.64,
+      "automaticCategoryId": "0",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.177Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c8ff9",
+      "account": "account3",
+      "amount": -7.85,
+      "automaticCategoryId": "400160",
+      "currency": "EUR",
+      "date": "2018-02-05T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.178Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c942b",
+      "account": "account3",
+      "amount": -1,
+      "automaticCategoryId": "400270",
+      "currency": "EUR",
+      "date": "2018-02-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.170Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "credit card",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55c9d26",
+      "account": "account1",
+      "amount": -270,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-12-12T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.180Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55ca9dd",
+      "account": "account1",
+      "amount": -3153,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-09-11T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.185Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55cb38d",
+      "account": "account1",
+      "amount": -1000,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-11-14T00:00:00+01:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.185Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55cbe77",
+      "account": "account1",
+      "amount": 2000,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-08-16T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.186Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "f8fff985b65c95626c2460e9b55cc152",
+      "account": "account1",
+      "amount": -665,
+      "automaticCategoryId": "100",
+      "currency": "EUR",
+      "date": "2017-08-30T00:00:00+02:00",
+      "dateOperation": null,
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "dateImport": "2018-08-02T14:40:30.186Z",
+        "version": 1
+      },
+      "originalBankLabel": "Original label",
+      "type": "transfer",
+      "vendorAccountId": "12345",
+      "vendorId": "123456"
+    }
+  ],
+  "io.cozy.bank.accounts": [
+    {
+      "_id": "account1",
+      "balance": 10500.74,
+      "institutionLabel": "Banque",
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "version": 1
+      },
+      "number": "07711 00072345678",
+      "shortLabel": "Compte 1",
+      "type": "Savings",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "account2",
+      "balance": 4.51,
+      "institutionLabel": "Banque",
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "version": 1
+      },
+      "number": "07711 00072345678",
+      "shortLabel": "Compte 2",
+      "type": "Savings",
+      "vendorId": "123456"
+    },
+    {
+      "_id": "account3",
+      "balance": 2050.36,
+      "institutionLabel": "Banque",
+      "label": "Label",
+      "linxoId": "123456",
+      "metadata": {
+        "version": 1
+      },
+      "number": "03791 00070085818",
+      "shortLabel": "Compte Bancaire",
+      "type": "Checkings",
+      "vendorId": "123456"
+    }
+  ]
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -494,5 +494,9 @@
       "disconnect": "Refuse and disconnect",
       "error": "Something went wrong, please try again later"
     }
+  },
+
+  "BalanceHistory": {
+    "subtitle": "Total balance"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -447,5 +447,9 @@
       "disconnect": "Refuser et se déconnecter",
       "error": "Une erreur est survenue, merci de réessayer plus tard"
     }
+  },
+
+  "BalanceHistory": {
+    "subtitle": "Solde total"
   }
 }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -36,6 +36,12 @@ module.exports = {
       ]
     },
     {
+      name: 'Balance',
+      components: () => [
+        'src/ducks/balance/History.jsx'
+      ]
+    },
+    {
       name: 'Loading',
       components: () => [
         'src/components/Loading/Loading.jsx'

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -30,6 +30,12 @@ module.exports = {
       ]
     },
     {
+      name: 'Chart',
+      components: () => [
+        'src/components/Chart/LineChart.jsx'
+      ]
+    },
+    {
       name: 'Loading',
       components: () => [
         'src/components/Loading/Loading.jsx'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3014,6 +3014,10 @@ cozy-device-helper@1.2.1:
   dependencies:
     lodash "4.17.10"
 
+cozy-flags@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.0.2.tgz#4afd4c0d087c2af707cb89653ca43b401618d7f7"
+
 cozy-konnector-libs@^3.0.13:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-3.8.1.tgz#c4f9d6c2df742023897691c8d0e257a516ec00cd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12302,6 +12302,10 @@ slide@^1.1.3, slide@^1.1.5, slide@~1.1.3, slide@~1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
+sma@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/sma/-/sma-0.1.0.tgz#79904a96ea686451e0cd735d29a7334bfb0e0a88"
+
 smart-buffer@^1.0.13:
   version "1.1.15"
   resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-1.1.15.tgz#7f114b5b65fab3e2a35aa775bb12f0d1c649bf16"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2534,6 +2534,10 @@ command-line-usage@^4.1.0:
     table-layout "^0.4.2"
     typical "^2.6.1"
 
+commander@2:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
+
 commander@2.15.1, commander@2.15.x, commander@^2.11.0, commander@^2.12.2, commander@^2.13.0, commander@^2.5.0, commander@^2.9.0, commander@~2.15.0:
   version "2.15.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
@@ -3327,6 +3331,222 @@ cycle@1.0.x:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
+
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
+
+d3-axis@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.8.tgz#31a705a0b535e65759de14173a31933137f18efa"
+
+d3-brush@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.4.tgz#00c2f238019f24f6c0a194a26d41a1530ffe7bc4"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-chord@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.4.tgz#7dec4f0ba886f713fe111c45f763414f6f74ca2c"
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
+d3-collection@1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
+
+d3-color@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.0.tgz#d1ea19db5859c86854586276ec892cf93148459a"
+
+d3-contour@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.0.tgz#cfb99098c48c46edd77e15ce123162f9e333e846"
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-dispatch@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.3.tgz#46e1491eaa9b58c358fce5be4e8bed626e7871f8"
+
+d3-drag@1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.1.tgz#df8dd4c502fb490fc7462046a8ad98a5c479282d"
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-dsv@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.8.tgz#907e240d57b386618dc56468bacfe76bf19764ae"
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.3.tgz#68bfbc349338a380c44d8acc4fbc3304aa2d8c0e"
+
+d3-fetch@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.1.0.tgz#31cbcd506b21d6519ac6a120a079de8d0a57c00f"
+  dependencies:
+    d3-dsv "1"
+
+d3-force@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.1.0.tgz#cebf3c694f1078fcc3d4daf8e567b2fbd70d4ea3"
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
+d3-format@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.0.tgz#a3ac44269a2011cdb87c7b5693040c18cddfff11"
+
+d3-geo@1:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.10.0.tgz#2972d18014f1e38fc1f8bb6d545377bdfb00c9ab"
+  dependencies:
+    d3-array "1"
+
+d3-hierarchy@1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.6.tgz#842c1372090f870b7ea013ebae5c0c8d9f56229c"
+
+d3-interpolate@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.2.0.tgz#40d81bd8e959ff021c5ea7545bc79b8d22331c41"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.5.tgz#241eb1849bd9e9e8021c0d0a799f8a0e8e441764"
+
+d3-polygon@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.3.tgz#16888e9026460933f2b179652ad378224d382c62"
+
+d3-quadtree@1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.3.tgz#ac7987e3e23fe805a990f28e1b50d38fcb822438"
+
+d3-random@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.0.tgz#6642e506c6fa3a648595d2b2469788a8d12529d3"
+
+d3-scale-chromatic@1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.3.0.tgz#7ee38ffcaa7ad55cfed83a6a668aac5570c653c4"
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale@2:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.0.tgz#8d3fd3e2a7c9080782a523c08507c5248289eef8"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.0.tgz#d53772382d3dc4f7507bfb28bcd2d6aed2a0ad6d"
+
+d3-shape@1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.0.tgz#45d01538f064bafd05ea3d6d2cb748fd8c41f777"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.1.tgz#85b7cdfbc9ffca187f14d3c456ffda268081bb31"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.8.tgz#dbd2d6007bf416fe67a76d17947b784bffea1e84"
+
+d3-timer@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.7.tgz#df9650ca587f6c96607ff4e60cc38229e8dd8531"
+
+d3-transition@1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.1.tgz#d8ef89c3b848735b060e54a39b32aaebaa421039"
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-voronoi@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.2.tgz#1687667e8f13a2d158c80c1480c5a29cb0d8973c"
+
+d3-zoom@1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.1.tgz#02f43b3c3e2db54f364582d7e4a236ccc5506b63"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.5.0.tgz#948413b91b988a6597f3e4c3e941d3b530bfee63"
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
 
 d@1:
   version "1.0.0"
@@ -5659,6 +5879,12 @@ i@0.3.x:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/i/-/i-0.3.6.tgz#d96c92732076f072711b6b10fd7d4f65ad8ee23d"
 
+iconv-lite@0.4, iconv-lite@~0.4.13:
+  version "0.4.23"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 iconv-lite@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -5668,12 +5894,6 @@ iconv-lite@^0.4.17, iconv-lite@^0.4.5:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.21.tgz#c47f8733d02171189ebc4a400f3218d348094798"
   dependencies:
     safer-buffer "^2.1.0"
-
-iconv-lite@~0.4.13:
-  version "0.4.23"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.23.tgz#297871f63be507adcfbfca715d0cd0eed84e9a63"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -11745,6 +11965,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
It uses static data for now. The balance history is passed in a rolling window algorithm with a size of 15. The result can be seen on the Balance page or in the styleguide

![image](https://user-images.githubusercontent.com/1606068/43701438-78eb14a8-9956-11e8-93cf-992f7f537731.png)
