### PR TITLE
feat: Disable local categorization model

### DIFF
--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -141,6 +141,8 @@ const globalModel = async (classifierOptions, transactions) => {
   }
 }
 
+// The local model is disabled for now because we found an issue with it
+// eslint-disable-next-line no-unused-vars
 const localModel = async (classifierOptions, transactions) => {
   localModelLog('info', 'Instanciating a new classifier')
   const classifier = await createLocalClassifier()
@@ -192,8 +194,8 @@ export const categorizes = async transactions => {
   const classifierOptions = { tokenizer }
 
   await Promise.all([
-    globalModel(classifierOptions, transactions),
-    localModel(classifierOptions, transactions)
+    globalModel(classifierOptions, transactions)
+    // localModel(classifierOptions, transactions)
   ])
 
   return transactions


### PR DESCRIPTION
We found a bug in the model this morning. Since we want to release as soon as possible, our best solution is to disable the model until François find how to fix the issue.

For information, the issue occurs when there are very few manually categorized transactions on the instance. In that case, the model applies wrong categories with a high probability to a lot of unrelated transactions.

We also have another bug: not only new transactions get the model applied to them.