### PR TITLE
chore: Use developement mode in dev

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -10,6 +10,7 @@ if (target !== 'mobile') {
 }
 
 module.exports = {
+  mode: 'development',
   devtool: 'cheap-module-eval-source-map',
   externals: ['cozy'],
   module: {


### PR DESCRIPTION
Watch mode was very slow because we didn't set webpack `mode` to `development`. Since the default is `production`, it was applying unnecessary optimizations.