### PR TITLE
fix: Notifications

### DIFF
--- a/src/ducks/notifications/BalanceLower.js
+++ b/src/ducks/notifications/BalanceLower.js
@@ -116,4 +116,6 @@ class BalanceLower extends Notification {
   }
 }
 
+BalanceLower.settingKey = 'balanceLower'
+
 export default BalanceLower

--- a/src/ducks/notifications/HealthBillLinked.js
+++ b/src/ducks/notifications/HealthBillLinked.js
@@ -118,4 +118,6 @@ class HealthBillLinked extends Notification {
   }
 }
 
+HealthBillLinked.settingKey = 'healthBillLinked'
+
 export default HealthBillLinked

--- a/src/ducks/notifications/TransactionGreater.js
+++ b/src/ducks/notifications/TransactionGreater.js
@@ -124,4 +124,6 @@ class TransactionGreater extends Notification {
   }
 }
 
+TransactionGreater.settingKey = 'transactionGreater'
+
 export default TransactionGreater

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -14,12 +14,6 @@ const dictRequire = lang => require(`../../locales/${lang}`)
 const translation = initTranslation(lang, dictRequire)
 const t = translation.t.bind(translation)
 
-const configKeys = {
-  BalanceLower: 'balanceLower',
-  TransactionGreater: 'transactionGreater',
-  HealthBillLinked: 'healthBillLinked'
-}
-
 const notificationClasses = [BalanceLower, TransactionGreater, HealthBillLinked]
 
 const fetchTransactionAccounts = async transactions => {
@@ -38,14 +32,13 @@ const fetchTransactionAccounts = async transactions => {
   return accounts
 }
 
-const getClassConfig = (Klass, config) =>
-  config.notifications[configKeys[Klass.name]]
+const getClassConfig = (Klass, config) => config.notifications[Klass.settingKey]
 
 const getEnabledNotificationClasses = config => {
   return notificationClasses.filter(Klass => {
     const klassConfig = getClassConfig(Klass, config)
     const enabled = klassConfig && klassConfig.enabled
-    log('info', `${Klass.name} is ${enabled ? '' : 'not'} enabled`)
+    log('info', `${Klass.settingKey} is ${enabled ? '' : 'not'} enabled`)
     return enabled
   })
 }

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -34,7 +34,7 @@ const fetchTransactionAccounts = async transactions => {
 
 const getClassConfig = (Klass, config) => config.notifications[Klass.settingKey]
 
-const getEnabledNotificationClasses = config => {
+export const getEnabledNotificationClasses = config => {
   return notificationClasses.filter(Klass => {
     const klassConfig = getClassConfig(Klass, config)
     const enabled = klassConfig && klassConfig.enabled

--- a/src/ducks/notifications/services.spec.js
+++ b/src/ducks/notifications/services.spec.js
@@ -1,0 +1,37 @@
+// Mocking handlersbars since we don't want to test HTML rendering here and it fails in the tests context
+jest.mock('handlebars')
+
+import { getEnabledNotificationClasses } from './services'
+import BalanceLower from './BalanceLower'
+import TransactionGreater from './TransactionGreater'
+import HealthBillLinked from './HealthBillLinked'
+
+describe('getEnabledNotificationClasses', () => {
+  it('should return the right classes', () => {
+    const config = {
+      notifications: {
+        balanceLower: { enabled: true },
+        transactionGreater: { enabled: true },
+        healthBillLinked: { enabled: true }
+      }
+    }
+
+    expect(getEnabledNotificationClasses(config)).toEqual([
+      BalanceLower,
+      TransactionGreater,
+      HealthBillLinked
+    ])
+
+    config.notifications.transactionGreater.enabled = false
+    expect(getEnabledNotificationClasses(config)).toEqual([
+      BalanceLower,
+      HealthBillLinked
+    ])
+
+    config.notifications.balanceLower.enabled = false
+    expect(getEnabledNotificationClasses(config)).toEqual([HealthBillLinked])
+
+    config.notifications.healthBillLinked.enabled = false
+    expect(getEnabledNotificationClasses(config)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
We had a problem due to code minification on production mode. The classes names were mangled by the minification process, but since we relied on it to do the link between settings and classes, it was broken. The result was that even if the user had notifications enabled, we treated it as disabled.

After some research, I found that it broke between webpack 3 (no problem) and webpack 4. I looked at Terser options, but I felt it was better to just not rely on classes `name` property, so we don't rely on a tool configuration to make our code work. I mean if in the future we change the minifier, but forget to set the right configuration, this code will again. I think it's not safe at all.