### PR TITLE
fix: Scrollbar not pushing content

### DIFF
--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -11,8 +11,6 @@ h4
 
 html, body
     +medium-screen()
-        min-height 100vh
-        overflow auto
         overflow-x hidden
 
 +small-screen()


### PR DESCRIPTION
The original bug is because we use a custom value for the
overflow-y for the html tag. If scroll is used, the scrollbar
does push content, if auto is used, the scrollbar does not push
the content, and the content can be truncated by the scrollbar.