### PR TITLE
Update local categorization model

### DIFF
--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -70,7 +70,6 @@ const createLocalClassifier = async () => {
     return null
   }
 
-  localModelLog('info', 'Instanciating a fresh classifier')
   const uniqueCategories = getUniqueCategories(transactions)
   const nbUniqueCategories = uniqueCategories.length
   const alpha = getAlphaParameter(
@@ -80,6 +79,9 @@ const createLocalClassifier = async () => {
     ALPHA_MAX_SMOOTHING
   )
   const options = { tokenizer, alpha }
+
+  localModelLog('info', 'Instanciating a fresh classifier')
+  localModelLog('debug', 'Alpha parameter value is ' + alpha)
   const classifier = bayes(options)
 
   localModelLog('info', 'Learning from manually categorized transactions')

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -2,7 +2,7 @@
 
 import { cozyClient } from 'cozy-konnector-libs'
 import logger from 'cozy-logger'
-import { maxBy, pick } from 'lodash'
+import { maxBy, pick, uniq } from 'lodash'
 import { tokenizer, createClassifier } from '.'
 import bayes from 'classificator'
 import { getLabel } from 'ducks/transactions/helpers'
@@ -14,6 +14,10 @@ const localModelLog = logger.namespace('local-categorization-model')
 const globalModelLog = logger.namespace('global-categorization-model')
 
 export const PARAMETERS_NOT_FOUND = 'Classifier files is not configured.'
+
+export const getUniqueCategories = transactions => {
+  return uniq(transactions.map(t => t.manualCategoryId))
+}
 
 const createLocalClassifier = async () => {
   const getTransWithManualCat = async (transactions, index, limit, skip) => {

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -71,7 +71,15 @@ const createLocalClassifier = async () => {
   }
 
   localModelLog('info', 'Instanciating a fresh classifier')
-  const options = { tokenizer, alpha: 0.1 }
+  const uniqueCategories = getUniqueCategories(transactions)
+  const nbUniqueCategories = uniqueCategories.length
+  const alpha = getAlphaParameter(
+    nbUniqueCategories,
+    ALPHA_MIN,
+    ALPHA_MAX,
+    ALPHA_MAX_SMOOTHING
+  )
+  const options = { tokenizer, alpha }
   const classifier = bayes(options)
 
   localModelLog('info', 'Learning from manually categorized transactions')

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -51,6 +51,13 @@ const getTransWithManualCat = async (transactions, index, limit, skip) => {
   return transactions
 }
 
+/**
+ * Create a ready to use classifier for the local categorization model
+ * @param {Array} transactionsToLearn - Transactions to learn from
+ * @param {Object} classifierOptions - Options to pass to the classifier initialization
+ * @param {Object} options
+ * @param {Number} learnSampleWeight - The weight of the transactionsToLearn parameter
+ */
 export const createLocalClassifier = (
   transactionsToLearn,
   classifierOptions,

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -34,24 +34,24 @@ export const getAlphaParameter = (
   return Math.max(min, Math.min(max, alpha))
 }
 
-const createLocalClassifier = async () => {
-  const getTransWithManualCat = async (transactions, index, limit, skip) => {
-    const query = {
-      selector: { manualCategoryId: { $exists: true } },
-      limit,
-      skip,
-      wholeResponse: true
-    }
-    const results = await cozyClient.data.query(index, query)
-    transactions = [...transactions, ...results.docs]
+const getTransWithManualCat = async (transactions, index, limit, skip) => {
+  const query = {
+    selector: { manualCategoryId: { $exists: true } },
+    limit,
+    skip,
+    wholeResponse: true
+  }
+  const results = await cozyClient.data.query(index, query)
+  transactions = [...transactions, ...results.docs]
 
-    if (results.next) {
-      return getTransWithManualCat(transactions, index, limit, skip + limit)
-    }
-
-    return transactions
+  if (results.next) {
+    return getTransWithManualCat(transactions, index, limit, skip + limit)
   }
 
+  return transactions
+}
+
+const createLocalClassifier = async () => {
   localModelLog('info', 'Fetching manually categorized transactions')
   const index = await cozyClient.data.defineIndex(TRANSACTION_DOCTYPE, [
     'manualCategoryId'

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -18,6 +18,10 @@ export const PARAMETERS_NOT_FOUND = 'Classifier files is not configured.'
 const ALPHA_MIN = 0.1
 const ALPHA_MAX = 10
 const ALPHA_MAX_SMOOTHING = 20
+const FAKE_TRANSACTION = {
+  label: 'thisisafaketransaction',
+  manualCategoryId: '0'
+}
 
 export const getUniqueCategories = transactions => {
   return uniq(transactions.map(t => t.manualCategoryId))
@@ -187,6 +191,14 @@ const localModel = async (classifierOptions, transactions) => {
     ALPHA_MAX_SMOOTHING
   )
   localModelLog('debug', 'Alpha parameter value is ' + alpha)
+
+  if (nbUniqueCategories === 1) {
+    localModelLog(
+      'info',
+      'Not enough different categories, adding a fake transaction to balance the weight of the categories'
+    )
+    transactionsWithManualCat.push(FAKE_TRANSACTION)
+  }
 
   const MIN_SAMPLE_WEIGHT = 1
   const MAX_SAMPLE_WEIGHT = 3

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -15,8 +15,23 @@ const globalModelLog = logger.namespace('global-categorization-model')
 
 export const PARAMETERS_NOT_FOUND = 'Classifier files is not configured.'
 
+const ALPHA_MIN = 0.1
+const ALPHA_MAX = 10
+const ALPHA_MAX_SMOOTHING = 20
+
 export const getUniqueCategories = transactions => {
   return uniq(transactions.map(t => t.manualCategoryId))
+}
+
+export const getAlphaParameter = (
+  nbUniqueCategories,
+  min,
+  max,
+  maxSmoothing
+) => {
+  const alpha = maxSmoothing / nbUniqueCategories
+
+  return Math.max(min, Math.min(max, alpha))
 }
 
 const createLocalClassifier = async () => {

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -173,8 +173,13 @@ const localModel = async (classifierOptions, transactions) => {
   )
 
   localModelLog('info', 'Instanciating a new classifier')
-  const uniqueCategories = getUniqueCategories(transactions)
+  const uniqueCategories = getUniqueCategories(transactionsWithManualCat)
   const nbUniqueCategories = uniqueCategories.length
+  localModelLog(
+    'debug',
+    'Number of unique categories in transactions with manual categories: ' +
+      nbUniqueCategories
+  )
   const alpha = getAlphaParameter(
     nbUniqueCategories,
     ALPHA_MIN,

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -170,8 +170,6 @@ const globalModel = async (classifierOptions, transactions) => {
   }
 }
 
-// The local model is disabled for now because we found an issue with it
-// eslint-disable-next-line no-unused-vars
 const localModel = async (classifierOptions, transactions) => {
   localModelLog('info', 'Instanciating a new classifier')
   const classifier = await createLocalClassifier()
@@ -223,8 +221,8 @@ export const categorizes = async transactions => {
   const classifierOptions = { tokenizer }
 
   await Promise.all([
-    globalModel(classifierOptions, transactions)
-    // localModel(classifierOptions, transactions)
+    globalModel(classifierOptions, transactions),
+    localModel(classifierOptions, transactions)
   ])
 
   return transactions

--- a/src/ducks/categorization/services.spec.js
+++ b/src/ducks/categorization/services.spec.js
@@ -1,0 +1,18 @@
+import { getUniqueCategories } from './services'
+
+describe('getUniqueCategories', () => {
+  it('Should return the list of unique categories for the given transactions', () => {
+    const transactions = [
+      { manualCategoryId: '200100' },
+      { manualCategoryId: '200100' },
+      { manualCategoryId: '400100' },
+      { manualCategoryId: '400400' },
+      { manualCategoryId: '400400' },
+      { manualCategoryId: '600170' }
+    ]
+
+    const expected = ['200100', '400100', '400400', '600170']
+
+    expect(getUniqueCategories(transactions)).toEqual(expected)
+  })
+})

--- a/src/ducks/categorization/services.spec.js
+++ b/src/ducks/categorization/services.spec.js
@@ -53,7 +53,7 @@ describe('getAlphaParemeter', () => {
 })
 
 describe('createLocalClassifier', () => {
-  const options = {
+  const classifierOptions = {
     tokenizer,
     alpha: 1
   }
@@ -78,14 +78,25 @@ describe('createLocalClassifier', () => {
   })
 
   it('Should create a classifier with the right options', () => {
-    createLocalClassifier(transactions, options)
+    const options = { learnSampleWeight: 1 }
+    createLocalClassifier(transactions, classifierOptions, options)
 
-    expect(bayes).toHaveBeenLastCalledWith(options)
+    expect(bayes).toHaveBeenLastCalledWith(classifierOptions)
   })
 
-  it('Should learn from passed transactions', () => {
-    createLocalClassifier(transactions, options)
+  it('Should learn from passed transactions according to the given weight', () => {
+    createLocalClassifier(transactions, classifierOptions, {
+      learnSampleWeight: 1
+    })
 
     expect(mockLearn).toHaveBeenCalledTimes(transactions.length)
+
+    mockLearn.mockReset()
+
+    createLocalClassifier(transactions, classifierOptions, {
+      learnSampleWeight: 4
+    })
+
+    expect(mockLearn).toHaveBeenCalledTimes(4 * transactions.length)
   })
 })

--- a/src/ducks/categorization/services.spec.js
+++ b/src/ducks/categorization/services.spec.js
@@ -1,4 +1,4 @@
-import { getUniqueCategories } from './services'
+import { getUniqueCategories, getAlphaParameter } from './services'
 
 describe('getUniqueCategories', () => {
   it('Should return the list of unique categories for the given transactions', () => {
@@ -14,5 +14,31 @@ describe('getUniqueCategories', () => {
     const expected = ['200100', '400100', '400400', '600170']
 
     expect(getUniqueCategories(transactions)).toEqual(expected)
+  })
+})
+
+describe('getAlphaParemeter', () => {
+  const MIN = 0.1
+  const MAX = 10
+  const MAX_SMOOTHING = 20
+
+  it('Should never be lesser than the passed min parameter', () => {
+    const nbUniqueCategories = 500
+    const alpha = getAlphaParameter(nbUniqueCategories, MIN, MAX, MAX_SMOOTHING)
+
+    expect(alpha).toBe(MIN)
+  })
+
+  it('Should never be higher than the passed max parameter', () => {
+    const nbUniqueCategories = 1
+    const alpha = getAlphaParameter(nbUniqueCategories, MIN, MAX, MAX_SMOOTHING)
+
+    expect(alpha).toBe(MAX)
+  })
+
+  it('Should return the right value between MIN and MAX', () => {
+    expect(getAlphaParameter(10, MIN, MAX, MAX_SMOOTHING)).toBe(2)
+    expect(getAlphaParameter(20, MIN, MAX, MAX_SMOOTHING)).toBe(1)
+    expect(getAlphaParameter(40, MIN, MAX, MAX_SMOOTHING)).toBe(0.5)
   })
 })

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -101,7 +101,8 @@ const onOperationOrBillCreate = async () => {
   const catChanges = await changesTransactions(catLastSeq)
 
   const toCategorize = catChanges.documents
-    .filter(t => t.cozyCategoryId === undefined)
+    .filter(isCreatedDoc)
+
   try {
     if (toCategorize.length > 0) {
       const transactionsCategorized = await categorizes(toCategorize)


### PR DESCRIPTION
The alpha model was previously fixed at `0.1`, but we saw that it doesn't handle all cases well. So François reworked it and came with some new expectations for this parameter:

* Never lesser than a minimum value (`0.1`)
* Never higher than a maximum value (`10`)
* Equals to `max smoothing parameter / number of unique categories` (where `max smoothing = 20`)

The initialization of the local model also needed a little rework:

* If the number of recategorized transactions is lower than a limit (`2`), give a higher weight to the recategorized transactions
* If the number of unique `manualCategoryId`s equals to `1`, add a fake transaction to the learn sample

Finally, we had a bug in which not only new transactions were passed in the categorization models.