### PR TITLE
Fix augmented modal

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -13,7 +13,6 @@ module.exports = {
   mode: 'development',
   devtool: 'cheap-module-eval-source-map',
   externals: ['cozy'],
-  mode: 'development',
   module: {
     rules: [
       {

--- a/src/components/AugmentedModal.jsx
+++ b/src/components/AugmentedModal.jsx
@@ -1,13 +1,25 @@
 import React, { Component } from 'react'
+import PropTypes from 'prop-types'
 import { Modal, ModalDescription, Panel, IntentIframe } from 'cozy-ui/react'
 import ventePrivee from 'assets/vente-privee.png'
 import styles from './AugmentedModal.styl'
 import ventePriveeInfo from 'assets/venteprivee-info.png'
 import ventePriveeInfo2x from 'assets/venteprivee-info@2x.png'
+import { Intents } from 'cozy-interapp'
 
 const { ModalBrandedHeader } = Modal
 
 class Content extends Component {
+  static contextTypes = {
+    client: PropTypes.object.isRequired
+  }
+
+  constructor(props, context) {
+    super(props, context)
+
+    this.intents = new Intents({ client: this.context.client })
+  }
+
   render() {
     const { fileId } = this.props
     return (
@@ -17,6 +29,7 @@ class Content extends Component {
             action="OPEN"
             type="io.cozy.files"
             data={{ id: fileId }}
+            create={this.intents.create}
           />
         </Panel.Main>
         <Panel.Side>

--- a/src/ducks/transactions/actions/BillAction.jsx
+++ b/src/ducks/transactions/actions/BillAction.jsx
@@ -45,11 +45,13 @@ const getBill = (transaction, actionProps) => {
 class AugmentedModalButton extends React.Component {
   state = { opened: false }
 
-  open() {
+  open = event => {
+    event.stopPropagation()
     this.setState({ opened: true })
   }
 
-  close() {
+  close = event => {
+    event.stopPropagation()
     this.setState({ opened: false })
   }
 
@@ -57,15 +59,15 @@ class AugmentedModalButton extends React.Component {
     const { fileId, text, compact } = this.props
     return (
       <ButtonAction
-        onClick={() => this.open()}
+        onClick={this.open}
         label={text}
         compact={compact}
         rightIcon="file"
         className={styles.TransactionActionButton}
       >
-        {this.state.opened ? (
-          <AugmentedModal fileId={fileId} onClose={() => this.close()} />
-        ) : null}
+        {this.state.opened && (
+          <AugmentedModal fileId={fileId} onClose={this.close} />
+        )}
       </ButtonAction>
     )
   }

--- a/src/ducks/transactions/actions/BillAction.jsx
+++ b/src/ducks/transactions/actions/BillAction.jsx
@@ -43,6 +43,8 @@ const getBill = (transaction, actionProps) => {
 }
 
 class AugmentedModalButton extends React.Component {
+  state = { opened: false }
+
   open() {
     this.setState({ opened: true })
   }


### PR DESCRIPTION
The augmented modal had some problems due to recent changes:

* We no longer expose cozy-client-js globally, so we had to pass the intent creation function to the `IntentIframe`
* Preact didn't propagate events through portals, but React does. It caused a bug in which we could not close the augmented modal