### PR TITLE
Show a modal during logout

### DIFF
--- a/src/components/LogoutModal/LogoutModal.jsx
+++ b/src/components/LogoutModal/LogoutModal.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Modal, { ModalDescription } from 'cozy-ui/react/Modal'
+import Spinner from 'cozy-ui/react/Spinner'
+import { translate } from 'cozy-ui/react/I18n'
+import styles from './LogoutModal.styl'
+
+function LogoutModal(props) {
+  const { t } = props
+
+  return (
+    <Modal
+      into="#logout-modal"
+      mobileFullscreen
+      closable={false}
+      containerClassName={styles.LogoutModal}
+    >
+      <ModalDescription className={styles.LogoutModal__description}>
+        <Spinner size="xxlarge" />
+        <p>{t('LogoutModal.message')}</p>
+      </ModalDescription>
+    </Modal>
+  )
+}
+
+export default translate()(LogoutModal)

--- a/src/components/LogoutModal/LogoutModal.styl
+++ b/src/components/LogoutModal/LogoutModal.styl
@@ -1,0 +1,6 @@
+.LogoutModal__description
+    height 100%
+    display flex
+    flex-direction column
+    justify-content center
+    align-items center

--- a/src/components/LogoutModal/index.js
+++ b/src/components/LogoutModal/index.js
@@ -1,0 +1,5 @@
+import LogoutModal from './LogoutModal'
+
+export { LogoutModal }
+
+export default LogoutModal

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -37,4 +37,7 @@
   data-cozy-tracking="{{.Tracking}}"
   data-cozy-app-slug="{{.AppSlug}}"
   <% } %>
->
+></div>
+<% if (__TARGET__ === 'mobile') { %>
+<div id="logout-modal" style="position: relative; z-index: 100;"></div>
+<% } %>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -501,5 +501,9 @@
 
   "BalanceHistory": {
     "subtitle": "All accounts"
+  },
+
+  "LogoutModal": {
+    "message": "Logout in progress..."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -454,5 +454,9 @@
 
   "BalanceHistory": {
     "subtitle": "Tous les comptes"
+  },
+
+  "LogoutModal": {
+    "message": "Déconnexion en cours..."
   }
 }


### PR DESCRIPTION
We now wait for cleanup to be done before redirecting to user to the login screen when he logs out. This can take several seconds, so we need to show him that something is happening. We choosed to show a modal with a spinner and a message indicating that the logout process is doing its job.