### PR TITLE
feat: Activate PouchDB only on mobile

### DIFF
--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -1,18 +1,20 @@
+/* global __TARGET__ */
+
 import { StackLink } from 'cozy-client'
 import PouchLink from 'cozy-pouch-link'
-import flag from 'cozy-flags'
 import { offlineDoctypes } from 'doctypes'
 
 export const getLinks = () => {
-  let links
+  const stackLink = new StackLink()
+  let links = [stackLink]
 
-  if (flag('pouch')) {
-    const stackLink = new StackLink()
+  if (__TARGET__ === 'mobile') {
     const pouchLink = new PouchLink({
       doctypes: offlineDoctypes,
       initialSync: true
     })
-    links = [pouchLink, stackLink]
+
+    links = [pouchLink, ...links]
   }
 
   return links


### PR DESCRIPTION
For now we activate it only on mobile. Maybe later we will use it on web too.