### PR TITLE
chore(deps): Update cozy-bar to v6.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "classnames": "^2.2.0",
     "cordova": "^7.1.0",
     "cozy-authentication": "1.3.0",
-    "cozy-bar": "^5.1.0",
+    "cozy-bar": "6.1.3",
     "cozy-client": "^2.20.1",
     "cozy-client-js": "0.12.1",
     "cozy-device-helper": "1.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,9 +3293,9 @@ cozy-authentication@1.3.0:
   dependencies:
     url-polyfill "1.0.11"
 
-cozy-bar@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-5.1.0.tgz#7c545237d67ea62cbd043edff9b0707b1525f958"
+cozy-bar@6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-6.1.3.tgz#0d349e059863e288ed3b8c9573babfa6a3581e96"
   dependencies:
     babel-preset-cozy-app "^0.3.1"
     core-js "^2.5.3"


### PR DESCRIPTION
We come from v5.1.0. So we must be careful if something breaks. According to the [changelog](https://github.com/cozy/cozy-bar/releases/tag/v6.0.0), we only need to use `name_prefix` in our manifest, which we alreaydy do (see https://github.com/cozy/cozy-banks/blob/master/manifest.webapp#L41).

Ping @CPatchane and @gregorylegarec can you have a look and tell us if we miss something ?