### PR TITLE
test: Update TransactionSelectDates snapshot

### DIFF
--- a/src/ducks/transactions/__snapshots__/TransactionSelectDates.spec.jsx.snap
+++ b/src/ducks/transactions/__snapshots__/TransactionSelectDates.spec.jsx.snap
@@ -4,6 +4,10 @@ exports[`options from select dates should compute correctly 1`] = `
 Array [
   Object {
     "disabled": true,
+    "yearMonth": "2018-10",
+  },
+  Object {
+    "disabled": true,
     "yearMonth": "2018-09",
   },
   Object {


### PR DESCRIPTION
We don't have enough time right now to see what we can do to avoid updating snapshot every months, but we should consider an action.