### PR TITLE
fix: wepback providing cozy-bar

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -6,17 +6,19 @@ module.exports = {
   devtool: 'cheap-source-map',
   externals: ['cozy'],
   module: {
-    rules: [{
-      test: require.resolve('cozy-bar/dist/cozy-bar.js'),
-      loader: 'imports-loader?css=./cozy-bar.css'
-    }]
+    rules: [
+      {
+        test: require.resolve('cozy-bar/dist/cozy-bar.js'),
+        loader: 'imports-loader?css=./cozy-bar.css'
+      }
+    ]
   },
   plugins: [
     new webpack.DefinePlugin({
       __STACK_ASSETS__: false,
       __DEVELOPMENT__: true,
       'process.env': {
-        'NODE_ENV': JSON.stringify('development')
+        NODE_ENV: JSON.stringify('development')
       }
     }),
     new webpack.ProvidePlugin({

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,6 +1,15 @@
 'use strict'
 
 const webpack = require('webpack')
+const { target } = require('./webpack.vars')
+
+const provided = {
+  'cozy.client': 'cozy-client-js/dist/cozy-client.js',
+}
+
+if (target != 'mobile') {
+  provided['cozy.bar'] = 'cozy-bar/dist/cozy-bar.js'
+}
 
 module.exports = {
   devtool: 'cheap-source-map',
@@ -21,10 +30,7 @@ module.exports = {
         NODE_ENV: JSON.stringify('development')
       }
     }),
-    new webpack.ProvidePlugin({
-      'cozy.client': 'cozy-client-js/dist/cozy-client.js',
-      'cozy.bar': 'cozy-bar/dist/cozy-bar.js'
-    })
+    new webpack.ProvidePlugin(provided)
   ],
   stats: {
     children: false

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,12 @@
 'use strict'
 
 const merge = require('webpack-merge')
-const { production, target, hotReload, analyze } = require('./config/webpack.vars')
+const {
+  production,
+  target,
+  hotReload,
+  analyze
+} = require('./config/webpack.vars')
 
 const common = merge(
   require('./config/webpack.config.base'),
@@ -18,8 +23,8 @@ const common = merge(
   require(`./config/webpack.target.${target}`)
 )
 
-if (production) {
-  module.exports = merge(common, require('./config/webpack.config.prod'))
-} else {
-  module.exports = merge(common, require('./config/webpack.config.dev'))
-}
+const modeConfig = production
+  ? require('./config/webpack.config.prod')
+  : require('./config/webpack.config.dev')
+
+module.exports = merge(common, modeConfig)


### PR DESCRIPTION
There was a risk that the ProvidePlugin from webpack.dev would
override the one from webpack.mobile, meaning that the bar would
be in non mobile mode even when we were building in mobile mode.

It is not the case in production mode since the webpack.production
does not define the ProvidePlugin.