### PR TITLE
Fix health expense status action

### DIFF
--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -91,7 +91,11 @@ class TransactionActions extends Component {
     const { transaction } = this.props
     if (transaction) {
       const { urls, brands, bill } = this.props
-      const actionProps = { urls, brands, bill }
+      const actionProps = {
+        urls,
+        brands,
+        bill
+      }
       const actions = await findMatchingActions(transaction, actionProps)
       if (!this.unmounted) {
         this.setState({ actions, actionProps })

--- a/src/ducks/transactions/TransactionActions.spec.jsx
+++ b/src/ducks/transactions/TransactionActions.spec.jsx
@@ -38,7 +38,9 @@ const tests = [
   ['depsantegene4', '.c-actionbtn--error', 'No reimbursement yet', 'hourglass', 'HealthExpenseStatus'],
   ['depsanteisa2', '.c-actionbtn--error', 'No reimbursement yet', 'hourglass', 'HealthExpenseStatus'],
   ['depsantecla3', '.c-actionbtn--error', 'No reimbursement yet', 'hourglass', 'HealthExpenseStatus'],
-  ['facturebouygues', null, '1 invoice', 'file', 'bill'],
+  ['facturebouygues', null, '1 invoice', 'file', 'bill', {
+    brands: brands.filter(x => x.name === 'Bouygues Telecom').map(b => ({ ...b, hasTrigger: true }))
+  }],
   ['salaireisa1', null, 'Accéder à votre paie', 'openwith', 'url'],
   ['fnac', null, 'Accéder au site Fnac', 'openwith', 'url'],
   ['edf', null, 'EDF', null, 'app'],
@@ -46,7 +48,7 @@ const tests = [
     brands: brands.filter(x => x.name == 'Malakoff Mederic')
   }, 'remboursementcomplementaire konnector not installed'],
   ['remboursementcomplementaire', null, '1 invoice', null, 'bill', {
-    brands: []
+    brands: brands.filter(x => x.name == 'Malakoff Mederic').map(b => ({ ...b, hasTrigger: true }))
   }, 'remboursementcomplementaire konnector installed'],
   ['normalshopping', null, 'toto', null]
 ]
@@ -58,10 +60,7 @@ const actionProps = {
     edf: 'edf-url://',
     maif: 'maifurl'
   },
-
-  // Brands represents the brands for which no konnector
-  // has been installed
-  brands: brands.filter(x => x.name == 'Malakoff Mederic')
+  brands: brands
 }
 
 let client, transactionsById

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -106,8 +106,14 @@ class TransactionsPage extends Component {
     }
   }
 
-  getKonnectorSlugs = triggers => {
-    return triggers
+  getInstalledKonnectorsSlugs() {
+    const { triggers } = this.props
+
+    if (isCollectionLoading(triggers)) {
+      return []
+    }
+
+    return triggers.data
       .filter(trigger => trigger.worker === 'konnector')
       .map(getKonnectorFromTrigger)
       .filter(Boolean)
@@ -212,18 +218,14 @@ class TransactionsPage extends Component {
     )
   }
 
-  getBrandsWithoutTrigger = () => {
-    const { triggers } = this.props
+  getBrands() {
+    const installedKonnectorsSlugs = this.getInstalledKonnectorsSlugs()
+    const brands = getBrands().map(brand => ({
+      ...brand,
+      hasTrigger: includes(installedKonnectorsSlugs, brand.konnectorSlug)
+    }))
 
-    if (isCollectionLoading(triggers)) {
-      return []
-    }
-
-    const slugs = this.getKonnectorSlugs(triggers.data)
-    const isBrandKonnectorAbsent = brand =>
-      !includes(slugs, brand.konnectorSlug)
-
-    return getBrands(isBrandKonnectorAbsent)
+    return brands
   }
 
   getFilteringOnAccount = () => {
@@ -256,7 +258,7 @@ class TransactionsPage extends Component {
           onScroll={this.checkToActivateTopInfiniteScroll}
           transactions={transations}
           urls={urls}
-          brands={this.getBrandsWithoutTrigger()}
+          brands={this.getBrands()}
           filteringOnAccount={this.getFilteringOnAccount()}
           manualLoadMore={isIOSApp()}
         />

--- a/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
+++ b/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
@@ -170,12 +170,8 @@ const action = {
 
     return <Icon icon="hourglass" color={color} />
   },
-  match: (transaction, { brands }) => {
-    return (
-      brands.filter(brand => brand.hasTrigger && brand.health).length > 0 &&
-      isHealthExpense(transaction) &&
-      getVendors(transaction)
-    )
+  match: transaction => {
+    return isHealthExpense(transaction) && getVendors(transaction)
   },
   Component: compose(
     withBreakpoints(),

--- a/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
+++ b/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
@@ -10,7 +10,6 @@ import {
 } from 'cozy-ui/react'
 import palette from 'cozy-ui/react/palette'
 import { isHealthExpense } from 'ducks/categories/helpers'
-import allBrands from 'ducks/brandDictionary/brands.json'
 import { BillComponent } from './BillAction'
 import styles from '../TransactionActions.styl'
 import { flowRight as compose } from 'lodash'
@@ -160,12 +159,6 @@ const Component = ({
   )
 }
 
-const allHealthBrands = allBrands.filter(brand => brand.health)
-const userCanInstallHealthKonnector = brands => {
-  const installedHealthBrands = brands.filter(brand => brand.health)
-  return allHealthBrands.length > installedHealthBrands.length
-}
-
 const action = {
   name,
   color: palette.charcoalGrey,
@@ -179,7 +172,7 @@ const action = {
   },
   match: (transaction, { brands }) => {
     return (
-      userCanInstallHealthKonnector(brands) &&
+      brands.filter(brand => brand.hasTrigger && brand.health).length > 0 &&
       isHealthExpense(transaction) &&
       getVendors(transaction)
     )

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -27,6 +27,10 @@ import { triggersConn } from 'doctypes'
 
 const name = 'konnector'
 
+function getBrandsWithoutTrigger(brands) {
+  return brands.filter(brand => !brand.hasTrigger)
+}
+
 const InformativeModal = ({
   onCancel,
   onConfirm,
@@ -127,10 +131,11 @@ class _Component extends React.Component {
   }
 
   findMatchingBrand() {
-    return findMatchingBrand(
-      this.props.actionProps.brands,
-      this.props.transaction.label
+    const brandsWithoutTrigger = getBrandsWithoutTrigger(
+      this.props.actionProps.brands
     )
+
+    return findMatchingBrand(brandsWithoutTrigger, this.props.transaction.label)
   }
 
   render() {
@@ -221,9 +226,11 @@ const action = {
   name,
   icon,
   match: (transaction, { brands, urls }) => {
+    const brandsWithoutTrigger = getBrandsWithoutTrigger(brands)
+
     return (
-      brands &&
-      matchBrands(brands, transaction.label) &&
+      brandsWithoutTrigger &&
+      matchBrands(brandsWithoutTrigger, transaction.label) &&
       (urls['COLLECT'] || urls['HOME'])
     )
   },


### PR DESCRIPTION
There was two flaws with this action:

* The `brands` property used in the `match` function was too ambiguous (which brands ? All brands ?). In this action we need to know brands without trigger. In other actions we need to know brands with trigger. So I refactored this to add a `hasTrigger` property to brands and pass all brands instead of only the ones without trigger. This way, the prop name is no ambiguous anymore
* The `userCanInstallHealthKonnector` function did what it was intended to do, but we actually didn't want that condition in this action. What we want to do is to always show the status if there are reimbursements, or if there is at least one health konnector with a trigger