### PR TITLE
Track local categorization model usage

### DIFF
--- a/src/ducks/billsMatching/Linker/Linker.spec.js
+++ b/src/ducks/billsMatching/Linker/Linker.spec.js
@@ -1,4 +1,5 @@
 jest.mock('cozy-konnector-libs')
+jest.mock('../../tracking')
 
 import Linker from './Linker'
 import { cozyClient } from 'cozy-konnector-libs'

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -15,12 +15,12 @@ const makeSubcategory = catId => ({
   transactions: []
 })
 
+export const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
+
 export const getCategoryId = transaction => {
   if (transaction.manualCategoryId) {
     return transaction.manualCategoryId
   }
-
-  const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
 
   if (
     transaction.localCategoryId &&

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -146,6 +146,7 @@ const localModel = async (classifierOptions, transactions) => {
       'info',
       'No classifier, impossible to categorize transactions'
     )
+    return
   }
 
   for (const transaction of transactions) {

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -1,9 +1,13 @@
-import { cozyClient, log } from 'cozy-konnector-libs'
+import { cozyClient } from 'cozy-konnector-libs'
+import logger from 'cozy-logger'
 import { maxBy, pick } from 'lodash'
 import { tokenizer, createClassifier } from '.'
 import bayes from 'classificator'
 import { getLabel } from 'ducks/transactions/helpers'
 import { TRANSACTION_DOCTYPE } from 'doctypes'
+
+const localModelLog = logger.namespace('local-categorization-model')
+const globalModelLog = logger.namespace('global-categorization-model')
 
 export const PARAMETERS_NOT_FOUND = 'Classifier files is not configured.'
 
@@ -25,37 +29,29 @@ const createLocalClassifier = async () => {
     return transactions
   }
 
-  log(
-    'info',
-    '[Local categorization model] Fetching manually categorized transactions'
-  )
+  localModelLog('info', 'Fetching manually categorized transactions')
   const index = await cozyClient.data.defineIndex(TRANSACTION_DOCTYPE, [
     'manualCategoryId'
   ])
   const transactions = await getTransWithManualCat([], index, 100)
-  log(
+  localModelLog(
     'info',
-    `[Local categorization model] Fetched ${
-      transactions.length
-    } manually categorized transactions`
+    `Fetched ${transactions.length} manually categorized transactions`
   )
 
   if (transactions.length === 0) {
-    log(
+    localModelLog(
       'info',
-      '[Local categorization model] Impossible to instanciate a classifier since there is no manually categorized transactions to learn from'
+      'Impossible to instanciate a classifier since there is no manually categorized transactions to learn from'
     )
     return null
   }
 
-  log('info', '[Local categorization model] Instanciating a fresh classifier')
+  localModelLog('info', 'Instanciating a fresh classifier')
   const options = { tokenizer, alpha: 0.1 }
   const classifier = bayes(options)
 
-  log(
-    'info',
-    '[Local categorization model] Learning from manually categorized transactions'
-  )
+  localModelLog('info', 'Learning from manually categorized transactions')
   for (const transaction of transactions) {
     classifier.learn(
       getLabelWithTags(transaction),
@@ -109,29 +105,23 @@ const getLabelWithTags = transaction => {
 }
 
 const globalModel = async (classifierOptions, transactions) => {
-  log(
-    'info',
-    '[Global categorization model] Fetching parameters from the stack'
-  )
+  globalModelLog('info', 'Fetching parameters from the stack')
   let parameters
 
   try {
     parameters = await getParameters()
-    log(
-      'info',
-      '[Global categorization model] Successfully fetched parameters from the stack'
-    )
+    globalModelLog('info', 'Successfully fetched parameters from the stack')
   } catch (e) {
-    log('info', `[Global model] ${e}`)
+    globalModelLog('info', e)
     return
   }
 
-  log('info', '[Global categorization model] Instanciating a new classifier')
+  globalModelLog('info', 'Instanciating a new classifier')
   const classifier = createClassifier(parameters, classifierOptions)
 
   for (const transaction of transactions) {
     const label = getLabelWithTags(transaction)
-    log('info', `[Global categorization model] Applying model to ${label}`)
+    globalModelLog('info', `Applying model to ${label}`)
 
     const { category, proba } = maxBy(
       classifier.categorize(label).likelihoods,
@@ -141,26 +131,26 @@ const globalModel = async (classifierOptions, transactions) => {
     transaction.cozyCategoryId = category
     transaction.cozyCategoryProba = proba
 
-    log('info', `[Global categorization model] Results for ${label} :`)
-    log('info', `[Global categorization model] cozyCategory: ${category}`)
-    log('info', `[Global categorization model] cozyProba: ${proba}`)
+    globalModelLog('info', `Results for ${label} :`)
+    globalModelLog('info', `cozyCategory: ${category}`)
+    globalModelLog('info', `cozyProba: ${proba}`)
   }
 }
 
 const localModel = async (classifierOptions, transactions) => {
-  log('info', '[Local categorization model] Instanciating a new classifier')
+  localModelLog('info', 'Instanciating a new classifier')
   const classifier = await createLocalClassifier()
 
   if (!classifier) {
-    log(
+    localModelLog(
       'info',
-      '[Local categorization model] No classifier, impossible to categorize transactions'
+      'No classifier, impossible to categorize transactions'
     )
   }
 
   for (const transaction of transactions) {
     const label = getLabelWithTags(transaction)
-    log('info', `[Local categorization model] Applying model to ${label}`)
+    localModelLog('info', `Applying model to ${label}`)
 
     const { category, proba } = maxBy(
       classifier.categorize(label).likelihoods,
@@ -170,9 +160,9 @@ const localModel = async (classifierOptions, transactions) => {
     transaction.localCategoryId = category
     transaction.localCategoryProba = proba
 
-    log('info', `[Local categorization model] Results for ${label} :`)
-    log('info', `[Local categorization model] localCategory: ${category}`)
-    log('info', `[Local categorization model] localProba: ${proba}`)
+    localModelLog('info', `Results for ${label} :`)
+    localModelLog('info', `localCategory: ${category}`)
+    localModelLog('info', `localProba: ${proba}`)
   }
 }
 
@@ -188,6 +178,8 @@ export const categorizes = async transactions => {
 }
 
 export const sendTransactions = async transactions => {
+  const log = logger.namespace('categorization-send-transactions')
+
   const transactionsToSend = transactions.map(transaction =>
     pick(transaction, [
       'amount',

--- a/src/ducks/tracking/__mocks__/index.js
+++ b/src/ducks/tracking/__mocks__/index.js
@@ -1,0 +1,5 @@
+export function getTracker() {
+  return {
+    trackEvent: jest.fn()
+  }
+}

--- a/src/ducks/tracking/index.js
+++ b/src/ducks/tracking/index.js
@@ -43,10 +43,5 @@ class NodeTracker {
 }
 
 export function getTracker(target, opts = {}) {
-  switch (target) {
-    case 'services':
-      return new NodeTracker(opts)
-    default:
-      return
-  }
+  return new NodeTracker(opts)
 }


### PR DESCRIPTION
We want to know the number of transactions that uses the local categorization model (eg how many have a `localCategoryProba` higher than the usage threshold (0.8 for now)). So everytime we apply the local model to some operations, we send an event to Matomo with the number of transaction that satisfy this condition.

To achieve this goal, I refactored the current tracking code. The idea is to have a `getTracker` function that returns the right tracker according to the target it gets passed. For services (NodeJS) we want to use a specific tracker. For others targets (web), we don't to anything for now but we will certainly want to use the tracker from cozy-ui. So for now I only added a `NodeTracker` that uses `matomo-tracker` under the hood.