### PR TITLE
fix(GroupSettings): Wrong toggle state

### DIFF
--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -72,7 +72,7 @@ class GroupSettings extends Component {
           {group ? (
             <Toggle
               id={account._id}
-              checked={group.accounts.existsById(account)}
+              checked={group.accounts.existsById(account._id)}
               onToggle={this.toggleAccount.bind(null, account._id, group)}
             />
           ) : (

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PureComponent } from 'react'
 import { withRouter } from 'react-router'
 import { sortBy, flowRight as compose } from 'lodash'
 import { Query, withMutations, withClient } from 'cozy-client'
@@ -21,7 +21,72 @@ const makeNewGroup = (client, t) => {
   return obj
 }
 
-class GroupSettings extends Component {
+export class AccountLine extends PureComponent {
+  render() {
+    const { account, group, toggleAccount } = this.props
+
+    return (
+      <tr>
+        <td className={styles.GrpStg__accntLabel}>
+          {account.shortLabel || account.label}
+        </td>
+        <td className={styles.GrpStg__accntBank}>
+          {getAccountInstitutionLabel(account)}
+        </td>
+        <td className={styles.GrpStg__accntNumber}>{account.number}</td>
+        <td className={styles.GrpStg__accntToggle}>
+          {group ? (
+            <Toggle
+              id={account._id}
+              checked={group.accounts.existsById(account._id)}
+              onToggle={toggleAccount.bind(null, account._id, group)}
+            />
+          ) : (
+            <Toggle id={account._id} disabled />
+          )}
+        </td>
+      </tr>
+    )
+  }
+}
+
+class _AccountsList extends PureComponent {
+  render() {
+    const { accounts, group, t, toggleAccount } = this.props
+
+    return (
+      <Table className={styles.GrpStg__table}>
+        <thead>
+          <tr>
+            <th className={styles.GrpStg__accntLabel}>{t('Groups.label')}</th>
+            <th className={styles.GrpStg__accntBank}>{t('Groups.bank')}</th>
+            <th className={styles.GrpStg__accntNumber}>
+              {t('Groups.account-number')}
+            </th>
+            <th className={styles.GrpStg__accntToggle}>
+              {t('Groups.included')}
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {accounts &&
+            sortBy(accounts, ['institutionLabel', 'label']).map(account => (
+              <AccountLine
+                account={account}
+                group={group}
+                toggleAccount={toggleAccount}
+                key={account._id}
+              />
+            ))}
+        </tbody>
+      </Table>
+    )
+  }
+}
+
+const AccountsList = translate()(_AccountsList)
+
+class DumbGroupSettings extends Component {
   state = { modifying: false, saving: false }
   rename = () => {
     const { group } = this.props
@@ -152,30 +217,11 @@ class GroupSettings extends Component {
             }
 
             return (
-              <Table className={styles.GrpStg__table}>
-                <thead>
-                  <tr>
-                    <th className={styles.GrpStg__accntLabel}>
-                      {t('Groups.label')}
-                    </th>
-                    <th className={styles.GrpStg__accntBank}>
-                      {t('Groups.bank')}
-                    </th>
-                    <th className={styles.GrpStg__accntNumber}>
-                      {t('Groups.account-number')}
-                    </th>
-                    <th className={styles.GrpStg__accntToggle}>
-                      {t('Groups.included')}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {accounts &&
-                    sortBy(accounts, ['institutionLabel', 'label']).map(
-                      account => this.renderAccountLine(account, group)
-                    )}
-                </tbody>
-              </Table>
+              <AccountsList
+                accounts={accounts}
+                group={group}
+                toggleAccount={this.toggleAccount}
+              />
             )
           }}
         </Query>
@@ -189,8 +235,9 @@ class GroupSettings extends Component {
   }
 }
 
-const enhance = Component =>
-  compose(translate(), withRouter, withClient)(Component)
+export const GroupSettings = translate()(DumbGroupSettings)
+
+const enhance = Component => compose(withRouter, withClient)(Component)
 
 const ExistingGroupSettings = enhance(props => (
   <Query query={client => client.get(GROUP_DOCTYPE, props.routeParams.groupId)}>

--- a/src/ducks/settings/GroupSettings.spec.js
+++ b/src/ducks/settings/GroupSettings.spec.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { AccountLine } from './GroupSettings'
+import { Toggle } from 'cozy-ui/react'
+import { mount } from 'enzyme'
+import AppLike from 'test/AppLike'
+import fixtures from 'test/fixtures/operations-merged.json'
+import { keyBy } from 'lodash'
+
+describe('GroupSettings', () => {
+  it('Should call existsById with an id when rendering an account line', () => {
+    const group = fixtures['io.cozy.bank.groups'][0]
+    const accountsById = keyBy(fixtures['io.cozy.bank.accounts'], '_id')
+    const existsById = jest.fn()
+    group.accounts = {
+      data: group.accounts.map(accountId => accountsById[accountId]),
+      existsById
+    }
+    const account = fixtures['io.cozy.bank.accounts'][0]
+    const toggleAccount = jest.fn()
+
+    const root = mount(
+      <AppLike>
+        <AccountLine
+          account={account}
+          group={group}
+          toggleAccount={toggleAccount}
+        />
+      </AppLike>
+    )
+
+    const toggles = root.find(Toggle)
+    toggles.at(0).simulate('click')
+
+    expect(existsById).toHaveBeenCalledWith(account._id)
+  })
+})

--- a/test/fixtures/operations-merged.json
+++ b/test/fixtures/operations-merged.json
@@ -147,8 +147,7 @@
         "comptegene1"
       ],
       "id": "f1d11eb324b64d604cbeee734e77de66",
-      "label": "Famille élargie",
-      "type": "io.cozy.bank.groups"
+      "label": "Famille élargie"
     },
     {
       "_id": "b3e33d6cc334ed5ef49738a2be2880a2",


### PR DESCRIPTION
We were not passing an id to `existsById`, thus the account was never found in the collection and the toggle never checked.