### PR TITLE
fix: Display tooltip on mobile

### DIFF
--- a/src/ducks/categories/CategoriesChart.styl
+++ b/src/ducks/categories/CategoriesChart.styl
@@ -21,6 +21,7 @@
     flex-direction column
     justify-content center
     align-items center
+    z-index -1
 
 .CategoriesChart__FigureBlock
     z-index -1


### PR DESCRIPTION
The chart is hidden by the figure block

![capture d ecran 2018-12-19 a 14 29 22](https://user-images.githubusercontent.com/1135513/50223131-9ae42280-039a-11e9-8603-bde95e19c003.png)
