### PR TITLE
fix: Add fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "timezone": "^1.0.13",
     "velocity-animate": "^1.5.0",
     "webpack-bundle-analyzer": "^2.13.1",
+    "whatwg-fetch": "^3.0.0",
     "yarn.lock": "^0.0.1-security"
   },
   "jest": {
@@ -226,7 +227,7 @@
     "globals": {
       "__ALLOW_HTTP__": false,
       "__TARGET__": "browser",
-      "__DEVELOPMENT__": false,
+      "__DEV__": false,
       "__SENTRY_TOKEN__": "token",
       "cozy": {}
     },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,6 @@
 /* global cozy, __TARGET__ */
 
+import 'whatwg-fetch'
 import 'styles/main'
 
 import React from 'react'

--- a/yarn.lock
+++ b/yarn.lock
@@ -15259,6 +15259,10 @@ whatwg-fetch@>=0.10.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
 
+whatwg-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
+
 whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"


### PR DESCRIPTION
On browsers without `fetch`, it is necessary to add a polyfill.