### PR TITLE
Fix date selector update when scrolling

### DIFF
--- a/src/components/List/index.jsx
+++ b/src/components/List/index.jsx
@@ -8,8 +8,10 @@ export const Header = ({ children }) => (
   <div className={styles['c-list-header']}>{children}</div>
 )
 
-export const Row = ({ children }) => (
-  <div className={styles['c-list-row']}>{children}</div>
+export const Row = props => (
+  <div ref={props.onRef} className={styles['c-list-row']}>
+    {props.children}
+  </div>
 )
 
 export const Content = ListItemText

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -32,8 +32,14 @@ const sAmount = styles['bnk-op-amount']
 const sAction = styles['bnk-op-action']
 
 class _RowDesktop extends React.PureComponent {
-  onSelectTransaction = () =>
+  constructor(props) {
+    super(props)
+    this.onSelectTransaction = this.onSelectTransaction.bind(this)
+  }
+
+  onSelectTransaction() {
     this.props.selectTransaction(this.props.transaction)
+  }
 
   render() {
     const {

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -49,6 +49,7 @@ class _RowDesktop extends React.PureComponent {
       isExtraLarge,
       showCategoryChoice,
       filteringOnAccount,
+      onRef,
       urls,
       brands
     } = this.props
@@ -59,9 +60,8 @@ class _RowDesktop extends React.PureComponent {
     const parentCategory = getParentCategory(categoryId)
 
     const account = transaction.account.data
-
     return (
-      <tr>
+      <tr ref={onRef}>
         <td className={cx(sDesc, 'u-pv-half', 'u-pl-1')}>
           <Media className="u-clickable">
             <Img title={categoryTitle} onClick={showCategoryChoice}>
@@ -128,10 +128,11 @@ class _RowMobile extends React.PureComponent {
       filteringOnAccount,
       brands,
       urls,
+      onRef
     } = this.props
     const account = transaction.account.data
     return (
-      <List.Row>
+      <List.Row onRef={onRef}>
         <Media className="u-full-width">
           <Img
             className="u-clickable u-mr-half"

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -43,7 +43,8 @@ class _RowDesktop extends React.PureComponent {
       isExtraLarge,
       showCategoryChoice,
       filteringOnAccount,
-      ...props
+      urls,
+      brands
     } = this.props
 
     const categoryId = getCategoryId(transaction)
@@ -97,8 +98,8 @@ class _RowDesktop extends React.PureComponent {
         <TdSecondary className={sAction}>
           <TransactionActions
             transaction={transaction}
-            urls={props.urls}
-            brands={props.brands}
+            urls={urls}
+            brands={brands}
             onlyDefault
           />
         </TdSecondary>
@@ -115,7 +116,13 @@ export const RowDesktop = compose(
 
 class _RowMobile extends React.PureComponent {
   render() {
-    const { transaction, t, filteringOnAccount, ...props } = this.props
+    const {
+      transaction,
+      t,
+      filteringOnAccount,
+      brands,
+      urls,
+    } = this.props
     const account = transaction.account.data
     return (
       <List.Row>
@@ -158,8 +165,8 @@ class _RowMobile extends React.PureComponent {
           <Img className={styles['bnk-transaction-mobile-action']}>
             <TransactionActions
               transaction={transaction}
-              urls={props.urls}
-              brands={props.brands}
+              urls={urls}
+              brands={brands}
               onlyDefault
               compact
               menuPosition="right"

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -88,7 +88,7 @@ class TransactionsD extends React.Component {
 
   constructor(props) {
     super(props)
-    this.scrollSpy = new TopMost(this.getScrollingElement)
+    this.topmost = new TopMost(this.getScrollingElement)
     this.handleScroll = (isIOSApp() ? debounce : throttle)(
       this.handleScroll.bind(this),
       300,
@@ -112,7 +112,7 @@ class TransactionsD extends React.Component {
   }
 
   updateTopMostVisibleTransaction() {
-    const topMostTransactionId = this.scrollSpy.getTopMostVisibleNodeId()
+    const topMostTransactionId = this.topmost.getTopMostVisibleNodeId()
     const topMostTransaction = this.transactionsById[topMostTransactionId]
     if (topMostTransaction) {
       this.props.onChangeTopMostTransaction(topMostTransaction)
@@ -129,7 +129,7 @@ class TransactionsD extends React.Component {
 
   handleRefRow = (transactionId, ref) => {
     const node = ReactDOM.findDOMNode(ref) // eslint-disable-line
-    this.scrollSpy.addNode(transactionId, node)
+    this.topmost.addNode(transactionId, node)
   }
 
   getScrollingElement = () => {

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -183,7 +183,7 @@ class TransactionsD extends React.Component {
                 return (
                   <Row
                     key={transaction._id}
-                    ref={this.handleRefRow.bind(null, transaction._id)}
+                    onRef={this.handleRefRow.bind(null, transaction._id)}
                     transaction={transaction}
                     brands={brands}
                     urls={urls}

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -89,6 +89,7 @@ class TransactionsD extends React.Component {
   constructor(props) {
     super(props)
     this.topmost = new TopMost(this.getScrollingElement)
+    this.handleRefRow = this.handleRefRow.bind(this)
     this.handleScroll = (isIOSApp() ? debounce : throttle)(
       this.handleScroll.bind(this),
       300,
@@ -127,7 +128,7 @@ class TransactionsD extends React.Component {
     this.updateTopMostVisibleTransaction()
   }
 
-  handleRefRow = (transactionId, ref) => {
+  handleRefRow(transactionId, ref) {
     const node = ReactDOM.findDOMNode(ref) // eslint-disable-line
     this.topmost.addNode(transactionId, node)
   }

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -1,7 +1,7 @@
 /* global mount */
 
 import React from 'react'
-import { RowDekstop, RowMobile } from './TransactionRow'
+import { RowDesktop, RowMobile } from './TransactionRow'
 import data from '../../../test/fixtures'
 import store from '../../../test/store'
 import AppLike from '../../../test/AppLike'
@@ -14,11 +14,15 @@ const allTransactions = data['io.cozy.bank.operations']
 describe('transaction row', () => {
   let root, client, transaction
 
-  const wrapRow = row => (
+  const wrapRow = (row, withTable) => (
     <AppLike store={store} client={client}>
-      <table>
-        <tbody>{row}</tbody>
-      </table>
+      {withTable ? (
+        <table>
+          <tbody>{row}</tbody>
+        </table>
+      ) : (
+        row
+      )}
     </AppLike>
   )
 
@@ -39,17 +43,30 @@ describe('transaction row', () => {
     transaction = client.hydrateDocument(rawTransaction)
   })
 
-  xit('should render correctly on desktop', () => {
+  it('should render correctly on desktop', () => {
     root = mount(
-      wrapRow(<RowDekstop transaction={transaction} urls={{}} brands={[]} />)
+      wrapRow(
+        <RowDesktop transaction={transaction} urls={{}} brands={[]} />,
+        true
+      )
     )
     expect(root.find(Caption).text()).toBe('Compte courant Isabelle - BNPP')
   })
 
   it('should render correctly on mobile', () => {
+    const handleRef = jest.fn()
     root = mount(
-      wrapRow(<RowMobile transaction={transaction} urls={{}} brands={[]} />)
+      wrapRow(
+        <RowMobile
+          onRef={handleRef}
+          transaction={transaction}
+          urls={{}}
+          brands={[]}
+        />,
+        false
+      )
     )
     expect(root.find(Caption).text()).toBe('Compte courant Isabelle - BNPP')
+    expect(handleRef).toHaveBeenCalled()
   })
 })

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -3,13 +3,12 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
+import { isIOSApp } from 'cozy-device-helper'
 import {
   flowRight as compose,
   isEqual,
   includes,
   findIndex,
-  find,
-  findLast,
   uniq,
   maxBy
 } from 'lodash'
@@ -43,42 +42,16 @@ import {
 } from 'doctypes'
 
 import { getBrands } from 'ducks/brandDictionary'
-import { isIOSApp } from 'cozy-device-helper'
 import { getKonnectorFromTrigger } from 'utils/triggers'
 import { queryConnect } from 'cozy-client'
 import { isCollectionLoading } from 'ducks/client/utils'
+import { findNearestMonth } from './helpers'
 
 const { BarRight } = cozy.bar
 
 const STEP_INFINITE_SCROLL = 30
 const SCROLL_THRESOLD_TO_ACTIVATE_TOP_INFINITE_SCROLL = 150
 const getMonth = date => date.slice(0, 7)
-
-// Performs successive `find`s until one of the find functions returns
-// a result
-const multiFind = (arr, findFns) => {
-  for (let findFn of findFns) {
-    const res = findFn(arr)
-    if (res) {
-      return res
-    }
-  }
-  return null
-}
-
-// The goal here is to find the first month having operations, closest
-// to the chosen month. To know if we have to search in the past or the
-// in the future, we check if the chosen month is before or after the
-// current month.
-const findNearestMonth = (chosenMonth, currentMonth, availableMonths) => {
-  const findBeforeChosenMonth = months => findLast(months, x => x < chosenMonth)
-  const findAfterChosenMonth = months => find(months, x => x > chosenMonth)
-  const findFns =
-    chosenMonth < currentMonth
-      ? [findBeforeChosenMonth, findAfterChosenMonth]
-      : [findAfterChosenMonth, findBeforeChosenMonth]
-  return multiFind(availableMonths, findFns)
-}
 
 class TransactionsPage extends Component {
   state = {

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -1,4 +1,35 @@
+import find from 'lodash/find'
+import findLast from 'lodash/findLast'
+
 export const getLabel = transaction =>
   transaction.label.toLowerCase().replace(/(?:^|\s)\S/g, a => a.toUpperCase())
 
 export const getDate = transaction => transaction.date.slice(0, 10)
+
+// Performs successive `find`s until one of the find functions returns
+// a result
+const multiFind = (arr, findFns) => {
+  for (let findFn of findFns) {
+    const res = findFn(arr)
+    if (res) {
+      return res
+    }
+  }
+  return null
+}
+
+/**
+ * Returns the first month having operations, closest to the given month.
+ *
+ * To know if we have to search in the past or the in the future, we check
+ * if the chosen month is before or after the current month.
+ */
+export const findNearestMonth = (chosenMonth, currentMonth, availableMonths) => {
+  const findBeforeChosenMonth = months => findLast(months, x => x < chosenMonth)
+  const findAfterChosenMonth = months => find(months, x => x > chosenMonth)
+  const findFns =
+    chosenMonth < currentMonth
+      ? [findBeforeChosenMonth, findAfterChosenMonth]
+      : [findAfterChosenMonth, findBeforeChosenMonth]
+  return multiFind(availableMonths, findFns)
+}

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -26,7 +26,11 @@ const multiFind = (arr, findFns) => {
  * To know if we have to search in the past or the in the future, we check
  * if the chosen month is before or after the current month.
  */
-export const findNearestMonth = (chosenMonth, currentMonth, availableMonths) => {
+export const findNearestMonth = (
+  chosenMonth,
+  currentMonth,
+  availableMonths
+) => {
   const findBeforeChosenMonth = months => findLast(months, x => x < chosenMonth)
   const findAfterChosenMonth = months => find(months, x => x > chosenMonth)
   const findFns =

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -6,8 +6,10 @@ export const getLabel = transaction =>
 
 export const getDate = transaction => transaction.date.slice(0, 10)
 
-// Performs successive `find`s until one of the find functions returns
-// a result
+/**
+ * Performs successive `find`s until one of the find functions returns
+ * a result
+ */
 const multiFind = (arr, findFns) => {
   for (let findFn of findFns) {
     const res = findFn(arr)

--- a/src/ducks/transactions/scroll/TopMost.js
+++ b/src/ducks/transactions/scroll/TopMost.js
@@ -1,4 +1,5 @@
 import sortBy from 'lodash/sortBy'
+import find from 'lodash/find'
 
 /**
  * TopMost stores DOM nodes and computes the top most
@@ -27,7 +28,7 @@ class TopMost {
     )
     const topMost = find(offsets, o => {
       const offset = o[1]
-      return offset - topRoot > 0
+      return offset - topRoot >= 0
     })
     return topMost ? topMost[0] : null
   }

--- a/src/ducks/transactions/scroll/TopMost.spec.js
+++ b/src/ducks/transactions/scroll/TopMost.spec.js
@@ -1,0 +1,19 @@
+import TopMost from './TopMost'
+
+const makeNodeAtTop = top => ({
+  getBoundingClientRect: () => ({ top })
+})
+
+describe('TopMost', () => {
+  it('should compute the highest visible node', () => {
+    const fakeEl = makeNodeAtTop(300)
+    const getScrollingElement = () => fakeEl
+    const tm = new TopMost(getScrollingElement)
+    tm.addNode('a', makeNodeAtTop(100))
+    tm.addNode('b', makeNodeAtTop(200))
+    tm.addNode('c', makeNodeAtTop(300))
+    tm.addNode('d', makeNodeAtTop(400))
+    tm.addNode('e', makeNodeAtTop(500))
+    expect(tm.getTopMostVisibleNodeId()).toBe('c')
+  })
+})


### PR DESCRIPTION
The date selector was not updating because transactions rows refs were not passed to the TopMost instance : while scrolling, we could not figure out the highest visible row.