### PR TITLE
fix(transactions): Align headers on medium screen

### DIFF
--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -53,9 +53,11 @@
         .bnk-op-desc
             cursor pointer
             maxed-flex-basis 60%
+            padding-left 3.25rem
         .bnk-op-amount
             cursor pointer
             maxed-flex-basis 40%
+            padding-right 3.5rem
         .bnk-op-actions
             width 150px
         .bnk-op-date


### PR DESCRIPTION
Headers were not properly aligned on medium screen:

| Before | After |
|--------|-------|
|![image](https://user-images.githubusercontent.com/1606068/48846268-f96bb000-ed9e-11e8-85ad-5a1bc983b003.png)|![image](https://user-images.githubusercontent.com/1606068/48846228-dfca6880-ed9e-11e8-981e-879858878bea.png)|