### PR TITLE
fix: Autoreload data on onboarding

### DIFF
--- a/src/ducks/onboarding/EnsureHasAccounts.jsx
+++ b/src/ducks/onboarding/EnsureHasAccounts.jsx
@@ -25,10 +25,37 @@ const LayoutContent = props => (
   </Layout>
 )
 
+export function EnsureHasAccountsView(props) {
+  const { children, accounts, location } = props
+
+  if (isCollectionLoading(accounts)) {
+    return (
+      <LayoutContent>
+        <div className={styles.Onboarding__loading}>
+          <Loading />
+        </div>
+      </LayoutContent>
+    )
+  }
+
+  if (
+    (accounts && accounts.data && accounts.data.length === 0) ||
+    (location && hasParameter(location.query, 'onboarding'))
+  ) {
+    return (
+      <LayoutContent>
+        <Onboarding />
+      </LayoutContent>
+    )
+  }
+
+  return children
+}
+
 /**
  * Replaces its children by Onboarding if we have no accounts
  */
-class EnsureHasAccounts extends Component {
+export class EnsureHasAccounts extends Component {
   intervalId = false
 
   startInterval = () => {
@@ -48,7 +75,7 @@ class EnsureHasAccounts extends Component {
     }
   }
 
-  fetchAccounts = () => {
+  fetchAccounts() {
     const client = getClient()
     if (!client) {
       return
@@ -81,30 +108,11 @@ class EnsureHasAccounts extends Component {
   }
 
   render() {
-    const { children, accounts, location } = this.props
-
-    if (isCollectionLoading(accounts)) {
-      return (
-        <LayoutContent>
-          <div className={styles.Onboarding__loading}>
-            <Loading />
-          </div>
-        </LayoutContent>
-      )
-    }
-
-    if (
-      (accounts && accounts.data && accounts.data.length === 0) ||
-      hasParameter(location.query, 'onboarding')
-    ) {
-      return (
-        <LayoutContent>
-          <Onboarding />
-        </LayoutContent>
-      )
-    }
-
-    return children
+    return (
+      <EnsureHasAccountsView accounts={this.props.accounts} location={this.props.location}>
+        {this.props.children}
+      </EnsureHasAccountsView>
+    )
   }
 }
 

--- a/src/ducks/onboarding/EnsureHasAccounts.jsx
+++ b/src/ducks/onboarding/EnsureHasAccounts.jsx
@@ -33,8 +33,18 @@ class EnsureHasAccounts extends Component {
 
   startInterval = () => {
     const { accounts } = this.props
-    if (accounts && accounts.length === 0 && !this.intervalId) {
-      this.intervalId = setInterval(() => this.fetchAccounts(), 30000)
+    const shouldStartInterval =
+      accounts &&
+      accounts.data &&
+      accounts.data.length === 0 &&
+      !this.intervalId
+
+    if (shouldStartInterval) {
+      const INTERVAL_DURATION = 30000
+      this.intervalId = setInterval(
+        () => this.fetchAccounts(),
+        INTERVAL_DURATION
+      )
     }
   }
 
@@ -43,7 +53,7 @@ class EnsureHasAccounts extends Component {
     if (!client) {
       return
     }
-    client.query(accountsConn.query)
+    client.query(accountsConn.query(client), { as: accountsConn.as })
   }
 
   stopInterval = () => {
@@ -59,7 +69,7 @@ class EnsureHasAccounts extends Component {
 
   componentDidUpdate() {
     const { accounts } = this.props
-    if (accounts.length === 0) {
+    if (accounts.data.length === 0) {
       this.startInterval()
     } else {
       this.stopInterval()

--- a/src/ducks/onboarding/EnsureHasAccounts.spec.jsx
+++ b/src/ducks/onboarding/EnsureHasAccounts.spec.jsx
@@ -1,0 +1,130 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import AppLike from 'test/AppLike'
+import { EnsureHasAccounts, EnsureHasAccountsView } from './EnsureHasAccounts'
+import Loading from 'components/Loading'
+import Onboarding from './Onboarding'
+
+jest.useFakeTimers()
+
+describe('EnsureHasAccountsView', () => {
+  const children = () => 'test'
+
+  it('Should show a loader if accounts are loading', () => {
+    const accounts = {
+      fetchStatus: 'loading'
+    }
+
+    const root = mount(
+      <AppLike>
+        <EnsureHasAccountsView accounts={accounts}>
+          {children()}
+        </EnsureHasAccountsView>
+      </AppLike>
+    )
+
+    const loader = root.find(Loading).get(0)
+    expect(loader).toBeDefined()
+  })
+
+  it('Should show the onboarding if there is no account', () => {
+    const accounts = {
+      fetchStatus: 'loaded',
+      data: []
+    }
+
+    const root = mount(
+      <AppLike>
+        <EnsureHasAccountsView accounts={accounts}>
+          {children()}
+        </EnsureHasAccountsView>
+      </AppLike>
+    )
+
+    const onboarding = root.find(Onboarding).get(0)
+    expect(onboarding).toBeDefined()
+  })
+
+  it('Should show its children if there are some accounts', () => {
+    const children = jest.fn().mockReturnValue('test')
+    const accounts = {
+      fetchStatus: 'loaded',
+      data: [{ _id: 'test' }]
+    }
+
+    mount(
+      <AppLike>
+        <EnsureHasAccountsView accounts={accounts}>
+          {children()}
+        </EnsureHasAccountsView>
+      </AppLike>
+    )
+
+    expect(children).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('EnsureHasAccounts', () => {
+  let root
+
+  beforeEach(() => {
+    jest
+      .spyOn(EnsureHasAccounts.prototype, 'fetchAccounts')
+      .mockImplementation(() => {})
+
+    const accounts = {
+      fetchStatus: 'loaded',
+      data: []
+    }
+
+    root = mount(
+      <AppLike>
+        <EnsureHasAccounts accounts={accounts} />
+      </AppLike>
+    )
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('Should start the interval', () => {
+    const component = root
+      .find(EnsureHasAccounts)
+      .first()
+      .instance()
+
+    expect(component.intervalId).toBeTruthy()
+  })
+
+  it('Should run the accounts query on each interval tick', () => {
+    const component = root
+      .find(EnsureHasAccounts)
+      .first()
+      .instance()
+
+    jest.advanceTimersByTime(60000)
+
+    expect(component.fetchAccounts).toHaveBeenCalledTimes(2)
+  })
+
+  it('Should not start the interval if there are accounts', () => {
+    const accounts = {
+      fetchStatus: 'loaded',
+      data: [{ _id: 'test' }]
+    }
+
+    const root = mount(
+      <AppLike>
+        <EnsureHasAccounts accounts={accounts}>test</EnsureHasAccounts>
+      </AppLike>
+    )
+
+    const component = root
+      .find(EnsureHasAccounts)
+      .first()
+      .instance()
+
+    expect(component.intervalId).toBe(false)
+  })
+})


### PR DESCRIPTION
The auto-refresh of the onboarding when there is no data but some triggers may be running was broken.