### PR TITLE
fix(service): Log manually categorized transactions number

### DIFF
--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -225,6 +225,7 @@ const localModel = async (classifierOptions, transactions) => {
     return
   }
 
+  localModelLog('info', `Applying model to ${transactions.length} transactions`)
   for (const transaction of transactions) {
     const label = getLabelWithTags(transaction)
     localModelLog('info', `Applying model to ${label}`)

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -173,7 +173,9 @@ const localModel = async (classifierOptions, transactions) => {
   const transactionsWithManualCat = await getTransWithManualCat([], index, 100)
   localModelLog(
     'info',
-    `Fetched ${transactions.length} manually categorized transactions`
+    `Fetched ${
+      transactionsWithManualCat.length
+    } manually categorized transactions`
   )
 
   localModelLog('info', 'Instanciating a new classifier')


### PR DESCRIPTION
We logged the number of all fetched transactions instead of only manually categorized ones.