### PR TITLE
fix: Balance Header design

### DIFF
--- a/src/components/Figure/FigureBlock.styl
+++ b/src/components/Figure/FigureBlock.styl
@@ -17,6 +17,3 @@
 +small-screen()
     .FigureBlock
         font-size .7em
-
-    .FigureBlock-figure
-        padding-bottom 0.5rem

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,6 +1,5 @@
 import React, { PureComponent, Fragment } from 'react'
 import { flowRight as compose, sortBy, get, keyBy, sumBy } from 'lodash'
-import cx from 'classnames'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import { queryConnect } from 'cozy-client'
 import flag from 'cozy-flags'
@@ -31,10 +30,9 @@ class Balance extends PureComponent {
     } = this.props
 
     const withChart = flag('balance-history')
-    const headerColorProps = { color: withChart ? 'primary' : 'default' }
-    const headerClassName = cx(styles.Balance_Header, {
-      [styles.Balance_Header_WithChart]: withChart
-    })
+    const color = withChart ? 'primary' : 'default'
+    const headerColorProps = { color }
+    const headerClassName = styles[`Balance_HeaderColor_${color}`]
     const titleColorProps = {
       color: withChart && !isMobile ? 'primary' : 'default'
     }

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -1,20 +1,16 @@
 @require 'settings/breakpoints'
 
-.Balance_Header
+.Balance_HeaderColor_primary
     padding-top: 1.5rem
     padding-bottom .5rem
     text-align center
     color white
-
-    +small-screen()
-        padding-top: .5rem
-        padding-bottom 0
-
-.Balance_Header_WithChart
     min-height 213px
 
     +small-screen()
         min-height 159px
+        padding-top: .5rem
+        padding-bottom 0
 
 .Balance__currentBalance
     text-align center


### PR DESCRIPTION
The old design must have the titles to the left

Before | After
-------|------
<img width="362" alt="capture d ecran 2018-12-14 a 15 49 07" src="https://user-images.githubusercontent.com/1135513/50009989-9f829280-ffb8-11e8-9176-8e2dfb5c4e60.png"> | <img width="363" alt="capture d ecran 2018-12-14 a 15 44 50" src="https://user-images.githubusercontent.com/1135513/50009959-8a0d6880-ffb8-11e8-8351-3e2b5ae683b0.png">
<img width="1280" alt="capture d ecran 2018-12-14 a 15 48 51" src="https://user-images.githubusercontent.com/1135513/50009887-66e2b900-ffb8-11e8-91f3-59c6aa483a28.png"> | <img width="1280" alt="capture d ecran 2018-12-14 a 15 43 46" src="https://user-images.githubusercontent.com/1135513/50009968-91347680-ffb8-11e8-88e6-84562b1d8f52.png">
<img width="362" alt="capture d ecran 2018-12-14 a 15 48 04" src="https://user-images.githubusercontent.com/1135513/50009905-72ce7b00-ffb8-11e8-9fd1-0e6ae623e195.png"> | <img width="362" alt="capture d ecran 2018-12-14 a 15 45 34" src="https://user-images.githubusercontent.com/1135513/50010042-b923da00-ffb8-11e8-8900-c0082dbd75e2.png">
<img width="1280" alt="capture d ecran 2018-12-14 a 15 48 17" src="https://user-images.githubusercontent.com/1135513/50009913-76620200-ffb8-11e8-81ab-b14164ae1336.png"> | <img width="1280" alt="capture d ecran 2018-12-14 a 15 45 54" src="https://user-images.githubusercontent.com/1135513/50010024-af01db80-ffb8-11e8-971a-71badb4e6b7f.png">

