### PR TITLE
fix(HasManyReimbursements): Split bill id

### DIFF
--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -57,7 +57,7 @@ class HasManyBills extends HasManyInPlace {
   }
 }
 
-class HasManyReimbursements extends HasManyInPlace {
+export class HasManyReimbursements extends HasManyInPlace {
   get raw() {
     return this.target[this.name]
   }
@@ -74,7 +74,10 @@ class HasManyReimbursements extends HasManyInPlace {
     if (!included || !included.length) {
       return null
     }
-    const missingIds = included.map(doc => doc.billId)
+    const missingIds = included
+      .map(doc => doc.billId && doc.billId.split(':')[1])
+      .filter(Boolean)
+
     return new QueryDefinition({ doctype: assoc.doctype, ids: missingIds })
   }
 }

--- a/src/doctypes.spec.js
+++ b/src/doctypes.spec.js
@@ -1,4 +1,4 @@
-import { transactionsConn } from './doctypes'
+import { transactionsConn, HasManyReimbursements } from './doctypes'
 import getClient from 'test/client'
 
 const client = getClient()
@@ -6,5 +6,25 @@ const client = getClient()
 describe('transactionsConn', () => {
   it('should have no limit', () => {
     expect(transactionsConn.query(client).limit).toBeNull()
+  })
+})
+
+describe('HasManyReimbursements', () => {
+  describe('query', () => {
+    it('should return a QueryDefinition with the right ids', () => {
+      const doc = {
+        reimbursements: [
+          { billId: 'io.cozy.bills:b1' },
+          { billId: 'io.cozy.bills:b2' },
+          { billId: 'io.cozy.bills:b3' },
+          {} // just to test that docs without billId are handled
+        ]
+      }
+
+      const assoc = { name: 'reimbursements' }
+      const queryDefinition = HasManyReimbursements.query(doc, null, assoc)
+
+      expect(queryDefinition.ids).toEqual(['b1', 'b2', 'b3'])
+    })
   })
 })


### PR DESCRIPTION
We splitted the bill id in `HasManyReimbursements::get data` but not in `HasManyReimbursements::query`.