### PR TITLE
chore(deps): Update cozy-flags to v1.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "cozy-client": "^2.13.1",
     "cozy-client-js": "0.12.1",
     "cozy-device-helper": "1.4.7",
-    "cozy-flags": "1.2.4",
+    "cozy-flags": "^1.2.5",
     "cozy-interapp": "0.2.3",
     "cozy-konnector-libs": "^3.0.13",
     "cozy-pouch-link": "^2.15.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3284,9 +3284,9 @@ cozy-device-helper@^1.4.4:
   dependencies:
     lodash "4.17.10"
 
-cozy-flags@1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.2.4.tgz#b5dbde7d0ef813c4bf9e6f3ff76a8c2def932257"
+cozy-flags@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.2.5.tgz#d6ece49bdc907a40efa3c014a4f997b70fbd5f0c"
 
 cozy-interapp@0.2.3:
   version "0.2.3"


### PR DESCRIPTION
This fixes the weird behavior where the balance history chart was shown then removed.