### PR TITLE
feat: Use local categorization model result

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -16,7 +16,21 @@ const makeSubcategory = catId => ({
 })
 
 export const getCategoryId = transaction => {
-  return transaction.manualCategoryId || transaction.automaticCategoryId
+  if (transaction.manualCategoryId) {
+    return transaction.manualCategoryId
+  }
+
+  const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
+
+  if (
+    transaction.localCategoryId &&
+    transaction.localCategoryProba &&
+    transaction.localCategoryProba > LOCAL_MODEL_USAGE_THRESHOLD
+  ) {
+    return transaction.localCategoryId
+  }
+
+  return transaction.automaticCategoryId
 }
 
 export const getParentCategory = transaction => {

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -1,0 +1,42 @@
+import { getCategoryId } from './helpers'
+
+describe('getCategoryId', () => {
+  it("Should return the manualCategoryId if there's one", () => {
+    const transaction = {
+      manualCategoryId: '200110',
+      automaticCategoryId: '200120',
+      localCategoryId: '200130',
+      localCategoryProba: 0.9
+    }
+
+    expect(getCategoryId(transaction)).toBe(transaction.manualCategoryId)
+  })
+
+  it("Should return the localCategoryId if there's no manualCategoryId and localCategoryProba is higher than the threshold", () => {
+    const transaction = {
+      automaticCategoryId: '200120',
+      localCategoryId: '200130',
+      localCategoryProba: 0.9
+    }
+
+    expect(getCategoryId(transaction)).toBe(transaction.localCategoryId)
+  })
+
+  it('Should return the automaticCategoryId if the localCategoryProba is lower than the threshold', () => {
+    const transaction = {
+      automaticCategoryId: '200120',
+      localCategoryId: '200130',
+      localCategoryProba: 0.5
+    }
+
+    expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
+  })
+
+  it("Should return the automaticCategoryId if there's neither manualCategoryId nor automaticCategoryId", () => {
+    const transaction = {
+      automaticCategoryId: '200120'
+    }
+
+    expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
+  })
+})


### PR DESCRIPTION
The local categorization model is doing its work in the service for a while in production now. This PR intends to use the result of this model and show its result to the user. For the user, it means that his transactions are now categorized automatically based on his manual categorization habits.

The rules are the following:

* If there's a manual category, use it
* If there's no manual category, but there's a local category and the probability of this category is higher than a threshold (defined at `0.8`), then use it
* If there's no manual category, but there's a local category but its probability is lower than the threshold, use the automatic category
* If there's neither manual category not local category, use the automatic category