### PR TITLE
chore(deps): Update cozy-client to v3.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "cordova": "7.1.0",
     "cozy-authentication": "1.3.0",
     "cozy-bar": "6.1.3",
-    "cozy-client": "^3.4.0",
+    "cozy-client": "^3.6.4",
     "cozy-client-js": "0.12.1",
     "cozy-device-helper": "1.4.7",
     "cozy-flags": "1.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3883,18 +3883,6 @@ cozy-client-js@^0.8.0:
     pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
     pouchdb-find "0.10.4"
 
-cozy-client@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-3.4.0.tgz#f78d15886adca60a578ee4a201c33751b2d6ad5c"
-  integrity sha512-kME5twc4AMTj+yTynuLe2yiezixsgmk0DVLUKS2b4KF5mfX0Hge3nj676NlcZ0DoR5SkSSm97b2XWryXQKaTxQ==
-  dependencies:
-    cozy-stack-client "^3.4.0"
-    lodash "4.17.11"
-    prop-types "15.6.2"
-    react "16.4.2"
-    react-redux "5.0.7"
-    redux "3.7.2"
-
 cozy-client@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-3.6.1.tgz#68a3b7f4035d4a4ddb6d0acc51b1047af0ecb871"
@@ -3907,6 +3895,19 @@ cozy-client@^3.6.1:
     react-redux "5.0.7"
     redux "3.7.2"
     sift "^7.0.1"
+
+cozy-client@^3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-3.6.4.tgz#6d77045d4af51336ec968a2c886123ae251a7b16"
+  integrity sha512-Gu8liXK7JbHTlx9VRyt9pHdv7JsTZ0pn56rzn2sm2zkzQvfnR3565DIlyJouMDqLGyTT8Bfd+ngS5SwNmDW1IQ==
+  dependencies:
+    cozy-stack-client "^3.4.0"
+    lodash "4.17.11"
+    prop-types "15.6.2"
+    react "16.4.2"
+    react-redux "5.0.7"
+    redux "3.7.2"
+    sift "7.0.1"
 
 cozy-device-helper@1.4.7:
   version "1.4.7"
@@ -15655,7 +15656,7 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-sift@^7.0.1:
+sift@7.0.1, sift@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/sift/-/sift-7.0.1.tgz#47d62c50b159d316f1372f8b53f9c10cd21a4b08"
   integrity sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g==


### PR DESCRIPTION
This fixes `cannot index document as it has no id` errors