### PR TITLE
Show the full graph when there is no transaction

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -156,7 +156,17 @@ class LineChart extends Component {
     const sortedData = sortBy(data, d => d.x)
 
     this.x.domain(d3.extent(data, d => d.x))
-    this.y.domain(d3.extent(data, d => d.y))
+
+    let yDomain = d3.extent(data, d => d.y)
+
+    // If min === max, the line will be drawn on the bottom, like
+    // all values are the min. We want to opposite, so we set the
+    // min to 0. This way the line will be drawn on the top
+    if (yDomain[0] === yDomain[1]) {
+      yDomain[0] = 0
+    }
+
+    this.y.domain(yDomain)
 
     this.line.datum(sortedData).attr('d', this.lineGenerator)
     this.clickLine.datum(sortedData).attr('d', this.lineGenerator)

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -7,7 +7,7 @@ import { sumBy, uniq, groupBy } from 'lodash'
 import styles from './History.styl'
 import HistoryChart from './HistoryChart'
 import { isCollectionLoading } from 'ducks/client/utils'
-import { format as formatDate } from 'date-fns'
+import { format as formatDate, subYears } from 'date-fns'
 import * as d3 from 'd3'
 import {
   getBalanceHistories,
@@ -21,10 +21,12 @@ class History extends Component {
   }
 
   getBalanceHistory(accounts, transactions) {
+    const today = new Date()
     const balanceHistories = getBalanceHistories(
       accounts,
       transactions,
-      new Date()
+      today,
+      subYears(today, 1)
     )
     const balanceHistory = sumBalanceHistories(Object.values(balanceHistories))
 


### PR DESCRIPTION
We showed only the last day's balance when there is no transaction:

![image](https://user-images.githubusercontent.com/1606068/49723570-67e9b280-fc67-11e8-8fed-1b7e0c51eff7.png)

This was because we didn't provide the whole `from` => `to` interval. So I just added the `to` date.

But it showed another problem: when there is only one value `n` in the dataset, the domain of the `y` axis is `[n, n]`, and d3 will draw the line like all values are the minimum:

![image](https://user-images.githubusercontent.com/1606068/49723756-ea727200-fc67-11e8-95fa-566f5e7146b6.png)

So I handled it by setting the minimum value of the domain to `0` in that case:

![image](https://user-images.githubusercontent.com/1606068/49723812-0aa23100-fc68-11e8-9218-dc0a7e451e0a.png)