### PR TITLE
Release 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-banks",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "main": "src/main.jsx",
   "scripts": {
     "build": "npm run build:browser && npm run build:services",

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -4,6 +4,7 @@
     display flex
     justify-content space-between
     align-items flex-start
+    flex-shrink 0
 
     +small-screen()
         flex-direction column

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110001" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.0.1" version="0.11.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110004" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.0.4" version="0.11.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110004" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.0.4" version="0.11.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110101" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.1.1" version="0.11.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>


### PR DESCRIPTION
- [ ] Create branch and the PR with the following content
- [ ] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode` and `ios-CFBundleVersion`.
- [ ] Write changelogs
  - [ ] Android: `src/targets/mobile/fastlane/metadata/android/{lang}/changelogs/ANDROID_VERSION.txt` (⚠️ ANDROID_VERSION should match `android-versionCode` in `config.xml`)
  - [ ] iOS : `src/targets/mobile/fastlane/metadata/ios/{lang}/release_notes.txt`
- [ ] Update metadata and screenshots
- [ ] Commit and tag with a beta tag (X.Y.Z-beta.M)
- [ ] Push the tag and wait for the CI to push the beta version to the registry
- [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)
- [ ] Release the app on Testflight for iOS. `yarn ios:publish`
- [ ] Release the app on Play Store on `beta` track. `yarn android:publish`
- [ ] Upload the APK (`src/targets/mobile/build/android/cozy-banks.apk`) on [the APK card in Trello](https://trello.com/c/wtToK7IN/1192-apks)
- [ ] Test well on the 3 platforms
- [ ] Tag the branch as prod (X.Y.Z)
- [ ] Push the tag, wait for the CI to push the build to the registry
- [ ] Update cozies with the latest web version via Rundeck
- [ ] [Promote Android app][playstore] to the production track
- [ ] [Promote iOS app][itunesconnect] to the production track.

<details>
<summary>How to check CI</summary>
In Travis <a href="https://travis-ci.org/cozy/cozy-banks/builds/">logs</a>, you should see

```
Attempting to publish banks (version 0.7.6-beta.0) from https://downcloud.cozycloud.cc/upload/cozy-banks/0.7.6-8f932d80f510e1942fa09865ce3526c166b00b0e/cozy-banks.tar.gz (sha256 dd42d7b55ff3992893cc2432f23a813ded6b6766a880bdf24184d35060150fe7) to https://apps-registry.cozycloud.cc (space: banks)
Application published!
```
To check that the registry has the right version:

```curl "https://apps-registry.cozycloud.cc/banks/registry/banks" | jq '.'```
</details>

<details>
<summary>How to update a Cozy on the beta version of the registry</summary>

```
cozy-stack apps update banks registry://banks/beta --domain drazik2.mycozy.cloud
```

</details>

<details>
<summary>How to deploy on Testflight</summary>

```
yarn ios:publish
```

</details>

<details>
<summary>Managing versions</summary>

#### How to bump versions

At the **start** of the release process

1. Bump the `version` number in `package.json` and `config.xml` according to semver.
2. Copy this version to the `ios-CFBundleVersion` attribute and add a fourth number `.1` (then `.2` for the next beta version etc..)
3. For `android-versionCode`, follow this formula `beta + patch*100 + minor * 10000 + major * 1000000`.
4. Update the version number for the `AppendUserAgent` preference in `config.xml`.

At the **end** of the release process

For iOS you can simply remove the suffix and rebuild/reupload.
For Android, you have nothing to do, and can simply promote the build to the production track.

#### Why not let Cordova manage this automatically ?

The difficulty is that for stores (both PlayStore and iTunesConnect), you cannot have build with the same versionCode (for
Android) or ios-CFBundleVersion (for iOS). Normally those two numbers are managed by Cordova automatically (computed from the `version` attribute) but this
does not work well if during the release process (after having pushed a beta build in Testflight/PlayStore), you want to put a new version (because you have detected bug). If you let Cordova manage this, you would have to change the `version` from your config.xml and your `package.json`, and your production users would see a jump of version.

#### Android versionCode

The android-versionCode has to be a integer. But it has to be related to the `versionName` for debugging/understand purposes. Cordova does patch + minor *100 + major * 10000 but it does not leave space for beta versions (that have the same `versionName`). This is why we go one step further : `beta + patch *100 + minor * 10000 * major * 1000000). 0.7.6-beta1 is then `700601`. This number is not visible to the users, it's `android-versionName` that is visible and it's copied from `version` automatically Cordova.

#### ios-CFBundleVersion

For iOS, this is a little bit better since `ios-CFBundleVersion` can be a string with a fourth number at the end. Add a fourth number `.1` (and then `.2`, `.3` etc..) to your version number while developing, until you are sure that the build is completely ready. Then you can remove the suffix and `ios-CFBundleVersion` will be the same as `version`.

Cordova doc : https://cordova.apache.org/docs/fr/latest/config_ref/
iOS doc : https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364
Android doc : https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes
</details>

[playstore]: https://play.google.com/apps/publish/?pli=1&account=7424624102327137158#ManageReleasesPlace:p=io.cozy.banks.mobile&appid=4975496102553953948
[itunesconnect]: https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/1349814380