### PR TITLE
perf: Mv balance history computations to HistoryChart

### DIFF
--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -2,13 +2,21 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import * as d3 from 'd3'
-import { translate } from 'cozy-ui/react'
+import { translate, withBreakpoints } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
 import { sumBy } from 'lodash'
 import LineChart from 'components/Chart/LineChart'
 import styles from './History.styl'
 import palette from 'cozy-ui/stylus/settings/palette.json'
 import { format as formatDate } from 'date-fns'
+import historyData from 'ducks/balance/history_data.json'
+import { getBalanceHistories } from 'ducks/balance/helpers'
+import {
+  isBefore as isDateBefore,
+  isAfter as isDateAfter,
+  endOfToday,
+  subMonths
+} from 'date-fns'
 
 class History extends Component {
   getCurrentBalance() {
@@ -56,7 +64,36 @@ export class HistoryChart extends Component {
     )
   }
 
+  getBalanceHistory() {
+    const balanceHistories = getBalanceHistories(
+      historyData['io.cozy.bank.accounts'],
+      historyData['io.cozy.bank.operations']
+    )
+    const balanceHistory = this.sortBalanceHistoryByDate(balanceHistories.all)
+
+    return balanceHistory
+  }
+
+  getChartData() {
+    const history = this.getBalanceHistory()
+    const today = endOfToday()
+    const twoMonthsAgo = subMonths(today, 2)
+    const data = history.filter(
+      h => isDateBefore(h.x, today) && isDateAfter(h.x, twoMonthsAgo)
+    )
+
+    return data
+  }
+
   render() {
+    const data = this.getChartData()
+    const chartData = this.getChartData()
+    const chartNbTicks = chartData.length
+    const chartIntervalBetweenPoints = 10
+    const width = this.props.breakpoints.isMobile
+      ? chartNbTicks * chartIntervalBetweenPoints
+      : '100%'
+    const height = 72
     return (
       <div
         className={styles.HistoryChart}
@@ -74,15 +111,12 @@ export class HistoryChart extends Component {
             '0%': '#76b9f3',
             '100%': palette.dodgerBlue
           }}
-          margin={{
-            top: 20,
-            bottom: 10,
-            left: 16,
-            right: 16
-          }}
           pointFillColor="white"
           pointStrokeColor="rgba(255, 255, 255, 0.3)"
           getTooltipContent={this.getTooltipContent}
+          data={data}
+          width={width}
+          height={height}
           {...this.props}
         />
       </div>
@@ -90,4 +124,4 @@ export class HistoryChart extends Component {
   }
 }
 
-export default translate()(History)
+export default withBreakpoints()(translate()(History))

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -14,17 +14,11 @@ import {
   maxBy,
   sortBy
 } from 'lodash'
+import { parse as parseDate } from 'date-fns'
 import { getFilteredAccounts } from 'ducks/filters'
 import BarBalance from 'components/BarBalance'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import flag from 'cozy-flags'
-import {
-  isBefore as isDateBefore,
-  isAfter as isDateAfter,
-  endOfToday,
-  parse as parseDate,
-  subMonths
-} from 'date-fns'
 
 import {
   getTransactionsFilteredByAccount,
@@ -44,8 +38,6 @@ import { Breadcrumb } from 'components/Breadcrumb'
 import BackButton from 'components/BackButton'
 
 import { HistoryChart } from 'ducks/balance/History'
-import historyData from 'ducks/balance/history_data.json'
-import { getBalanceHistories } from 'ducks/balance/helpers'
 
 import { TransactionTableHead, TransactionsWithSelection } from './Transactions'
 import styles from './TransactionsPage.styl'
@@ -228,27 +220,6 @@ class TransactionsPage extends Component {
     return balanceHistory
   }
 
-  getBalanceHistory() {
-    const balanceHistories = getBalanceHistories(
-      historyData['io.cozy.bank.accounts'],
-      historyData['io.cozy.bank.operations']
-    )
-    const balanceHistory = this.sortBalanceHistoryByDate(balanceHistories.all)
-
-    return balanceHistory
-  }
-
-  getChartData() {
-    const history = this.getBalanceHistory()
-    const today = endOfToday()
-    const twoMonthsAgo = subMonths(today, 2)
-    const data = history.filter(
-      h => isDateBefore(h.x, today) && isDateAfter(h.x, twoMonthsAgo)
-    )
-
-    return data
-  }
-
   render() {
     const {
       t,
@@ -312,20 +283,11 @@ class TransactionsPage extends Component {
     const filteringOnAccount =
       filteringDoc && filteringDoc._type === ACCOUNT_DOCTYPE
 
-    const chartData = this.getChartData()
-    const chartNbTicks = chartData.length
-    const chartIntervalBetweenPoints = 10
-
     return (
       <div className={styles.TransactionPage} ref={node => (this.root = node)}>
         {subcategoryName ? <BackButton /> : null}
         {flag('balance-history') && (
           <HistoryChart
-            data={chartData}
-            width={
-              isMobile ? chartNbTicks * chartIntervalBetweenPoints : '100%'
-            }
-            height={72}
             margin={{
               top: 10,
               bottom: 10,


### PR DESCRIPTION
History calculation are done at each render of the transactions leading, to bad performance.

I will bring screeshots ;)