### PR TITLE
fix: Historychart error after refactor

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -31,10 +31,10 @@ import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 import History from './History'
 import historyData from './history_data.json'
-import { getBalanceHistories } from './helpers'
+import { getBalanceHistories, sortBalanceHistoryByDate } from './helpers'
 import { buildVirtualGroups } from 'ducks/groups/helpers'
 import sma from 'sma'
-import { parse as parseDate, format as formatDate } from 'date-fns'
+import { format as formatDate } from 'date-fns'
 
 import styles from './Balance.styl'
 import btnStyles from 'styles/buttons.styl'
@@ -283,23 +283,12 @@ class Balance extends React.Component {
     this.props.router.push('/transactions')
   }
 
-  sortBalanceHistoryByDate(history) {
-    const balanceHistory = sortBy(Object.entries(history), ([date]) => date)
-      .reverse()
-      .map(([date, balance]) => ({
-        x: parseDate(date),
-        y: balance
-      }))
-
-    return balanceHistory
-  }
-
   getBalanceHistory() {
     const balanceHistories = getBalanceHistories(
       historyData['io.cozy.bank.accounts'],
       historyData['io.cozy.bank.operations']
     )
-    const balanceHistory = this.sortBalanceHistoryByDate(balanceHistories.all)
+    const balanceHistory = sortBalanceHistoryByDate(balanceHistories.all)
 
     return balanceHistory
   }

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -1,22 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import * as d3 from 'd3'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
 import { sumBy } from 'lodash'
-import LineChart from 'components/Chart/LineChart'
 import styles from './History.styl'
-import palette from 'cozy-ui/stylus/settings/palette.json'
-import { format as formatDate } from 'date-fns'
-import historyData from 'ducks/balance/history_data.json'
-import { getBalanceHistories } from 'ducks/balance/helpers'
-import {
-  isBefore as isDateBefore,
-  isAfter as isDateAfter,
-  endOfToday,
-  subMonths
-} from 'date-fns'
+import HistoryChart from './HistoryChart'
 
 class History extends Component {
   getCurrentBalance() {
@@ -47,81 +36,6 @@ History.propTypes = {
   accounts: PropTypes.array.isRequired,
   chartProps: PropTypes.object,
   className: PropTypes.string
-}
-
-export class HistoryChart extends Component {
-  getTooltipContent = item => {
-    const date = formatDate(item.x, 'DD  MMM')
-    const balance = item.y.toFixed(2)
-
-    return (
-      <div>
-        {date}
-        <strong className={styles.HistoryChart__tooltipBalance}>
-          {balance}€
-        </strong>
-      </div>
-    )
-  }
-
-  getBalanceHistory() {
-    const balanceHistories = getBalanceHistories(
-      historyData['io.cozy.bank.accounts'],
-      historyData['io.cozy.bank.operations']
-    )
-    const balanceHistory = this.sortBalanceHistoryByDate(balanceHistories.all)
-
-    return balanceHistory
-  }
-
-  getChartData() {
-    const history = this.getBalanceHistory()
-    const today = endOfToday()
-    const twoMonthsAgo = subMonths(today, 2)
-    const data = history.filter(
-      h => isDateBefore(h.x, today) && isDateAfter(h.x, twoMonthsAgo)
-    )
-
-    return data
-  }
-
-  render() {
-    const data = this.getChartData()
-    const chartData = this.getChartData()
-    const chartNbTicks = chartData.length
-    const chartIntervalBetweenPoints = 10
-    const width = this.props.breakpoints.isMobile
-      ? chartNbTicks * chartIntervalBetweenPoints
-      : '100%'
-    const height = 72
-    return (
-      <div
-        className={styles.HistoryChart}
-        ref={node => (this.container = node)}
-      >
-        <LineChart
-          xScale={d3.scaleTime}
-          lineColor="white"
-          axisColor="white"
-          labelsColor="#a2c4f9"
-          onUpdate={() =>
-            this.container.scrollTo(this.container.scrollWidth, 0)
-          }
-          gradient={{
-            '0%': '#76b9f3',
-            '100%': palette.dodgerBlue
-          }}
-          pointFillColor="white"
-          pointStrokeColor="rgba(255, 255, 255, 0.3)"
-          getTooltipContent={this.getTooltipContent}
-          data={data}
-          width={width}
-          height={height}
-          {...this.props}
-        />
-      </div>
-    )
-  }
 }
 
 export default withBreakpoints()(translate()(History))

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -1,0 +1,95 @@
+import React, { Component } from 'react'
+import * as d3 from 'd3'
+import { withBreakpoints } from 'cozy-ui/react'
+import LineChart from 'components/Chart/LineChart'
+import styles from './History.styl'
+import palette from 'cozy-ui/stylus/settings/palette.json'
+import { format as formatDate } from 'date-fns'
+import historyData from 'ducks/balance/history_data.json'
+import {
+  getBalanceHistories,
+  sortBalanceHistoryByDate
+} from 'ducks/balance/helpers'
+import {
+  isBefore as isDateBefore,
+  isAfter as isDateAfter,
+  endOfToday,
+  subMonths
+} from 'date-fns'
+
+class HistoryChart extends Component {
+  getTooltipContent = item => {
+    const date = formatDate(item.x, 'DD  MMM')
+    const balance = item.y.toFixed(2)
+
+    return (
+      <div>
+        {date}
+        <strong className={styles.HistoryChart__tooltipBalance}>
+          {balance}€
+        </strong>
+      </div>
+    )
+  }
+
+  getBalanceHistory() {
+    const balanceHistories = getBalanceHistories(
+      historyData['io.cozy.bank.accounts'],
+      historyData['io.cozy.bank.operations']
+    )
+    const balanceHistory = sortBalanceHistoryByDate(balanceHistories.all)
+
+    return balanceHistory
+  }
+
+  getChartData() {
+    const history = this.getBalanceHistory()
+    const today = endOfToday()
+    const twoMonthsAgo = subMonths(today, 2)
+    const data = history.filter(
+      h => isDateBefore(h.x, today) && isDateAfter(h.x, twoMonthsAgo)
+    )
+
+    return data
+  }
+
+  render() {
+    const data = this.getChartData()
+    const chartData = this.getChartData()
+    const chartNbTicks = chartData.length
+    const chartIntervalBetweenPoints = 10
+    const width = this.props.breakpoints.isMobile
+      ? chartNbTicks * chartIntervalBetweenPoints
+      : '100%'
+    const height = 72
+    return (
+      <div
+        className={styles.HistoryChart}
+        ref={node => (this.container = node)}
+      >
+        <LineChart
+          xScale={d3.scaleTime}
+          lineColor="white"
+          axisColor="white"
+          labelsColor="#a2c4f9"
+          onUpdate={() =>
+            this.container.scrollTo(this.container.scrollWidth, 0)
+          }
+          gradient={{
+            '0%': '#76b9f3',
+            '100%': palette.dodgerBlue
+          }}
+          pointFillColor="white"
+          pointStrokeColor="rgba(255, 255, 255, 0.3)"
+          getTooltipContent={this.getTooltipContent}
+          data={data}
+          width={width}
+          height={height}
+          {...this.props}
+        />
+      </div>
+    )
+  }
+}
+
+export default withBreakpoints()(HistoryChart)

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -1,10 +1,11 @@
-import { flatten, groupBy, sumBy, uniq } from 'lodash'
+import { flatten, groupBy, sumBy, uniq, sortBy } from 'lodash'
 import {
   min as getEarliestDate,
   isAfter as isDateAfter,
   isEqual as isDateEqual,
   subDays,
   startOfToday,
+  parse as parseDate,
   format as formatDate
 } from 'date-fns'
 
@@ -76,4 +77,15 @@ const sumAllBalancesByDate = accountsBalances => {
   }
 
   return balances
+}
+
+export const sortBalanceHistoryByDate = history => {
+  const balanceHistory = sortBy(Object.entries(history), ([date]) => date)
+    .reverse()
+    .map(([date, balance]) => ({
+      x: parseDate(date),
+      y: balance
+    }))
+
+  return balanceHistory
 }

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -11,10 +11,8 @@ import {
   find,
   findLast,
   uniq,
-  maxBy,
-  sortBy
+  maxBy
 } from 'lodash'
-import { parse as parseDate } from 'date-fns'
 import { getFilteredAccounts } from 'ducks/filters'
 import BarBalance from 'components/BarBalance'
 import { translate, withBreakpoints } from 'cozy-ui/react'
@@ -37,7 +35,7 @@ import Loading from 'components/Loading'
 import { Breadcrumb } from 'components/Breadcrumb'
 import BackButton from 'components/BackButton'
 
-import { HistoryChart } from 'ducks/balance/History'
+import HistoryChart from 'ducks/balance/HistoryChart'
 
 import { TransactionTableHead, TransactionsWithSelection } from './Transactions'
 import styles from './TransactionsPage.styl'
@@ -207,17 +205,6 @@ class TransactionsPage extends Component {
     if (scrollInfo.scroll > SCROLL_THRESOLD_TO_ACTIVATE_TOP_INFINITE_SCROLL) {
       this.setState({ infiniteScrollTop: true })
     }
-  }
-
-  sortBalanceHistoryByDate(history) {
-    const balanceHistory = sortBy(Object.entries(history), ([date]) => date)
-      .reverse()
-      .map(([date, balance]) => ({
-        x: parseDate(date),
-        y: balance
-      }))
-
-    return balanceHistory
   }
 
   render() {


### PR DESCRIPTION
- extraction de la fonction `sortBalanceHistoryByDate` dans les helpers
- extraction du composant HistoryChart dans son fichier pour exporter correctement avec ses breakpoints