### PR TITLE
fix: Don't use color var in stylus func

### DIFF
--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -24,15 +24,15 @@
     .Balance__row
         &:active
         &:focus
-            background alpha(dodgerBlue, 0.1)
+            background zircon
 
 .Balance__row--selected
     border-left 0.25rem dodgerBlue solid
-    background alpha(dodgerBlue, 0.1)
+    background zircon
 
 .Balance__row--selected-account-from-group
     border-left 0.25rem #cdced2 solid
-    background alpha(silver, 0.1)
+    background paleGrey
 
 .Balance__account_name
     maxed-flex-basis 25%


### PR DESCRIPTION
Some cleaning in preparation for a future [release of Cozy-UI](https://github.com/cozy/cozy-ui/pull/641) with color variables as CSS custom properties.

We can't have custom properties in Stylus functions, it just breaks.
Most of `alpha()` color actually need ligter colors, not transparency. I think that was the case and that should do it.

Correct me if I'm wrong.

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/1606068/48472089-bc7b4880-e7f5-11e8-96eb-84c5de6364bc.png)|![image](https://user-images.githubusercontent.com/1606068/48472111-ca30ce00-e7f5-11e8-8128-735c24b7cb60.png)|

