### PR TITLE
fix: Add contextTypes on component using context

### DIFF
--- a/src/components/UserActionRequired/index.jsx
+++ b/src/components/UserActionRequired/index.jsx
@@ -1,5 +1,6 @@
 /* global __TARGET__ */
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import ReactMarkdown from 'react-markdown'
 import tosIcon from 'assets/icons/icon-tos.svg'
 import { Modal, Icon, Button, translate, Alerter } from 'cozy-ui/react'
@@ -35,6 +36,12 @@ const TosUpdatedModal = translate()(({ t, newTosLink, onAccept, onRefuse }) => (
 ))
 
 class UserActionRequired extends Component {
+  static contextTypes = {
+    store: PropTypes.object.isRequired,
+    client: PropTypes.object.isRequired,
+    router: PropTypes.object.isRequired
+  }
+
   state = {
     warnings: []
   }

--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -1,6 +1,7 @@
 /* global __DEV__ */
 
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Router, Route } from 'react-router'
 import { withClient } from 'cozy-client'
 import { Authentication, Revoked } from 'cozy-authentication'
@@ -59,6 +60,10 @@ const withAuth = Wrapped =>
   class WithAuth extends React.Component {
     state = {
       isLoggingOut: false
+    }
+
+    static contextTypes = {
+      store: PropTypes.object.isRequired
     }
 
     onAuthentication = async res => {

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -210,6 +210,9 @@ const addFetchTriggers = Component => {
   const res = (props, context) => (
     <Component {...props} fetchTriggers={mkFetchTriggers(context.client)} />
   )
+  res.contextTypes = {
+    client: PropTypes.object.isRequired
+  }
   res.displayName = `withAddTrigger(${Component.displayName})`
   return res
 }


### PR DESCRIPTION
We forgot to add the `contextTypes` property on components using the context. React requires it.