### PR TITLE
feat: Use cozy-interapp lib 🚜

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "cozy-client-js": "0.12.0",
     "cozy-device-helper": "1.4.5",
     "cozy-flags": "1.2.2",
+    "cozy-interapp": "0.2.2",
     "cozy-konnector-libs": "^3.0.13",
     "cozy-pouch-link": "^1.0.0-beta.21",
     "cozy-stack-client": "^1.0.0-beta.21",

--- a/src/components/FileIntentDisplay.jsx
+++ b/src/components/FileIntentDisplay.jsx
@@ -1,20 +1,15 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import { Intents } from 'cozy-interapp'
 import { withClient } from 'cozy-client'
 
 import FullscreenIntentModal from 'components/FullscreenIntentModal'
 
 class FileIntentDisplay extends Component {
-  constructor(props) {
-    super(props)
-    this.intents = new Intents({ client: props.client })
-  }
-
   createIntent = () => {
     const id = this.props.fileId
     const doctype = 'io.cozy.files'
-    return this.intents.create('OPEN', doctype, { id })
+    const cozyClient = this.props.client
+    return cozyClient.intents.create('OPEN', doctype, { id })
   }
 
   showModal = () => {

--- a/src/components/FileIntentDisplay.jsx
+++ b/src/components/FileIntentDisplay.jsx
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Intents } from 'cozy-interapp'
+import { withClient } from 'cozy-client'
 
 import FullscreenIntentModal from 'components/FullscreenIntentModal'
-import { withClient } from 'cozy-client'
 
 class FileIntentDisplay extends Component {
   constructor(props) {

--- a/src/components/FileIntentDisplay.jsx
+++ b/src/components/FileIntentDisplay.jsx
@@ -1,13 +1,20 @@
-/* global cozy */
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { Intents } from 'cozy-interapp'
+
 import FullscreenIntentModal from 'components/FullscreenIntentModal'
+import { withClient } from 'cozy-client'
 
 class FileIntentDisplay extends Component {
+  constructor(props) {
+    super(props)
+    this.intents = new Intents({ client: props.client })
+  }
+
   createIntent = () => {
     const id = this.props.fileId
     const doctype = 'io.cozy.files'
-    return cozy.client.intents.create('OPEN', doctype, { id })
+    return this.intents.create('OPEN', doctype, { id })
   }
 
   showModal = () => {
@@ -45,4 +52,4 @@ FileIntentDisplay.propTypes = {
   onError: PropTypes.func.isRequired
 }
 
-export default FileIntentDisplay
+export default withClient(FileIntentDisplay)

--- a/src/ducks/authentication/MobileRouter.jsx
+++ b/src/ducks/authentication/MobileRouter.jsx
@@ -21,7 +21,7 @@ import {
   resetClient,
   getToken
 } from 'ducks/authentication/lib/client'
-import { withClient } from 'utils/client'
+import { withClient } from 'cozy-client'
 
 export const AUTH_PATH = 'authentication'
 

--- a/src/ducks/authentication/MobileRouter.jsx
+++ b/src/ducks/authentication/MobileRouter.jsx
@@ -1,8 +1,9 @@
-import { defaultRoute } from 'components/AppRoute'
 import React from 'react'
 import { Router, Route } from 'react-router'
-import { setURLContext, logException } from 'lib/sentry'
+import { withClient } from 'cozy-client'
 import { Authentication, Revoked } from 'cozy-authentication'
+import { defaultRoute } from 'components/AppRoute'
+import { setURLContext, logException } from 'lib/sentry'
 import {
   storeCredentials,
   revokeClient,
@@ -21,7 +22,6 @@ import {
   resetClient,
   getToken
 } from 'ducks/authentication/lib/client'
-import { withClient } from 'cozy-client'
 
 export const AUTH_PATH = 'authentication'
 

--- a/src/ducks/client/web.js
+++ b/src/ducks/client/web.js
@@ -1,5 +1,6 @@
 /* global cozy */
 import CozyClient from 'cozy-client'
+import { Intents } from 'cozy-interapp'
 import { schema } from 'doctypes'
 
 export const getToken = () => {
@@ -20,6 +21,8 @@ export const getCozyURL = () => {
 export const getClient = (uri, token) => {
   cozy.client.init({ cozyURL: uri, token })
   const client = new CozyClient({ uri, token, schema })
+  const intents = new Intents({ client })
+  client.intents = intents
 
   return client
 }

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -1,7 +1,6 @@
 /* global __TARGET__ */
 
 import React, { Component } from 'react'
-import { Intents } from 'cozy-interapp'
 import { withClient } from 'cozy-client'
 
 // import { IntentOpener } from 'cozy-ui/react'
@@ -17,13 +16,9 @@ import { withClient } from 'cozy-client'
 // Mobile
 
 class SameWindowLink extends Component {
-  constructor(props) {
-    super(props)
-    this.intents = new Intents({ client: props.client })
-  }
-
   redirect = async () => {
-    const redirectionURL = await this.intents.getRedirectionURL(
+    const cozyClient = this.props.client
+    const redirectionURL = await cozyClient.intents.getRedirectionURL(
       'io.cozy.apps',
       {
         category: 'banking'

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -1,6 +1,9 @@
-/* global cozy, __TARGET__ */
+/* global __TARGET__ */
 
 import React, { Component } from 'react'
+import { Intents } from 'cozy-interapp'
+
+import { withClient } from 'cozy-client'
 // import { IntentOpener } from 'cozy-ui/react'
 
 /*
@@ -14,8 +17,13 @@ import React, { Component } from 'react'
 // Mobile
 
 class SameWindowLink extends Component {
+  constructor(props) {
+    super(props)
+    this.intents = new Intents({ client: props.client })
+  }
+
   redirect = async () => {
-    const redirectionURL = await cozy.client.intents.getRedirectionURL(
+    const redirectionURL = await this.intents.getRedirectionURL(
       'io.cozy.apps',
       {
         category: 'banking'
@@ -61,4 +69,4 @@ const AddAccountLink = props => {
   return <SameWindowLink {...props} />
 }
 
-export default AddAccountLink
+export default withClient(AddAccountLink)

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -2,8 +2,8 @@
 
 import React, { Component } from 'react'
 import { Intents } from 'cozy-interapp'
-
 import { withClient } from 'cozy-client'
+
 // import { IntentOpener } from 'cozy-ui/react'
 
 /*

--- a/src/ducks/transactions/TransactionSelectDates.spec.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.spec.jsx
@@ -3,7 +3,6 @@ import fixtures from 'test/fixtures'
 
 const transactions = fixtures['io.cozy.bank.operations']
 
-
 describe('options from select dates', () => {
   it('should compute correctly', () => {
     expect(getOptions(transactions)).toMatchSnapshot()

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -1,9 +1,10 @@
-/* global __TARGET__, cozy */
+/* global __TARGET__ */
 
 import React from 'react'
 import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
+import { Intents } from 'cozy-interapp'
 import { matchBrands, findMatchingBrand } from 'ducks/brandDictionary'
 import {
   IntentModal,
@@ -23,6 +24,7 @@ import { TransactionModalRow } from '../TransactionModal'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 import iconCollectAccount from 'assets/icons/icon-collect-account.svg'
 import { triggersConn } from 'doctypes'
+import { withClient } from 'cozy-client'
 
 const name = 'konnector'
 
@@ -72,10 +74,14 @@ InformativeModal.propTypes = {
   confirmText: PropTypes.string.isRequired
 }
 
-class Component extends React.Component {
-  state = {
-    showInformativeModal: false,
-    showIntentModal: false
+class _Component extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      showInformativeModal: false,
+      showIntentModal: false
+    }
+    this.intents = new Intents({ client: props.client })
   }
 
   showInformativeModal = () =>
@@ -105,7 +111,7 @@ class Component extends React.Component {
       this.showIntentModal()
     } else if (__TARGET__ === 'mobile') {
       const brand = this.findMatchingBrand()
-      const intentWindow = await cozy.client.intents.redirect(
+      const intentWindow = await this.intents.redirect(
         'io.cozy.accounts',
         {
           slug: brand.konnectorSlug
@@ -187,7 +193,7 @@ class Component extends React.Component {
   }
 }
 
-Component.propTypes = {
+_Component.propTypes = {
   t: PropTypes.func.isRequired,
   transaction: PropTypes.object.isRequired,
   actionProps: PropTypes.object.isRequired,
@@ -195,6 +201,8 @@ Component.propTypes = {
   isModalItem: PropTypes.bool,
   fetchTriggers: PropTypes.func.isRequired
 }
+
+const Component = withClient(_Component)
 
 const mkFetchTriggers = client => () =>
   client.query(triggersConn.query(client), { as: triggersConn.as })

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -4,7 +4,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
-import { Intents } from 'cozy-interapp'
 import { withClient } from 'cozy-client'
 import { matchBrands, findMatchingBrand } from 'ducks/brandDictionary'
 import {
@@ -75,13 +74,9 @@ InformativeModal.propTypes = {
 }
 
 class _Component extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      showInformativeModal: false,
-      showIntentModal: false
-    }
-    this.intents = new Intents({ client: props.client })
+  state = {
+    showInformativeModal: false,
+    showIntentModal: false
   }
 
   showInformativeModal = () =>
@@ -111,7 +106,8 @@ class _Component extends React.Component {
       this.showIntentModal()
     } else if (__TARGET__ === 'mobile') {
       const brand = this.findMatchingBrand()
-      const intentWindow = await this.intents.redirect(
+      const cozyClient = this.props.client
+      const intentWindow = await cozyClient.intents.redirect(
         'io.cozy.accounts',
         {
           slug: brand.konnectorSlug

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
 import { Intents } from 'cozy-interapp'
+import { withClient } from 'cozy-client'
 import { matchBrands, findMatchingBrand } from 'ducks/brandDictionary'
 import {
   IntentModal,
@@ -24,7 +25,6 @@ import { TransactionModalRow } from '../TransactionModal'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 import iconCollectAccount from 'assets/icons/icon-collect-account.svg'
 import { triggersConn } from 'doctypes'
-import { withClient } from 'cozy-client'
 
 const name = 'konnector'
 

--- a/src/utils/client.js
+++ b/src/utils/client.js
@@ -41,13 +41,6 @@ export const withCrud = withMutations(client => ({
   destroyDocument: document => client.destroy(document)
 }))
 
-export const withClient = Component => {
-  const Wrapped = (props, context) => (
-    <Component {...props} client={context.client} />
-  )
-  return Wrapped
-}
-
 export const queryConnect = querySpecs => Component => {
   const enhancers = Object.keys(querySpecs).map(dest =>
     withQuery(dest, querySpecs[dest], Component)

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -1,13 +1,19 @@
 import React from 'react'
 import { I18n } from 'cozy-ui/react'
+import { CozyProvider } from 'cozy-client'
 import { Provider } from 'react-redux'
 import langEn from 'locales/en.json'
 import store from 'test/store'
+import getClient from 'test/client'
 
-const AppLike = ({ children, store }) => (
-  <I18n lang={'en'} dictRequire={() => langEn}>
-    <Provider store={store}>{children}</Provider>
-  </I18n>
+const AppLike = ({ children, store, client }) => (
+  <Provider store={store}>
+    <CozyProvider client={client || getClient()}>
+      <I18n lang={'en'} dictRequire={() => langEn}>
+        {children}
+      </I18n>
+    </CozyProvider>
+  </Provider>
 )
 
 AppLike.defaultProps = {

--- a/test/client.js
+++ b/test/client.js
@@ -1,0 +1,16 @@
+import CozyClient from 'cozy-client'
+
+const defaultOptions = {
+  uri: 'http://cozy.works:8080',
+  token: 'MyOwnToken'
+}
+
+export const getClient = ({ uri, token, fetchJSONReturn } = defaultOptions) => {
+  const client = new CozyClient({ uri, token })
+  if (fetchJSONReturn) {
+    client.client.fetchJSON = jest.fn().mockReturnValue(fetchJSONReturn)
+  }
+  return client
+}
+
+export default getClient

--- a/yarn.lock
+++ b/yarn.lock
@@ -3289,6 +3289,10 @@ cozy-flags@1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.2.2.tgz#0535473ff691970af4023bc0b5420b54b496ad19"
 
+cozy-interapp@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.2.2.tgz#cd274e00dc112d4d5fbd608624b65d226360516b"
+
 cozy-konnector-libs@^3.0.13:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-3.8.1.tgz#c4f9d6c2df742023897691c8d0e257a516ec00cd"


### PR DESCRIPTION
To remove cozy-client-js we should extract intent in a new lib.
This lib is cozy-interapp, we change instantiation to pass cozy-client