### PR TITLE
feat(mobile): Wait for client to be resetted before redirect on logout

### DIFF
--- a/src/ducks/mobile/utils.js
+++ b/src/ducks/mobile/utils.js
@@ -2,14 +2,14 @@
 const getLang = () =>
   navigator && navigator.language ? navigator.language.slice(0, 2) : 'en'
 
-export function resetClient(cozyClient) {
+export async function resetClient(cozyClient) {
+  if (cozyClient) {
+    await cozyClient.logout()
+  }
+
   // reset cozy-bar
   if (document.getElementById('coz-bar')) {
     document.getElementById('coz-bar').remove()
-  }
-
-  if (cozyClient) {
-    cozyClient.logout()
   }
 }
 


### PR DESCRIPTION
Currently we redirect the user to the login page as soon as he clicks on the "logout" button. But the process of destroying PouchDB databases can take several seconds. So it's safer to wait for the dbs to be destroyed before redirecting the user.