### PR TITLE
feat: Add a setting to show the balance history

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,8 +1,7 @@
 import React, { PureComponent, Fragment } from 'react'
 import { flowRight as compose, sortBy, get, keyBy, sumBy } from 'lodash'
-import { translate, withBreakpoints } from 'cozy-ui/react'
+import { translate, withBreakpoints, Spinner } from 'cozy-ui/react'
 import { queryConnect } from 'cozy-client'
-import flag from 'cozy-flags'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 
 import Loading from 'components/Loading'
@@ -29,7 +28,12 @@ class Balance extends PureComponent {
       settings: settingsCollection
     } = this.props
 
-    const withChart = flag('balance-history')
+    if (isCollectionLoading(settingsCollection)) {
+      return <Spinner />
+    }
+
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
+    const withChart = settings.experimentalFeatures.balanceHistory
     const color = withChart ? 'primary' : 'default'
     const headerColorProps = { color }
     const headerClassName = styles[`Balance_HeaderColor_${color}`]
@@ -43,8 +47,7 @@ class Balance extends PureComponent {
 
     if (
       isCollectionLoading(accountsCollection) ||
-      isCollectionLoading(groupsCollection) ||
-      isCollectionLoading(settingsCollection)
+      isCollectionLoading(groupsCollection)
     ) {
       return (
         <Fragment>
@@ -76,7 +79,6 @@ class Balance extends PureComponent {
 
     const accounts = accountsCollection.data
     const groups = [...groupsCollection.data, ...buildVirtualGroups(accounts)]
-    const settings = getDefaultedSettingsFromCollection(settingsCollection)
 
     const accountsSorted = sortBy(accounts, ['institutionLabel', 'label'])
     const groupsSorted = sortBy(

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -33,7 +33,7 @@ class Balance extends PureComponent {
     }
 
     const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    const withChart = settings.experimentalFeatures.balanceHistory
+    const withChart = settings.balanceHistory.enabled
     const color = withChart ? 'primary' : 'default'
     const headerColorProps = { color }
     const headerClassName = styles[`Balance_HeaderColor_${color}`]

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import TogglePane, {
   TogglePaneTitle,
   TogglePaneSubtitle,
@@ -13,7 +13,7 @@ import { flowRight as compose, set } from 'lodash'
 import Loading from 'components/Loading'
 import { getDefaultedSettingsFromCollection } from './helpers'
 
-class Configuration extends Component {
+class Configuration extends React.PureComponent {
   saveDocument = async doc => {
     const { saveDocument } = this.props
     await saveDocument(doc)

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -66,6 +66,18 @@ class Configuration extends Component {
           title={t('CommunitySettings.title')}
           settingsKey="community"
         />
+        <TogglePane
+          settingsCollection={settingsCollection}
+          saveDocument={this.saveDocument}
+          rows={[
+            {
+              name: 'balanceHistory',
+              description: t('ExperimentalFeatures.balance_history.subtitle')
+            }
+          ]}
+          title={t('ExperimentalFeatures.title')}
+          settingsKey="experimentalFeatures"
+        />
       </div>
     )
   }

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -1,17 +1,41 @@
 import React, { Component } from 'react'
-import TogglePane from './TogglePane'
+import TogglePane, {
+  TogglePaneTitle,
+  TogglePaneSubtitle,
+  TogglePaneText
+} from './TogglePane'
+import ToggleRow from './ToggleRow'
 import { translate } from 'cozy-ui/react'
 import { isCollectionLoading } from 'ducks/client/utils'
 import { queryConnect, withMutations } from 'cozy-client'
 import { settingsConn } from 'doctypes'
-import { flowRight as compose } from 'lodash'
+import { flowRight as compose, set } from 'lodash'
 import Loading from 'components/Loading'
+import { getDefaultedSettingsFromCollection } from './helpers'
 
 class Configuration extends Component {
   saveDocument = async doc => {
     const { saveDocument } = this.props
     await saveDocument(doc)
-    this.setState({})
+    this.forceUpdate()
+  }
+
+  onToggle = key => checked => {
+    const { settingsCollection } = this.props
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
+    set(settings, [...key.split('.'), 'enabled'], checked)
+    this.saveDocument(settings, {
+      updateCollections: ['settings']
+    })
+  }
+
+  onChangeValue = key => value => {
+    const { settingsCollection } = this.props
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
+    set(settings, [...key.split('.'), 'value'], value)
+    this.saveDocument(settings, {
+      updateCollections: ['settings']
+    })
   }
 
   render() {
@@ -21,63 +45,76 @@ class Configuration extends Component {
       return <Loading />
     }
 
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
+
     return (
       <div>
-        <TogglePane
-          settingsCollection={settingsCollection}
-          saveDocument={this.saveDocument}
-          rows={[
-            {
-              title: t('Notifications.if_balance_lower.settingTitle'),
-              name: 'balanceLower',
-              description: t('Notifications.if_balance_lower.description')
-            },
-            {
-              title: t('Notifications.if_transaction_greater.settingTitle'),
-              name: 'transactionGreater',
-              description: t('Notifications.if_transaction_greater.description')
-            },
-            {
-              title: t('Notifications.when_health_bill_linked.settingTitle'),
-              name: 'healthBillLinked',
-              description: t(
-                'Notifications.when_health_bill_linked.description'
-              )
-            }
-          ]}
-          title={t('Notifications.title')}
-          settingsKey="notifications"
-          description={t('Notifications.description')}
-        />
-        <TogglePane
-          rows={[
-            {
-              title: t('CommunitySettings.local_model_override.title'),
-              name: 'localModelOverride',
-              description: t('CommunitySettings.local_model_override.subtitle')
-            },
-            {
-              name: 'autoCategorization',
-              description: t('CommunitySettings.auto_categorization.subtitle')
-            }
-          ]}
-          saveDocument={this.saveDocument}
-          settingsCollection={settingsCollection}
-          title={t('CommunitySettings.title')}
-          settingsKey="community"
-        />
-        <TogglePane
-          settingsCollection={settingsCollection}
-          saveDocument={this.saveDocument}
-          rows={[
-            {
-              name: 'balanceHistory',
-              description: t('ExperimentalFeatures.balance_history.subtitle')
-            }
-          ]}
-          title={t('ExperimentalFeatures.title')}
-          settingsKey="experimentalFeatures"
-        />
+        <TogglePane>
+          <TogglePaneTitle>{t('Notifications.title')}</TogglePaneTitle>
+          <TogglePaneText>{t('Notifications.description')}</TogglePaneText>
+          <ToggleRow
+            title={t('Notifications.if_balance_lower.settingTitle')}
+            description={t('Notifications.if_balance_lower.description')}
+            onToggle={this.onToggle('notifications.balanceLower')}
+            onChangeValue={this.onChangeValue('notifications.balanceLower')}
+            enabled={settings.notifications.balanceLower.enabled}
+            value={settings.notifications.balanceLower.value}
+            name="balanceLower"
+          />
+          <ToggleRow
+            title={t('Notifications.if_transaction_greater.settingTitle')}
+            description={t('Notifications.if_transaction_greater.description')}
+            onToggle={this.onToggle('notifications.transactionGreater')}
+            onChangeValue={this.onChangeValue(
+              'notifications.transactionGreater'
+            )}
+            enabled={settings.notifications.transactionGreater.enabled}
+            value={settings.notifications.transactionGreater.value}
+            name="transactionGreater"
+          />
+          <ToggleRow
+            title={t('Notifications.when_health_bill_linked.settingTitle')}
+            description={t('Notifications.when_health_bill_linked.description')}
+            onToggle={this.onToggle('notifications.healthBillLinked')}
+            enabled={settings.notifications.healthBillLinked.enabled}
+            name="healthBillLinked"
+          />
+        </TogglePane>
+        <TogglePane>
+          <TogglePaneTitle>
+            {t('AdvancedFeaturesSettings.title')}
+          </TogglePaneTitle>
+          <TogglePaneSubtitle>
+            {t('AdvancedFeaturesSettings.automatic_categorization.title')}
+          </TogglePaneSubtitle>
+          <ToggleRow
+            description={t(
+              'AdvancedFeaturesSettings.automatic_categorization.local_model_override.description'
+            )}
+            onToggle={this.onToggle('community.localModelOverride')}
+            enabled={settings.community.localModelOverride.enabled}
+            name="localModelOverride"
+          />
+          <ToggleRow
+            description={t(
+              'AdvancedFeaturesSettings.automatic_categorization.auto_categorization.description'
+            )}
+            onToggle={this.onToggle('community.autoCategorization')}
+            enabled={settings.community.autoCategorization.enabled}
+            name="autoCategorization"
+          />
+          <TogglePaneSubtitle>
+            {t('AdvancedFeaturesSettings.balance_history.title')}
+          </TogglePaneSubtitle>
+          <ToggleRow
+            description={t(
+              'AdvancedFeaturesSettings.balance_history.show_chart.description'
+            )}
+            onToggle={this.onToggle('balanceHistory')}
+            enabled={settings.balanceHistory.enabled}
+            name="balanceHistory"
+          />
+        </TogglePane>
       </div>
     )
   }

--- a/src/ducks/settings/TogglePane.jsx
+++ b/src/ducks/settings/TogglePane.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { Title } from 'cozy-ui/react'
 import ToggleRow from './ToggleRow'
@@ -8,7 +8,7 @@ const ToogleDescription = ({ children }) => (
   <p className="u-coolGrey">{children}</p>
 )
 
-class TogglePane extends Component {
+class TogglePane extends React.PureComponent {
   onToggle = (setting, checked) => {
     const { settingsCollection, settingsKey } = this.props
     const settings = getDefaultedSettingsFromCollection(settingsCollection)

--- a/src/ducks/settings/TogglePane.jsx
+++ b/src/ducks/settings/TogglePane.jsx
@@ -1,83 +1,31 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { Title } from 'cozy-ui/react'
-import ToggleRow from './ToggleRow'
-import { getDefaultedSettingsFromCollection } from './helpers'
-
-const ToogleDescription = ({ children }) => (
-  <p className="u-coolGrey">{children}</p>
-)
+import styles from './TogglePane.styl'
 
 class TogglePane extends React.PureComponent {
-  onToggle = (setting, checked) => {
-    const { settingsCollection, settingsKey } = this.props
-    const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    settings[settingsKey][setting].enabled = checked
-    this.props.saveDocument(settings, {
-      updateCollections: ['settings']
-    })
-  }
-
-  onChangeValue = (setting, value) => {
-    const { settingsCollection, settingsKey } = this.props
-    const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    settings[settingsKey][setting].value = value
-    this.props.saveDocument(settings, {
-      updateCollections: ['settings']
-    })
-  }
-
-  renderRows = () => {
-    const { rows, settingsCollection, settingsKey } = this.props
-    const settings = getDefaultedSettingsFromCollection(settingsCollection)
-
-    return (
-      <div>
-        {rows.map(row => {
-          const setting = settings[settingsKey][row.name]
-
-          return (
-            <ToggleRow
-              key={row.name}
-              enabled={setting.enabled}
-              value={setting.value}
-              title={row.title}
-              description={row.description}
-              onChangeValue={this.onChangeValue}
-              name={row.name}
-              onToggle={this.onToggle}
-            />
-          )
-        })}
-      </div>
-    )
-  }
-
   render() {
-    const { title, description } = this.props
+    return <div className="u-pb-2-half">{this.props.children}</div>
+  }
+}
 
+export class TogglePaneTitle extends React.PureComponent {
+  render() {
     return (
-      <div className="u-pb-2-half">
-        <Title>{title}</Title>
-        {description && <ToogleDescription>{description}</ToogleDescription>}
-        {this.renderRows()}
-      </div>
+      <Title className={styles.TogglePaneTitle}>{this.props.children}</Title>
     )
   }
 }
 
-TogglePane.propTypes = {
-  rows: PropTypes.arrayOf(
-    PropTypes.shape({
-      title: PropTypes.string,
-      name: PropTypes.string,
-      description: PropTypes.string
-    })
-  ).isRequired,
-  title: PropTypes.string.isRequired,
-  settingsKey: PropTypes.string.isRequired,
-  settingsCollection: PropTypes.object.isRequired,
-  saveDocument: PropTypes.func.isRequired
+export class TogglePaneSubtitle extends React.PureComponent {
+  render() {
+    return <h5 className={styles.TogglePaneSubtitle}>{this.props.children}</h5>
+  }
+}
+
+export class TogglePaneText extends React.PureComponent {
+  render() {
+    return <p className="u-coolGrey">{this.props.children}</p>
+  }
 }
 
 export default TogglePane

--- a/src/ducks/settings/TogglePane.styl
+++ b/src/ducks/settings/TogglePane.styl
@@ -1,0 +1,6 @@
+.TogglePaneTitle
+    margin-bottom 1rem
+
+.TogglePaneSubtitle
+    margin-top 1rem
+    margin-bottom 1rem

--- a/src/ducks/settings/ToggleRow.jsx
+++ b/src/ducks/settings/ToggleRow.jsx
@@ -31,7 +31,7 @@ class ToggleRow extends Component {
             {hasValue && (
               <input
                 type="number"
-                onChange={e => onChangeValue(name, parseNumber(e.target.value))}
+                onChange={e => onChangeValue(parseNumber(e.target.value))}
                 value={value}
                 className={cx(
                   styles.ToggleRow__input,
@@ -46,7 +46,7 @@ class ToggleRow extends Component {
             <Toggle
               id={name}
               checked={enabled}
-              onToggle={checked => onToggle(name, checked)}
+              onToggle={checked => onToggle(checked)}
             />
           </div>
         </div>

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -3,6 +3,9 @@
 exports[`defaulted settings should return defaulted settings 1`] = `
 Object {
   "_type": "io.cozy.bank.settings",
+  "balanceHistory": Object {
+    "enabled": false,
+  },
   "billsMatching": Object {
     "billsLastSeq": "0",
     "transactionsLastSeq": "0",
@@ -15,11 +18,6 @@ Object {
       "enabled": false,
     },
     "localModelOverride": Object {
-      "enabled": false,
-    },
-  },
-  "experimentalFeatures": Object {
-    "balanceHistory": Object {
       "enabled": false,
     },
   },

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -18,6 +18,11 @@ Object {
       "enabled": false,
     },
   },
+  "experimentalFeatures": Object {
+    "balanceHistory": Object {
+      "enabled": false,
+    },
+  },
   "notifications": Object {
     "balanceLower": Object {
       "enabled": false,

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -41,5 +41,10 @@ export const DEFAULTS_SETTINGS = {
   categorization: {
     lastSeq: 0
   },
-  showIncomeCategory: true
+  showIncomeCategory: true,
+  experimentalFeatures: {
+    balanceHistory: {
+      enabled: false
+    }
+  }
 }

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -42,9 +42,7 @@ export const DEFAULTS_SETTINGS = {
     lastSeq: 0
   },
   showIncomeCategory: true,
-  experimentalFeatures: {
-    balanceHistory: {
-      enabled: false
-    }
+  balanceHistory: {
+    enabled: false
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -410,17 +410,6 @@
     "app": "App"
   },
 
-  "CommunitySettings": {
-    "title": "Community-based features",
-    "auto_categorization": {
-      "subtitle": "Help us improve the model by anonymously sharing your categorized transactions. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>More</a>"
-    },
-    "local_model_override": {
-      "title": "Automatic categorization of your transactions",
-      "subtitle": "Learn from my manual categorizations"
-    }
-  },
-
   "AppSettings": {
     "reset": "reset",
     "description": "By clicking Reset, you will be able to start your application over, and will only lose the data saved on your smartphone.",
@@ -522,10 +511,22 @@
     "message": "Logout in progress..."
   },
 
-  "ExperimentalFeatures": {
-    "title": "Experimental features",
+  "AdvancedFeaturesSettings": {
+    "title": "Advanced features",
+    "automatic_categorization": {
+      "title" :"Automatic categorization",
+      "local_model_override": {
+        "description": "Learn from my manual categorizations"
+      },
+      "auto_categorization": {
+        "description": "Help us improve the model by anonymously sharing your categorized transactions. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>More</a>"
+      }
+    },
     "balance_history": {
-      "subtitle": "Balance history chart"
+      "title": "Balance history chart",
+      "show_chart": {
+        "description": "Build my balance history chart"
+      }
     }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -520,5 +520,12 @@
 
   "LogoutModal": {
     "message": "Logout in progress..."
+  },
+
+  "ExperimentalFeatures": {
+    "title": "Experimental features",
+    "balance_history": {
+      "subtitle": "Balance history chart"
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -421,17 +421,6 @@
     "configuration": "Configuration"
   },
 
-  "CommunitySettings": {
-    "title": "Fonctions communautaires",
-    "auto_categorization": {
-      "subtitle": "Participer à l'amélioration du modèle par le partage anonymisé de vos écritures catégorisées. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>En savoir plus</a>"
-    },
-    "local_model_override": {
-      "title": "Catégorisation automatique des écritures",
-      "subtitle": "Apprendre de mes catégorisations manuelles"
-    }
-  },
-
   "Onboarding": {
     "title": {
       "desktop": "Connecter vos comptes bancaires",
@@ -475,10 +464,22 @@
     "message": "Déconnexion en cours..."
   },
 
-  "ExperimentalFeatures": {
-    "title": "Fonctions expérimentales",
+  "AdvancedFeaturesSettings": {
+    "title": "Fonctions avancées",
+    "automatic_categorization": {
+      "title" :"Catégorisation automatique",
+      "local_model_override": {
+        "description": "Apprendre de mes catégorisations manuelles"
+      },
+      "auto_categorization": {
+        "description": "Participer à l'amélioration du modèle par le partage anonymisé de vos écritures catégorisées. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>En savoir plus</a>"
+      }
+    },
     "balance_history": {
-      "subtitle": "Courbe d'historique de solde"
+      "title": "Courbe d'historique de soldes",
+      "show_chart": {
+        "description": "Voir mon historique de soldes"
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -473,5 +473,12 @@
 
   "LogoutModal": {
     "message": "Déconnexion en cours..."
+  },
+
+  "ExperimentalFeatures": {
+    "title": "Fonctions expérimentales",
+    "balance_history": {
+      "subtitle": "Courbe d'historique de solde"
+    }
   }
 }


### PR DESCRIPTION
The balance history on balance page is not behind a flag anymore. Instead, the user can enable it via a setting.

![image](https://user-images.githubusercontent.com/1606068/50157819-b08e1500-02d2-11e9-9510-c60cb7bfb348.png)

I refactored the components used in this page so we have more flexibility and can achieve what we wanted easily.
