### PR TITLE
Get app slug from stack

### DIFF
--- a/src/ducks/mobile/utils.js
+++ b/src/ducks/mobile/utils.js
@@ -17,6 +17,7 @@ export const initBar = (url, accessToken, options = {}) => {
   cozy.bar.init({
     appName: 'Banks',
     appEditor: 'Cozy',
+    appSlug: 'banks',
     cozyURL: url,
     token: accessToken,
     iconPath: require('targets/favicons/icon-banks.svg'),

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -34,5 +34,6 @@
   data-cozy-icon-path="{{.IconPath}}"
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-app-name-prefix="{{.AppNamePrefix}}"
+  data-cozy-app-slug="{{.AppSlug}}"
   <% } %>
 >


### PR DESCRIPTION
Necessary to use the new cozy-bar navigation
and the home app detection