### PR TITLE
fix(transactions): Infinite scroll

### DIFF
--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -11,6 +11,7 @@ import TransactionSelectDates from 'ducks/transactions/TransactionSelectDates'
 import flag from 'cozy-flags'
 import HistoryChart from 'ducks/balance/HistoryChart'
 import { Table } from 'components/Table'
+import { Padded } from 'components/Spacing'
 
 import styles from './TransactionsPage.styl'
 import transactionsStyles from './Transactions.styl'
@@ -152,10 +153,12 @@ class TransactionHeader extends Component {
   render() {
     return (
       <div className={styles.TransactionPage__top}>
-        {this.displayBalanceHistory()}
-        {this.displayAccountSwitch()}
-        {this.displaySelectDates()}
-        {this.displayBreadcrumb()}
+        <Padded>
+          {this.displayBalanceHistory()}
+          {this.displayAccountSwitch()}
+          {this.displaySelectDates()}
+          {this.displayBreadcrumb()}
+        </Padded>
         {this.displayTableHead()}
       </div>
     )

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -14,7 +14,6 @@ import {
 } from 'lodash'
 import { getFilteredAccounts } from 'ducks/filters'
 import BarBalance from 'components/BarBalance'
-import { Padded } from 'components/Spacing'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 
 import {
@@ -312,27 +311,25 @@ class TransactionsPage extends Component {
     const chartData = this.getChartData()
 
     return (
-      <Padded>
-        <div className={styles.TransactionPage}>
-          <TransactionHeader
-            transactions={filteredTransactions}
-            handleChangeMonth={this.handleChangeMonth}
-            currentMonth={this.state.currentMonth}
-            chartData={chartData}
-          />
-          {isMobile &&
-            !isCollectionLoading(accounts) && (
-              <BarRight>
-                <BarBalance accounts={filteredAccounts} />
-              </BarRight>
-            )}
-          {isFetching ? (
-            <Loading loadingType="movements" />
-          ) : (
-            this.displayTransactions()
+      <div className={styles.TransactionPage}>
+        <TransactionHeader
+          transactions={filteredTransactions}
+          handleChangeMonth={this.handleChangeMonth}
+          currentMonth={this.state.currentMonth}
+          chartData={chartData}
+        />
+        {isMobile &&
+          !isCollectionLoading(accounts) && (
+            <BarRight>
+              <BarBalance accounts={filteredAccounts} />
+            </BarRight>
           )}
-        </div>
-      </Padded>
+        {isFetching ? (
+          <Loading loadingType="movements" />
+        ) : (
+          this.displayTransactions()
+        )}
+      </div>
     )
   }
 }

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -15,8 +15,6 @@
 
 .TransactionPage__bottom
     overflow auto // TODO remove in small screen
-    @extend $full-width-table
-    margin-bottom -2rem
 
 .bnk-mov-figures
     margin          1em 0


### PR DESCRIPTION
We broke it when introducing the `Padded` component. We needed to wrap only a part of the header in `Padded` instead of the whole page, and to remove some custom negative margins, which is great.