### PR TITLE
fix(settings): Remove _type from default settings

### DIFF
--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -2,7 +2,6 @@
 
 exports[`defaulted settings should return defaulted settings 1`] = `
 Object {
-  "_type": "io.cozy.bank.settings",
   "billsMatching": Object {
     "billsLastSeq": "0",
     "transactionsLastSeq": "0",

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -2,7 +2,6 @@ export const DOCTYPE = 'io.cozy.bank.settings'
 export const COLLECTION_NAME = 'settings'
 
 export const DEFAULTS_SETTINGS = {
-  _type: 'io.cozy.bank.settings',
   notifications: {
     lastSeq: 0,
     balanceLower: {


### PR DESCRIPTION
It led to an error when saving settings in the service. There was no error in the app because it uses the new cozy-client that handles it automatically.