### PR TITLE
chore: Add eoviMCD in brand dictionnary

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -92,6 +92,12 @@
     "konnectorSlug": "engie"
   },
   {
+    "name": "Eovi MCD Particuliers",
+    "regexp": "\\beovi mcd mutuelle\\b",
+    "konnectorSlug": "eovimcdparticuliers"
+  },
+
+  {
     "name": "Free",
     "regexp": "\\bfree (telecom|hautdebit)\\b",
     "konnectorSlug": "free"


### PR DESCRIPTION
@kossi, as resquested, would be great to put it quickly in prod

(we hope that will be a soft advertise to have our first accounts slowly)
But more than 0.