### PR TITLE
chore: Use cheap-module-eval-source-map

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -12,7 +12,7 @@ if (target !== 'mobile') {
 }
 
 module.exports = {
-  devtool: 'cheap-source-map',
+  devtool: 'cheap-module-eval-source-map',
   externals: ['cozy'],
   module: {
     rules: [


### PR DESCRIPTION
I propose to use cheap-module-eval-source-map when building for dev to get lines in source files in error stacktrace while developing.