### PR TITLE
Service fixes

### DIFF
--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`defaulted settings should return defaulted settings 1`] = `
 Object {
+  "_type": "io.cozy.bank.settings",
   "billsMatching": Object {
     "billsLastSeq": "0",
     "transactionsLastSeq": "0",

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -2,6 +2,7 @@ export const DOCTYPE = 'io.cozy.bank.settings'
 export const COLLECTION_NAME = 'settings'
 
 export const DEFAULTS_SETTINGS = {
+  _type: 'io.cozy.bank.settings',
   notifications: {
     lastSeq: 0,
     balanceLower: {

--- a/src/ducks/settings/services.js
+++ b/src/ducks/settings/services.js
@@ -2,6 +2,7 @@ import logger from 'cozy-logger'
 import { getDefaultedSettings } from './helpers'
 import { Document } from 'cozy-doctypes'
 import { DOCTYPE } from './constants'
+import { omit } from 'lodash'
 
 const log = logger.namespace('settings-doctype')
 
@@ -14,7 +15,7 @@ class Settings extends Document {
       log('info', 'No settings yet, default settings are used')
     }
 
-    return getDefaultedSettings(settings)
+    return omit(getDefaultedSettings(settings), ['_type'])
   }
 }
 

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -36,7 +36,7 @@ const fetchChangesOrAll = async (Model, lastSeq) => {
       descending: true,
       limit: 1
     })
-    return { documents, newLastSeq: lastChanges.last_seq }
+    return { documents, newLastSeq: lastChanges.newLastSeq }
   } else {
     return Model.fetchChanges(lastSeq)
   }


### PR DESCRIPTION
This PR addresses two things:

* Revert a commit that removed the `_type` property in default settings. We actually needed it in the app and the new cozy-client removes it automatically. Since the service uses the old cozy-client-js, we need to remove it by hand in the service
* There was a typo in the retrieval of the last seq in the `fetchChangesOrAll` function. We ended with undefined last seq persisted in DB