### PR TITLE
Balance history UI

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -32,6 +32,8 @@ class LineChart extends Component {
       nbTicks,
       tickFormat,
       tickPadding,
+      tickSizeOuter,
+      tickSizeInner,
       xScale,
       yScale,
       onUpdate,
@@ -87,14 +89,14 @@ class LineChart extends Component {
       .attr('stroke-width', lineWidth)
       .attr('fill', 'none')
 
-    this.xAxisGenerator = d3.axisBottom(this.x)
+    this.xAxisGenerator = d3
+      .axisBottom(this.x)
+      .tickSizeOuter(tickSizeOuter)
+      .tickSizeInner(tickSizeInner)
+      .tickPadding(tickPadding)
 
     if (nbTicks !== undefined) {
       this.xAxisGenerator.ticks(nbTicks)
-    }
-
-    if (tickPadding !== undefined) {
-      this.xAxisGenerator.tickPadding(tickPadding)
     }
 
     if (tickFormat) {
@@ -233,7 +235,10 @@ LineChart.defaultProps = {
   labelsColor: 'black',
   axisMargin: 0,
   enterAnimationDuration: 1000,
-  showAxis: false
+  showAxis: false,
+  tickPadding: 8,
+  tickSizeOuter: 0,
+  tickSizeInner: 5
 }
 
 export default LineChart

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -36,7 +36,8 @@ class LineChart extends Component {
       yScale,
       onUpdate,
       axisMargin,
-      gradient
+      gradient,
+      showAxis
     } = this.props
 
     const width = this.getRootWidth()
@@ -100,9 +101,11 @@ class LineChart extends Component {
       this.xAxisGenerator.tickFormat(tickFormat)
     }
 
-    this.axis = this.svg
-      .append('g')
-      .attr('transform', `translate(0, ${innerHeight + axisMargin})`)
+    if (showAxis) {
+      this.axis = this.svg
+        .append('g')
+        .attr('transform', `translate(0, ${innerHeight + axisMargin})`)
+    }
 
     this.setData(data, true)
 
@@ -148,7 +151,9 @@ class LineChart extends Component {
         })
     }
 
-    this.updateAxis()
+    if (this.props.showAxis) {
+      this.updateAxis()
+    }
   }
 
   updateAxis() {
@@ -214,7 +219,8 @@ LineChart.propTypes = {
   onUpdate: PropTypes.func,
   axisMargin: PropTypes.number,
   gradient: PropTypes.object,
-  enterAnimationDuration: PropTypes.number
+  enterAnimationDuration: PropTypes.number,
+  showAxis: PropTypes.bool
 }
 
 LineChart.defaultProps = {
@@ -226,7 +232,8 @@ LineChart.defaultProps = {
   axisColor: 'black',
   labelsColor: 'black',
   axisMargin: 0,
-  enterAnimationDuration: 1000
+  enterAnimationDuration: 1000,
+  showAxis: false
 }
 
 export default LineChart

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -114,8 +114,8 @@ class LineChart extends Component {
   setData(data, animate) {
     const sortedData = sortBy(data, d => d.x)
 
-    this.x.domain([d3.min(data, d => d.x), d3.max(data, d => d.x)])
-    this.y.domain([d3.min(data, d => d.y), d3.max(data, d => d.y)])
+    this.x.domain(d3.extent(data, d => d.x))
+    this.y.domain(d3.extent(data, d => d.y))
 
     this.line.datum(sortedData).attr('d', this.lineGenerator)
 

--- a/src/components/Chart/LineChart.md
+++ b/src/components/Chart/LineChart.md
@@ -14,6 +14,7 @@
     left: 10,
     right: 10
   }}
+  showAxis
 />
 ```
 
@@ -38,6 +39,7 @@ const d3 = require('d3');
   nbTicks={2}
   tickFormat={d3.timeFormat('%x')}
   xScale={d3.scaleTime}
+  showAxis
 />
 ```
 
@@ -67,5 +69,6 @@ const d3 = require('d3');
     '0%': 'steelblue',
     '100%': 'white'
   }}
+  showAxis
 />
 ```

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -12,6 +12,7 @@ import { connect } from 'react-redux'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import { or } from 'airbnb-prop-types'
+import * as d3 from 'd3'
 
 import { withRouter } from 'react-router'
 import { translate, Button, Icon, withBreakpoints } from 'cozy-ui/react'
@@ -371,6 +372,7 @@ class Balance extends React.Component {
       Object.keys(groupBy(chartData, i => formatDate(i.x, 'YYYY-MM')))
     ).length
     const chartIntervalBetweenPoints = 57
+    const TICK_FORMAT = d3.timeFormat('%b')
 
     return (
       <div className={styles['Balance']}>
@@ -380,10 +382,19 @@ class Balance extends React.Component {
         {flag('balance-history') ? (
           <History
             accounts={historyData['io.cozy.bank.accounts']}
-            transactions={historyData['io.cozy.bank.operations']}
             chartProps={{
               data: chartData,
-              width: chartNbTicks * chartIntervalBetweenPoints
+              width: chartNbTicks * chartIntervalBetweenPoints,
+              height: 103,
+              margin: {
+                top: 10,
+                bottom: 35,
+                left: 16,
+                right: 16
+              },
+              showAxis: true,
+              axisMargin: 10,
+              tickFormat: TICK_FORMAT
             }}
           />
         ) : (

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -28,34 +28,7 @@ class History extends Component {
         <div className={styles.History__subtitle}>
           {t('BalanceHistory.subtitle')}
         </div>
-        <div
-          className={styles.History__chartContainer}
-          ref={node => (this.chartContainer = node)}
-        >
-          <LineChart
-            height={150}
-            margin={{
-              top: 20,
-              bottom: 40,
-              left: 10,
-              right: 10
-            }}
-            tickFormat={d3.timeFormat('%b')}
-            xScale={d3.scaleTime}
-            lineColor="white"
-            axisColor="white"
-            labelsColor="#a2c4f9"
-            onUpdate={() =>
-              this.chartContainer.scrollTo(this.chartContainer.scrollWidth, 0)
-            }
-            axisMargin={10}
-            gradient={{
-              '0%': '#76b9f3',
-              '100%': palette.dodgerBlue
-            }}
-            {...chartProps}
-          />
-        </div>
+        <HistoryChart {...chartProps} />
       </div>
     )
   }
@@ -65,6 +38,32 @@ History.propTypes = {
   accounts: PropTypes.array.isRequired,
   chartProps: PropTypes.object,
   className: PropTypes.string
+}
+
+export class HistoryChart extends Component {
+  render() {
+    return (
+      <div
+        className={styles.HistoryChart}
+        ref={node => (this.container = node)}
+      >
+        <LineChart
+          xScale={d3.scaleTime}
+          lineColor="white"
+          axisColor="white"
+          labelsColor="#a2c4f9"
+          onUpdate={() =>
+            this.container.scrollTo(this.container.scrollWidth, 0)
+          }
+          gradient={{
+            '0%': '#76b9f3',
+            '100%': palette.dodgerBlue
+          }}
+          {...this.props}
+        />
+      </div>
+    )
+  }
 }
 
 export default translate()(History)

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -59,6 +59,12 @@ export class HistoryChart extends Component {
             '0%': '#76b9f3',
             '100%': palette.dodgerBlue
           }}
+          margin={{
+            top: 10,
+            bottom: 10,
+            left: 16,
+            right: 16
+          }}
           {...this.props}
         />
       </div>

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -50,7 +50,7 @@ class History extends Component {
             }
             axisMargin={10}
             gradient={{
-              '0%': 'rgba(255, 255, 255, 0.7)',
+              '0%': '#76b9f3',
               '100%': palette.dodgerBlue
             }}
             {...chartProps}

--- a/src/ducks/balance/History.styl
+++ b/src/ducks/balance/History.styl
@@ -25,7 +25,7 @@
 .History__subtitle
     margin-top 0.25rem
     text-transform uppercase
-    font-size 0.85rem
+    font-size 0.75rem
     font-weight bold
     color #a2c4f9
 

--- a/src/ducks/balance/History.styl
+++ b/src/ducks/balance/History.styl
@@ -1,4 +1,5 @@
 @require '~styles/mixins.styl'
+@require '~styles/variables.styl'
 
 .History
     background-color dodgerBlue
@@ -28,5 +29,15 @@
     font-weight bold
     color #a2c4f9
 
-.History__chartContainer
+.HistoryChart
     overflow-y auto
+    background-color dodgerBlue
+    @extend $full-width
+
+    +small-screen()
+        margin-top (- content-padding-small)
+
+.History .HistoryChart
+    margin-left 0
+    margin-right 0
+    margin-top 0

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -25,7 +25,6 @@ import {
   parse as parseDate,
   subMonths
 } from 'date-fns'
-import * as d3 from 'd3'
 
 import {
   getTransactionsFilteredByAccount,
@@ -44,7 +43,7 @@ import Loading from 'components/Loading'
 import { Breadcrumb } from 'components/Breadcrumb'
 import BackButton from 'components/BackButton'
 
-import History from 'ducks/balance/History'
+import { HistoryChart } from 'ducks/balance/History'
 import historyData from 'ducks/balance/history_data.json'
 import { getBalanceHistories } from 'ducks/balance/helpers'
 
@@ -320,15 +319,17 @@ class TransactionsPage extends Component {
       <div className={styles.TransactionPage} ref={node => (this.root = node)}>
         {subcategoryName ? <BackButton /> : null}
         {flag('balance-history') && (
-          <History
-            accounts={historyData['io.cozy.bank.accounts']}
-            transactions={historyData['io.cozy.bank.operations']}
-            chartProps={{
-              data: chartData,
-              width: isMobile
-                ? chartNbTicks * chartIntervalBetweenPoints
-                : '100%',
-              tickFormat: d3.timeFormat('%x')
+          <HistoryChart
+            data={chartData}
+            width={
+              isMobile ? chartNbTicks * chartIntervalBetweenPoints : '100%'
+            }
+            height={72}
+            margin={{
+              top: 10,
+              bottom: 10,
+              left: 16,
+              right: 16
             }}
           />
         )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -497,6 +497,6 @@
   },
 
   "BalanceHistory": {
-    "subtitle": "Total balance"
+    "subtitle": "All accounts"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -450,6 +450,6 @@
   },
 
   "BalanceHistory": {
-    "subtitle": "Solde total"
+    "subtitle": "Tous les comptes"
   }
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,6 +13,12 @@ import { getClient } from 'utils/client'
 import 'utils/flag'
 import FastClick from 'fastclick'
 import { isReporterEnabled, configureReporter, setURLContext } from 'lib/sentry'
+import * as d3 from 'd3'
+
+const D3_LOCALES_MAP = {
+  fr: 'fr-FR',
+  en: 'en-GB'
+}
 
 if (__TARGET__ === 'mobile') {
   require('styles/mobile.styl')
@@ -44,6 +50,10 @@ const setupApp = async persistedState => {
     __TARGET__ === 'mobile' && navigator && navigator.language
       ? navigator.language.slice(0, 2)
       : data.cozyLocale || 'en'
+
+  d3.timeFormatDefaultLocale(
+    require(`d3-time-format/locale/${D3_LOCALES_MAP[lang]}.json`)
+  )
 
   history = setupHistory()
 


### PR DESCRIPTION
There are two distincts UIs : 

One for the balances page, that shows the X axis and the current balance:

![image](https://user-images.githubusercontent.com/1606068/43838304-3f9ed970-9b1b-11e8-8f0a-eb45a74bf5fc.png)

And one for the transactions page, that only shows the line: 

![image](https://user-images.githubusercontent.com/1606068/43838339-5b3688fe-9b1b-11e8-9268-30a4e3613981.png)

Some UI things that are related to interactions are not present in this PR, but will be in a next one.