### PR TITLE
feat: Add pouch on web to develop easily

### DIFF
--- a/config/webpack.target.browser.js
+++ b/config/webpack.target.browser.js
@@ -15,7 +15,8 @@ module.exports = {
   },
   plugins: [
     new webpack.DefinePlugin({
-      __TARGET__: JSON.stringify('browser')
+      __TARGET__: JSON.stringify('browser'),
+      __POUCH__: JSON.stringify(process.env.FORCE_POUCH ? true : false)
     }),
     new HtmlWebpackPlugin({
       alwaysWriteToDisk: true,

--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -27,6 +27,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __ALLOW_HTTP__: !production,
       __TARGET__: JSON.stringify('mobile'),
+      __POUCH__: JSON.stringify(true)
     }),
     new webpack.ProvidePlugin({
       PouchDB: 'pouchdb',

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -22,6 +22,7 @@
     - [Debug notification triggers](#debug-notification-triggers)
     - [When creating a notification](#when-creating-a-notification)
     - [Misc](#misc)
+- [Pouch On Web](#pouch-on-web)
 
 <!-- /MarkdownTOC -->
 
@@ -242,6 +243,29 @@ ACH import test/fixtures/operations-notifs.json test/fixtures/helpers.js --url <
 
 🖼 The PNG icons that are included in the emails are generated manually from the SVG via `scripts/icons-to-png.sh` and uploaded automatically to files.cozycloud.cc via Jenkins (which follows the file `files.cozycloud.cc` at the root of the repo).
 
+## Pouch On Web
+
+If you want activate Pouch on web app, you need:
+- a token
+- launch your build with `FORCE_POUCH`
+
+```
+cozy-stack instances token-cli cozy.tools:8080 $(cat manifest.webapp | jq -r '[.permissions[] | .type] | join(" ")')
+env FORCE_POUCH=true yarn watch
+```
+
+Launch your web application and in console javascript fill in the token and refresh the page:
+
+```
+flag('cozyToken', <your token>)
+```
+
+Now you can play with replication:
+
+```
+cozyClient.links[0].startReplication()
+cozyClient.links[0].stopReplication()
+```
 
 [pass]: https://www.passwordstore.org/
 [ACH]: https://github.com/cozy/ACH

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
       "__ALLOW_HTTP__": false,
       "__TARGET__": "browser",
       "__DEV__": false,
+      "__POUCH__": false,
       "__SENTRY_TOKEN__": "token",
       "cozy": {}
     },

--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -1,10 +1,10 @@
-/* global __TARGET__ */
+/* global __POUCH__ */
 
 import { StackLink } from 'cozy-client'
 import { offlineDoctypes } from 'doctypes'
 
 let PouchLink
-if (__TARGET__ == 'mobile') {
+if (__POUCH__) {
   PouchLink = require('cozy-pouch-link').default
 }
 
@@ -26,7 +26,7 @@ export const getLinks = () => {
   const stackLink = new StackLink()
   links = [stackLink]
 
-  if (__TARGET__ === 'mobile') {
+  if (__POUCH__) {
     const pouchLink = setupPouchLink()
     links = [pouchLink, ...links]
   }


### PR DESCRIPTION
## Pouch On Web

If you want activate Pouch on web app, you need:
- a token
- launch your build with `FORCE_POUCH`

```
cozy-stack instances token-cli cozy.tools:8080 $(cat manifest.webapp | jq -r '[.permissions[] | .type] | join(" ")')
env FORCE_POUCH=true yarn watch
```

Launch your web application and in console javascript fill in the token and refresh the page:

```
flag('cozyToken', <your token>)
```

Now you can play with replication:

```
cozyClient.links[0].startReplication()
cozyClient.links[0].stopReplication()
```