### PR TITLE
chore(fixtures): Remove free bill on Docteur Martin transaction

### DIFF
--- a/test/fixtures/latestfixture_2018-12-11.json
+++ b/test/fixtures/latestfixture_2018-12-11.json
@@ -1244,9 +1244,6 @@
       "currency": "€",
       "amount": -25,
       "date": "2018-10-19T00:00:00Z",
-      "bills": [
-        "io.cozy.bills:b0"
-      ],
       "_id": "paiementdocteur",
       "reimbursements": [
         {


### PR DESCRIPTION
Having a health transaction linked to a Free bill was a nonsense for demo.