### PR TITLE
Transaction: Update design on table head

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -4,8 +4,14 @@ import cx from 'classnames'
 
 import styles from './Header.styl'
 
-const Header = ({ children, className, color }) => (
-  <div className={cx(styles[`HeaderColor_${color}`], className)}>
+const Header = ({ children, className, color, fixed }) => (
+  <div
+    className={cx(
+      styles[`HeaderColor_${color}`],
+      { [styles.HeaderFixed]: fixed },
+      className
+    )}
+  >
     {children}
   </div>
 )
@@ -17,7 +23,8 @@ Header.propTypes = {
 }
 
 Header.defaultProps = {
-  color: 'default'
+  color: 'default',
+  fixed: false
 }
 
 export default Header

--- a/src/components/Header/Header.styl
+++ b/src/components/Header/Header.styl
@@ -1,5 +1,15 @@
 @require 'settings/breakpoints'
 
+.HeaderFixed
+    position sticky
+    position -webkit-sticky
+    z-index 1
+    top 0
+    box-shadow 0 2px 4px 0 rgba(0, 0, 0, 0.24), 0 0 4px 0 rgba(0, 0, 0, 0.16)
+
+    +medium-screen()
+        top 3rem
+
 .HeaderColor_default
     background-color var(--white)
 

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -35,13 +35,8 @@ select-date-height-small = 2.75rem
 +small-screen()
     .SelectDates
         m = 0.75rem // size of the margin-top/bottom
-        topbar-height = 3rem
-        top topbar-height
-        left 0
-        right 0
         width auto
         height select-date-height-small
-        position fixed
         background white
         z-index 2
         display flex
@@ -105,4 +100,3 @@ select-date-height-small = 2.75rem
 .SelectDates__Button--disabled
     color silver
     cursor not-allowed
-

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -152,7 +152,7 @@ class TransactionHeader extends Component {
 
   render() {
     return (
-      <div className={styles.TransactionPage__top}>
+      <React.Fragment>
         <Padded>
           {this.displayBalanceHistory()}
           {this.displayAccountSwitch()}
@@ -160,7 +160,7 @@ class TransactionHeader extends Component {
           {this.displayBreadcrumb()}
         </Padded>
         {this.displayTableHead()}
-      </div>
+      </React.Fragment>
     )
   }
 }

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -10,42 +10,11 @@ import { AccountSwitch } from 'ducks/account'
 import TransactionSelectDates from 'ducks/transactions/TransactionSelectDates'
 import flag from 'cozy-flags'
 import HistoryChart from 'ducks/balance/HistoryChart'
-import { Table } from 'components/Table'
 import Header from 'components/Header'
 import { Padded } from 'components/Spacing'
 
+import TableHead from './header/TableHead'
 import styles from './TransactionsPage.styl'
-import transactionsStyles from './Transactions.styl'
-
-const sDate = transactionsStyles['bnk-op-date']
-const sDesc = transactionsStyles['bnk-op-desc']
-const sAmount = transactionsStyles['bnk-op-amount']
-const sAction = transactionsStyles['bnk-op-action']
-
-const TableHeadDesktop = ({ t, mainColumnTitle }) => (
-  <thead>
-    <tr>
-      <td className={sDesc}>{mainColumnTitle}</td>
-      <td className={sDate}>{t('Transactions.header.date')}</td>
-      <td className={sAmount}>{t('Transactions.header.amount')}</td>
-      <td className={sAction}>{t('Transactions.header.action')}</td>
-    </tr>
-  </thead>
-)
-
-const transactionTableHeadStyle = {
-  background: 'white',
-  marginTop: '1rem',
-  marginLeft: '-2rem',
-  marginRight: '-2rem'
-}
-export const TransactionTableHead = translate()(props => (
-  <div style={transactionTableHeadStyle}>
-    <Table className={transactionsStyles['TransactionTable']}>
-      <TableHeadDesktop t={props.t} mainColumnTitle={props.mainColumnTitle} />
-    </Table>
-  </div>
-))
 
 const historyChartMargin = {
   top: 10,
@@ -118,24 +87,6 @@ class TransactionHeader extends Component {
     )
   }
 
-  displayTableHead() {
-    const { t, breakpoints, router } = this.props
-
-    if (breakpoints.isMobile || breakpoints.isTablet) {
-      return null
-    }
-
-    return (
-      <TransactionTableHead
-        mainColumnTitle={t(
-          router.params.subcategoryName
-            ? 'Categories.headers.movements'
-            : 'Transactions.header.description'
-        )}
-      />
-    )
-  }
-
   displayBalanceHistory() {
     if (!flag('transaction-history') || !this.props.chartData) {
       return
@@ -152,6 +103,8 @@ class TransactionHeader extends Component {
   }
 
   render() {
+    const { router } = this.props
+    const isSubcategory = !!router.params.subcategoryName
     const withChart = flag('transaction-history')
     const colorProps = { color: withChart ? 'primary' : 'default' }
 
@@ -163,7 +116,7 @@ class TransactionHeader extends Component {
           {this.displaySelectDates()}
           {this.displayBreadcrumb()}
         </Padded>
-        {this.displayTableHead()}
+        <TableHead isSubcategory={isSubcategory} />
       </Header>
     )
   }

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -158,8 +158,8 @@ class TransactionHeader extends Component {
     return (
       <Header {...colorProps}>
         <Padded>
-          {this.displayBalanceHistory()}
           {this.displayAccountSwitch()}
+          {this.displayBalanceHistory()}
           {this.displaySelectDates()}
           {this.displayBreadcrumb()}
         </Padded>

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -116,7 +116,7 @@ class TransactionHeader extends Component {
           {this.displaySelectDates()}
           {this.displayBreadcrumb()}
         </Padded>
-        <TableHead isSubcategory={isSubcategory} />
+        <TableHead isSubcategory={isSubcategory} {...colorProps} />
       </Header>
     )
   }

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -103,14 +103,17 @@ class TransactionHeader extends Component {
   }
 
   render() {
-    const { router } = this.props
+    const {
+      router,
+      breakpoints: { isMobile, isTablet }
+    } = this.props
     const isSubcategory = !!router.params.subcategoryName
     const withChart = flag('transaction-history')
     const colorProps = { color: withChart ? 'primary' : 'default' }
 
     return (
-      <Header {...colorProps}>
-        <Padded>
+      <Header {...colorProps} fixed>
+        <Padded className={isMobile || isTablet ? 'u-p-0' : ''}>
           {this.displayAccountSwitch()}
           {this.displayBalanceHistory()}
           {this.displaySelectDates()}

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -11,6 +11,7 @@ import TransactionSelectDates from 'ducks/transactions/TransactionSelectDates'
 import flag from 'cozy-flags'
 import HistoryChart from 'ducks/balance/HistoryChart'
 import { Table } from 'components/Table'
+import Header from 'components/Header'
 import { Padded } from 'components/Spacing'
 
 import styles from './TransactionsPage.styl'
@@ -151,8 +152,11 @@ class TransactionHeader extends Component {
   }
 
   render() {
+    const withChart = flag('transaction-history')
+    const colorProps = { color: withChart ? 'primary' : 'default' }
+
     return (
-      <React.Fragment>
+      <Header {...colorProps}>
         <Padded>
           {this.displayBalanceHistory()}
           {this.displayAccountSwitch()}
@@ -160,7 +164,7 @@ class TransactionHeader extends Component {
           {this.displayBreadcrumb()}
         </Padded>
         {this.displayTableHead()}
-      </React.Fragment>
+      </Header>
     )
   }
 }

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -136,7 +136,7 @@ class TransactionHeader extends Component {
   }
 
   displayBalanceHistory() {
-    if (!flag('balance-history') || !this.props.chartData) {
+    if (!flag('transaction-history') || !this.props.chartData) {
       return
     }
 

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -26,11 +26,6 @@ import { withUpdateCategory } from 'ducks/categories'
 import { getLabel } from './helpers'
 import styles from './Transactions.styl'
 
-const sDate = styles['bnk-op-date']
-const sDesc = styles['bnk-op-desc']
-const sAmount = styles['bnk-op-amount']
-const sAction = styles['bnk-op-action']
-
 class _RowDesktop extends React.PureComponent {
   constructor(props) {
     super(props)
@@ -62,7 +57,7 @@ class _RowDesktop extends React.PureComponent {
     const account = transaction.account.data
     return (
       <tr ref={onRef}>
-        <td className={cx(sDesc, 'u-pv-half', 'u-pl-1')}>
+        <td className={cx(styles.ColumnSizeDesc, 'u-pv-half', 'u-pl-1')}>
           <Media className="u-clickable">
             <Img title={categoryTitle} onClick={showCategoryChoice}>
               <CategoryIcon
@@ -85,13 +80,13 @@ class _RowDesktop extends React.PureComponent {
           </Media>
         </td>
         <TdSecondary
-          className={cx(sDate, 'u-clickable')}
+          className={cx(styles.ColumnSizeDate, 'u-clickable')}
           onClick={this.onSelectTransaction}
         >
           {f(transaction.date, `D ${isExtraLarge ? 'MMMM' : 'MMM'} YYYY`)}
         </TdSecondary>
         <TdSecondary
-          className={cx(sAmount, 'u-clickable')}
+          className={cx(styles.ColumnSizeAmount, 'u-clickable')}
           onClick={this.onSelectTransaction}
         >
           <Figure
@@ -101,7 +96,7 @@ class _RowDesktop extends React.PureComponent {
             signed
           />
         </TdSecondary>
-        <TdSecondary className={sAction}>
+        <TdSecondary className={styles.ColumnSizeAction}>
           <TransactionActions
             transaction={transaction}
             urls={urls}

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -164,10 +164,7 @@ class TransactionsD extends React.Component {
     const Row = isDesktop ? RowDesktop : RowMobile
 
     return (
-      <TransactionContainer
-        className={styles.TransactionTable}
-        ref={ref => (this.transactionsRef = ref)}
-      >
+      <TransactionContainer className={styles.TransactionTable}>
         {manualLoadMore &&
           limitMin > 0 && (
             <LoadMoreButton onClick={() => this.props.onReachTop(20)}>

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -137,9 +137,7 @@ class TransactionsD extends React.Component {
     const {
       breakpoints: { isDesktop }
     } = this.props
-    return isDesktop
-      ? document.querySelector('.js-transactionPageBottom')
-      : window
+    return isDesktop ? document.querySelector('.js-scrolling-element') : window
   }
 
   renderTransactions() {
@@ -255,7 +253,7 @@ export class TransactionsWithSelection extends React.Component {
     const props = this.props
     const { transactionId } = this.state
     return (
-      <React.Fragment>
+      <div className="js-scrolling-element">
         <Transactions selectTransaction={this.selectTransaction} {...props} />
         {transactionId && (
           <TransactionModal
@@ -264,7 +262,7 @@ export class TransactionsWithSelection extends React.Component {
             {...props}
           />
         )}
-      </React.Fragment>
+      </div>
     )
   }
 }

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -2,6 +2,22 @@
 @require '~styles/mixins.styl'
 @require 'settings/breakpoints'
 
+.ColumnSizeDesc
+    maxed-flex-basis 40%
+    padding-left 4rem
+
+.ColumnSizeDate
+    maxed-flex-basis 15%
+    color coolGrey
+    text-align right
+
+.ColumnSizeAmount
+    maxed-flex-basis 20%
+    text-align right
+
+.ColumnSizeAction
+    maxed-flex-basis 25%
+
 .TransactionTable
     color charcoalGrey
 
@@ -11,23 +27,8 @@
         // causes a misalignment between the thead and tbody
         overflow-y scroll
 
-    .bnk-op-date
-        maxed-flex-basis 15%
-        color coolGrey
-        text-align right
-
-    .bnk-op-desc
-        maxed-flex-basis 40%
-        padding-left 4rem
-
     .bnk-op-desc-caption
         margin-top 0
-
-    .bnk-op-amount
-        maxed-flex-basis 20%
-        text-align right
-    .bnk-op-action
-        maxed-flex-basis 25%
 
     .bnk-transaction-mobile-action
         position relative

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -31,7 +31,6 @@ import Loading from 'components/Loading'
 
 import { TransactionsWithSelection } from './Transactions'
 import TransactionHeader from './TransactionHeader'
-import styles from './TransactionsPage.styl'
 import {
   ACCOUNT_DOCTYPE,
   appsConn,
@@ -243,24 +242,20 @@ class TransactionsPage extends Component {
     }
 
     return (
-      <div
-        className={styles.TransactionPage__bottom + ' js-transactionPageBottom'}
-      >
-        <TransactionsWithSelection
-          limitMin={limitMin}
-          limitMax={limitMax}
-          onReachTop={this.handleDecreaseLimitMin}
-          onReachBottom={this.handleIncreaseLimitMax}
-          infiniteScrollTop={infiniteScrollTop}
-          onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
-          onScroll={this.checkToActivateTopInfiniteScroll}
-          transactions={transations}
-          urls={urls}
-          brands={this.getBrands()}
-          filteringOnAccount={this.getFilteringOnAccount()}
-          manualLoadMore={isIOSApp()}
-        />
-      </div>
+      <TransactionsWithSelection
+        limitMin={limitMin}
+        limitMax={limitMax}
+        onReachTop={this.handleDecreaseLimitMin}
+        onReachBottom={this.handleIncreaseLimitMax}
+        infiniteScrollTop={infiniteScrollTop}
+        onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
+        onScroll={this.checkToActivateTopInfiniteScroll}
+        transactions={transations}
+        urls={urls}
+        brands={this.getBrands()}
+        filteringOnAccount={this.getFilteringOnAccount()}
+        manualLoadMore={isIOSApp()}
+      />
     )
   }
 
@@ -312,7 +307,7 @@ class TransactionsPage extends Component {
     const chartData = this.getChartData()
 
     return (
-      <div className={styles.TransactionPage}>
+      <React.Fragment>
         <TransactionHeader
           transactions={filteredTransactions}
           handleChangeMonth={this.handleChangeMonth}
@@ -330,7 +325,7 @@ class TransactionsPage extends Component {
         ) : (
           this.displayTransactions()
         )}
-      </div>
+      </React.Fragment>
     )
   }
 }

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -247,7 +247,6 @@ class TransactionsPage extends Component {
         className={styles.TransactionPage__bottom + ' js-transactionPageBottom'}
       >
         <TransactionsWithSelection
-          className={styles.TransactionPage__top}
           limitMin={limitMin}
           limitMax={limitMax}
           onReachTop={this.handleDecreaseLimitMin}

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -1,17 +1,5 @@
 @require 'settings/breakpoints'
-@require '~components/SelectDates/SelectDates.styl'
 @require '~styles/mixins.styl'
-
-.TransactionPage
-    display flex
-    flex-direction column
-    height 100%
-    +small-screen()
-        display block
-
-        // SelectDate is fixed on mobile so we need to add some
-        // padding
-        padding-top select-date-height-small
 
 .TransactionPage__bottom
     overflow auto // TODO remove in small screen

--- a/src/ducks/transactions/header/TableHead.jsx
+++ b/src/ducks/transactions/header/TableHead.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { flowRight as compose } from 'lodash'
+import { translate, withBreakpoints } from 'cozy-ui/react'
+import { Table } from 'components/Table'
+
+import transactionsStyles from '../Transactions.styl'
+import styles from './TableHead.styl'
+
+const TableHead = ({ t, breakpoints, isSubcategory }) => {
+  if (breakpoints.isMobile || breakpoints.isTablet) {
+    return null
+  }
+
+  return (
+    <div className={styles.TableHead}>
+      <Table className={transactionsStyles.TransactionTable}>
+        <thead>
+          <tr>
+            <td className={transactionsStyles['bnk-op-desc']}>
+              {t(
+                isSubcategory
+                  ? 'Categories.headers.movements'
+                  : 'Transactions.header.description'
+              )}
+            </td>
+            <td className={transactionsStyles['bnk-op-date']}>
+              {t('Transactions.header.date')}
+            </td>
+            <td className={transactionsStyles['bnk-op-amount']}>
+              {t('Transactions.header.amount')}
+            </td>
+            <td className={transactionsStyles['bnk-op-action']}>
+              {t('Transactions.header.action')}
+            </td>
+          </tr>
+        </thead>
+      </Table>
+    </div>
+  )
+}
+
+export default compose(
+  withBreakpoints(),
+  translate()
+)(TableHead)

--- a/src/ducks/transactions/header/TableHead.jsx
+++ b/src/ducks/transactions/header/TableHead.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import { Table } from 'components/Table'
@@ -6,37 +7,39 @@ import { Table } from 'components/Table'
 import transactionsStyles from '../Transactions.styl'
 import styles from './TableHead.styl'
 
-const TableHead = ({ t, breakpoints, isSubcategory }) => {
+const TableHead = ({ t, breakpoints, isSubcategory, color }) => {
   if (breakpoints.isMobile || breakpoints.isTablet) {
     return null
   }
 
   return (
-    <div className={styles.TableHead}>
-      <Table className={transactionsStyles.TransactionTable}>
-        <thead>
-          <tr>
-            <td className={transactionsStyles['bnk-op-desc']}>
-              {t(
-                isSubcategory
-                  ? 'Categories.headers.movements'
-                  : 'Transactions.header.description'
-              )}
-            </td>
-            <td className={transactionsStyles['bnk-op-date']}>
-              {t('Transactions.header.date')}
-            </td>
-            <td className={transactionsStyles['bnk-op-amount']}>
-              {t('Transactions.header.amount')}
-            </td>
-            <td className={transactionsStyles['bnk-op-action']}>
-              {t('Transactions.header.action')}
-            </td>
-          </tr>
-        </thead>
-      </Table>
-    </div>
+    <Table className={styles[`TableHead_${color}`]}>
+      <thead>
+        <tr>
+          <td className={transactionsStyles.ColumnSizeDesc}>
+            {t(
+              isSubcategory
+                ? 'Categories.headers.movements'
+                : 'Transactions.header.description'
+            )}
+          </td>
+          <td className={transactionsStyles.ColumnSizeDate}>
+            {t('Transactions.header.date')}
+          </td>
+          <td className={transactionsStyles.ColumnSizeAmount}>
+            {t('Transactions.header.amount')}
+          </td>
+          <td className={transactionsStyles.ColumnSizeAction}>
+            {t('Transactions.header.action')}
+          </td>
+        </tr>
+      </thead>
+    </Table>
   )
+}
+
+TableHead.propTypes = {
+  color: PropTypes.oneOf(['default', 'primary'])
 }
 
 export default compose(

--- a/src/ducks/transactions/header/TableHead.styl
+++ b/src/ducks/transactions/header/TableHead.styl
@@ -1,5 +1,23 @@
-.TableHead
+.TableHead_default
     background white
     marginTop 1rem
     marginLeft -2rem
     marginRight -2rem
+
+.TableHead_primary
+    background-color var(--primary-light)
+
+    thead
+        tr
+            border 0
+            padding .5rem 0
+
+            td
+                padding 0 1rem
+                font-size .75rem
+                line-height 1rem
+                font-weight bold
+                color var(--primary-contrast-text)
+
+            td + td
+                border-left 1px solid var(--primary)

--- a/src/ducks/transactions/header/TableHead.styl
+++ b/src/ducks/transactions/header/TableHead.styl
@@ -1,0 +1,5 @@
+.TableHead
+    background white
+    marginTop 1rem
+    marginLeft -2rem
+    marginRight -2rem

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -10,10 +10,6 @@ h4
     margin-top 0
     margin-bottom 1rem
 
-html, body
-    +medium-screen()
-        overflow-x hidden
-
 +small-screen()
     [role='banner'][data-drawer-visible='true']
         z-index 90


### PR DESCRIPTION
Changes :
- Add a flag (transaction-history) to display separately the graph current balance and transaction
- Add blue frame on transaction
- Add new design on table head

You can see design with and without `transaction-history` flag:

without | with
--------|-----
![capture d ecran 2018-12-06 a 09 00 24](https://user-images.githubusercontent.com/1135513/49570009-cd6f3380-f935-11e8-8d83-d8199ae3c2c9.png) | ![capture d ecran 2018-12-06 a 09 01 19](https://user-images.githubusercontent.com/1135513/49570030-d95af580-f935-11e8-97c6-0f70ce869a32.png)
![capture d ecran 2018-12-06 a 09 02 39](https://user-images.githubusercontent.com/1135513/49571610-145f2800-f93a-11e8-9303-6bfdc968a251.png) | ![capture d ecran 2018-12-06 a 09 01 47](https://user-images.githubusercontent.com/1135513/49571616-1923dc00-f93a-11e8-92a8-1c9280956104.png)
