### PR TITLE
fix(InfiniteScroll): Remove listener on unmount

### DIFF
--- a/src/ducks/transactions/scroll/InfiniteScroll.jsx
+++ b/src/ducks/transactions/scroll/InfiniteScroll.jsx
@@ -40,6 +40,7 @@ class InfiniteScroll extends React.Component {
 
   componentWillUnmount() {
     this.stopListeningToScroll()
+    window.removeEventListener('resize', this.onWindowResize)
     this.unmounted = true
   }
 


### PR DESCRIPTION
Everything was properly cleaned except the listener on window resize.