### PR TITLE
fix: Bad balance for virtual groups on transactions page

### DIFF
--- a/src/ducks/client/utils.js
+++ b/src/ducks/client/utils.js
@@ -12,13 +12,16 @@ export const associateDocuments = (
   associationDoctype,
   documentsToAssociate
 ) => {
+  const ids = documentsToAssociate.map(doc => doc.id)
+
   originalDocument[associationName] = {
     data: documentsToAssociate,
     doctype: associationDoctype,
     name: associationName,
+    raw: ids,
     target: {
       ...originalDocument,
-      [associationName]: documentsToAssociate.map(doc => doc.id)
+      [associationName]: ids
     }
   }
 


### PR DESCRIPTION
The virtual groups didn't have a `raw` property, so we were returning all accounts instead of accounts associated to the selected virtual group.