### PR TITLE
chore: Remove duplicated name_prefix in manifest

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -39,7 +39,6 @@
     }
   ],
   "editor": "Cozy",
-  "name_prefix": "Cozy",
   "screenshots": [
     "screenshot1.png",
     "screenshot2.png",


### PR DESCRIPTION
We had this property twice in our manifest.