### PR TITLE
fix(deps): Update cozy-flags to v1.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "cozy-client-js": "0.14.2",
     "cozy-device-helper": "1.4.14",
     "cozy-doctypes": "1.17.0",
-    "cozy-flags": "1.3.1",
+    "cozy-flags": "1.3.2",
     "cozy-interapp": "0.2.13",
     "cozy-konnector-libs": "4.11.8",
     "cozy-pouch-link": "4.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4663,10 +4663,10 @@ cozy-doctypes@1.17.0:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-flags@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.3.1.tgz#593a3cf4535f40a8d5d537b81d192d163188986b"
-  integrity sha512-/i8NtN0WQd0HkkU+FTyEEBGHOo/Qp0Rhl3ZiPDr5e2lqicWg3Lmr9mwS5XdMRdQAKombUYKQmEWfcqT564A4jQ==
+cozy-flags@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.3.2.tgz#c8c90c970b7fb84f4bff22c0dd50778bbe6ac1e5"
+  integrity sha512-u//xb2JR9KRsX4JJncDHwUDIHMmxstN96G0u7I5cgaCCa4r7aPRuCbzJ12IdSyhFDdSwV1L81Cyi+ZYJijNwjw==
 
 cozy-interapp@0.2.13:
   version "0.2.13"
@@ -13591,13 +13591,6 @@ pouchdb-adapter-cordova-sqlite@2.0.5:
   integrity sha512-K7eIQzFYfuYOo4Nwn8r96Pq01t5mPOppO+n31U7IM/fPJTIGS/juJyNYYY9ePrlrz8icHEDl35cgHLMq40xFyA==
   dependencies:
     pouchdb-adapter-websql-core "^6.4.3"
-
-"pouchdb-adapter-cordova-sqlite@git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
-  version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
-  resolved "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
-  dependencies:
-    pouchdb-adapter-websql-core "^6.1.1"
 
 "pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"


### PR DESCRIPTION
This release fixes a bug in browser/node detection that broke the flag system in browser. See https://github.com/cozy/cozy-libs/pull/181 for more details.