### PR TITLE
feat(TransactionHeader): Don't show columns headings on tablet

### DIFF
--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -119,7 +119,7 @@ class TransactionHeader extends Component {
   displayTableHead() {
     const { t, breakpoints, router } = this.props
 
-    if (breakpoints.isMobile) {
+    if (breakpoints.isMobile || breakpoints.isTablet) {
       return null
     }
 

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -49,21 +49,6 @@
     .bnk-op-caticon
         cursor pointer
 
-    +medium-screen()
-        .bnk-op-desc
-            cursor pointer
-            maxed-flex-basis 60%
-            padding-left 3.25rem
-        .bnk-op-amount
-            cursor pointer
-            maxed-flex-basis 40%
-            padding-right 3.5rem
-        .bnk-op-actions
-            width 150px
-        .bnk-op-date
-        .bnk-op-action
-            display none
-
     tbody
         overflow inherit!important
 


### PR DESCRIPTION
We just want to be consistent with the mobile style, which don't show this.