### PR TITLE
Alert for konnectors waiting for manual update

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -149,6 +149,11 @@
       "description": "Allow to anonymously send categorized transactions",
       "type": "cc.cozycloud.autocategorization",
       "verbs": ["POST"]
+    },
+    "konnectors": {
+      "description": "Required to know if a konnector is waiting for a manual update",
+      "type": "io.cozy.konnectors",
+      "verbs": ["GET"]
     }
   }
 }

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,6 +10,7 @@ import { settingsConn } from 'doctypes'
 import { queryConnect } from 'cozy-client'
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 import { Alerter } from 'cozy-ui/react'
+import KonnectorUpdateInfo from './KonnectorUpdateInfo'
 
 const ReactHint = ReactHintFactory(React)
 
@@ -25,7 +26,10 @@ const App = props => {
       </Sidebar>
 
       <Main>
-        <Content>{props.children}</Content>
+        <Content>
+          {flag('konnector-update-info') && <KonnectorUpdateInfo />}
+          {props.children}
+        </Content>
       </Main>
 
       {/* Outside every other component to bypass overflow:hidden */}
@@ -37,4 +41,5 @@ const App = props => {
     </Layout>
   )
 }
+
 export default queryConnect({ settingsCollection: settingsConn })(App)

--- a/src/components/Info/__snapshots__/index.spec.js.snap
+++ b/src/components/Info/__snapshots__/index.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Info should render its children 1`] = `
 <div
-  className="infos u-p-1"
+  className="infos u-p-1 infos--normal"
 >
   <div
     className="infos--container"
@@ -18,7 +18,7 @@ exports[`Info should render its children 1`] = `
 
 exports[`Info should render with a title 1`] = `
 <div
-  className="infos u-p-1"
+  className="infos u-p-1 infos--normal"
 >
   <div
     className="infos--container"
@@ -41,7 +41,7 @@ exports[`Info should render with a title 1`] = `
 
 exports[`Info should render with an icon 1`] = `
 <div
-  className="infos u-p-1"
+  className="infos u-p-1 infos--normal"
 >
   <div
     className="infos--container"
@@ -53,6 +53,22 @@ exports[`Info should render with an icon 1`] = `
     />
     <div
       className="infos--content u-pl-half"
+    >
+      Children
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Info should render with the right variant 1`] = `
+<div
+  className="infos u-p-1 infos--error"
+>
+  <div
+    className="infos--container"
+  >
+    <div
+      className="infos--content"
     >
       Children
     </div>

--- a/src/components/Info/__snapshots__/index.spec.js.snap
+++ b/src/components/Info/__snapshots__/index.spec.js.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Info should render its children 1`] = `
+<div
+  className="infos u-p-1"
+>
+  <div
+    className="infos--container"
+  >
+    <div
+      className="infos--content"
+    >
+      Children
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Info should render with a title 1`] = `
+<div
+  className="infos u-p-1"
+>
+  <div
+    className="infos--container"
+  >
+    <div
+      className="infos--content"
+    >
+      <SubTitle
+        className="infos--title"
+        ellipsis={false}
+        tag="div"
+      >
+        title
+      </SubTitle>
+      Children
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Info should render with an icon 1`] = `
+<div
+  className="infos u-p-1"
+>
+  <div
+    className="infos--container"
+  >
+    <Icon
+      className="infos--icon"
+      icon="openwith"
+      spin={false}
+    />
+    <div
+      className="infos--content u-pl-half"
+    >
+      Children
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import styles from './styles.styl'
+import { Icon, SubTitle } from 'cozy-ui/react'
+
+const Infos = ({ icon, children, className, title }) => {
+  return (
+    <div className={cx(styles['infos'], 'u-p-1', className)}>
+      <div className={styles['infos--container']}>
+        {icon && <Icon icon={icon} className={styles['infos--icon']} />}
+        <div
+          className={cx(styles['infos--content'], {
+            ['u-pl-half']: icon !== null
+          })}
+        >
+          {title && (
+            <SubTitle className={styles['infos--title']}>{title}</SubTitle>
+          )}
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+Infos.defaultProps = {
+  icon: null
+}
+Infos.propTypes = {
+  icon: PropTypes.any,
+  title: PropTypes.node
+}
+export default Infos

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 import { Icon, SubTitle } from 'cozy-ui/react'
 
-const Infos = ({ icon, children, className, title }) => {
+export const Infos = ({ icon, children, className, title }) => {
   return (
     <div className={cx(styles['infos'], 'u-p-1', className)}>
       <div className={styles['infos--container']}>

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -31,4 +31,4 @@ Infos.propTypes = {
   icon: PropTypes.any,
   title: PropTypes.node
 }
-export default Infos
+export default React.memo(Infos)

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -28,7 +28,7 @@ Infos.defaultProps = {
   icon: null
 }
 Infos.propTypes = {
-  icon: PropTypes.any,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   title: PropTypes.node
 }
 export default React.memo(Infos)

--- a/src/components/Info/index.js
+++ b/src/components/Info/index.js
@@ -4,9 +4,16 @@ import PropTypes from 'prop-types'
 import styles from './styles.styl'
 import { Icon, SubTitle } from 'cozy-ui/react'
 
-export const Infos = ({ icon, children, className, title }) => {
+export const Infos = ({ icon, children, className, title, variant }) => {
   return (
-    <div className={cx(styles['infos'], 'u-p-1', className)}>
+    <div
+      className={cx(
+        styles['infos'],
+        'u-p-1',
+        styles[`infos--${variant}`],
+        className
+      )}
+    >
       <div className={styles['infos--container']}>
         {icon && <Icon icon={icon} className={styles['infos--icon']} />}
         <div
@@ -25,10 +32,13 @@ export const Infos = ({ icon, children, className, title }) => {
 }
 
 Infos.defaultProps = {
-  icon: null
+  icon: null,
+  variant: 'normal'
 }
+
 Infos.propTypes = {
   icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-  title: PropTypes.node
+  title: PropTypes.node,
+  variant: PropTypes.oneOf(['normal', 'error'])
 }
 export default React.memo(Infos)

--- a/src/components/Info/index.spec.js
+++ b/src/components/Info/index.spec.js
@@ -18,4 +18,10 @@ describe('Info', () => {
       shallow(<Infos icon="openwith">Children</Infos>).getElement()
     ).toMatchSnapshot()
   })
+
+  it('should render with the right variant', () => {
+    expect(
+      shallow(<Infos variant="error">Children</Infos>).getElement()
+    ).toMatchSnapshot()
+  })
 })

--- a/src/components/Info/index.spec.js
+++ b/src/components/Info/index.spec.js
@@ -1,0 +1,21 @@
+import React from 'react'
+import { Infos } from '.'
+import { shallow } from 'enzyme'
+
+describe('Info', () => {
+  it('should render its children', () => {
+    expect(shallow(<Infos>Children</Infos>).getElement()).toMatchSnapshot()
+  })
+
+  it('should render with a title', () => {
+    expect(
+      shallow(<Infos title="title">Children</Infos>).getElement()
+    ).toMatchSnapshot()
+  })
+
+  it('should render with an icon', () => {
+    expect(
+      shallow(<Infos icon="openwith">Children</Infos>).getElement()
+    ).toMatchSnapshot()
+  })
+})

--- a/src/components/Info/styles.styl
+++ b/src/components/Info/styles.styl
@@ -4,7 +4,7 @@
     background paleGrey
     display flex
     align-items center
-    background-color #fff2f2
+    background-color var(--chablis)
 
 .infos--icon
     width rem(16)
@@ -20,4 +20,4 @@
     width 100%
 
 .infos--title
-    color #f52d2d
+    color var(--monza)

--- a/src/components/Info/styles.styl
+++ b/src/components/Info/styles.styl
@@ -1,0 +1,24 @@
+@require 'settings/palette.styl'
+@require 'tools/mixins'
+
+.infos
+    background paleGrey
+    display flex
+    align-items center
+    background-color #fff2f2
+
+.infos--icon
+    width rem(16)
+    height rem(16)
+    padding-top: 0.2em
+
+.infos--content
+    width 100%
+    text-align left
+
+.infos--container
+    display flex
+    width 100%
+
+.infos--title
+    color #f52d2d

--- a/src/components/Info/styles.styl
+++ b/src/components/Info/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'tools/mixins'
 
 .infos

--- a/src/components/Info/styles.styl
+++ b/src/components/Info/styles.styl
@@ -1,9 +1,13 @@
 @require 'tools/mixins'
 
 .infos
-    background paleGrey
     display flex
     align-items center
+
+.infos--normal
+    background-color var(--paleGrey)
+
+.infos--error
     background-color var(--chablis)
 
 .infos--icon
@@ -19,5 +23,5 @@
     display flex
     width 100%
 
-.infos--title
+.infos--error .infos--title
     color var(--monza)

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -2,9 +2,38 @@ import React from 'react'
 import Info from '../Info'
 import styles from './styles.styl'
 import { Text, ButtonLink, Icon, translate } from 'cozy-ui/react'
+import { withClient } from 'cozy-client'
+import { flowRight as compose } from 'lodash'
+import { Intents } from 'cozy-interapp'
 
 class KonnectorUpdateInfo extends React.PureComponent {
+  intents = new Intents({ client: this.props.client })
+
+  state = {
+    url: null
+  }
+
+  async componentDidMount() {
+    try {
+      const url = await this.intents.getRedirectionURL('io.cozy.apps', {
+        type: 'konnector',
+        pendingUpdate: true
+      })
+
+      this.setState({ url })
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err)
+    }
+  }
+
   render() {
+    const { url } = this.state
+
+    if (!url) {
+      return null
+    }
+
     const { t } = this.props
 
     return (
@@ -20,7 +49,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
           icon={<Icon icon="openwith" />}
           label={t('KonnectorUpdateInfo.cta')}
           theme="secondary"
-          href="#"
+          href={url}
           extension="full"
         />
       </Info>
@@ -28,4 +57,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
   }
 }
 
-export default translate()(KonnectorUpdateInfo)
+export default compose(
+  translate(),
+  withClient
+)(KonnectorUpdateInfo)

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import Info from '../Info'
+import styles from './styles.styl'
+import { Text, ButtonLink, Icon, translate } from 'cozy-ui/react'
+
+class KonnectorUpdateInfo extends React.PureComponent {
+  render() {
+    const { t } = this.props
+
+    return (
+      <Info variant="error" title={t('KonnectorUpdateInfo.title')}>
+        <Text
+          tag="p"
+          className={styles['KonnectorUpdateInfo__message']}
+          dangerouslySetInnerHTML={{
+            __html: t('KonnectorUpdateInfo.content')
+          }}
+        />
+        <ButtonLink
+          icon={<Icon icon="openwith" />}
+          label={t('KonnectorUpdateInfo.cta')}
+          theme="secondary"
+          href="#"
+          extension="full"
+        />
+      </Info>
+    )
+  }
+}
+
+export default translate()(KonnectorUpdateInfo)

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -71,9 +71,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
           label={t('KonnectorUpdateInfo.cta')}
           theme="secondary"
           href={url}
-          extension={
-            breakpoints.isDesktop || breakpoints.isTablet ? 'narrow' : 'full'
-          }
+          extension={breakpoints.isMobile ? 'full' : 'narrow'}
         />
       </Info>
     )

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -1,7 +1,13 @@
 import React from 'react'
 import Info from '../Info'
 import styles from './styles.styl'
-import { Text, ButtonLink, Icon, translate } from 'cozy-ui/react'
+import {
+  Text,
+  ButtonLink,
+  Icon,
+  translate,
+  withBreakpoints
+} from 'cozy-ui/react'
 import { withClient } from 'cozy-client'
 import { flowRight as compose } from 'lodash'
 import { Intents } from 'cozy-interapp'
@@ -34,7 +40,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
       return null
     }
 
-    const { t } = this.props
+    const { t, breakpoints } = this.props
 
     return (
       <Info variant="error" title={t('KonnectorUpdateInfo.title')}>
@@ -50,7 +56,9 @@ class KonnectorUpdateInfo extends React.PureComponent {
           label={t('KonnectorUpdateInfo.cta')}
           theme="secondary"
           href={url}
-          extension="full"
+          extension={
+            breakpoints.isDesktop || breakpoints.isTablet ? 'narrow' : 'full'
+          }
         />
       </Info>
     )
@@ -59,5 +67,6 @@ class KonnectorUpdateInfo extends React.PureComponent {
 
 export default compose(
   translate(),
-  withClient
+  withClient,
+  withBreakpoints()
 )(KonnectorUpdateInfo)

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -32,7 +32,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
       this.setState({ url })
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.log(err)
+      console.warning('Error while retrieving redirection URL', err)
     }
   }
 

--- a/src/components/KonnectorUpdateInfo/styles.styl
+++ b/src/components/KonnectorUpdateInfo/styles.styl
@@ -1,4 +1,4 @@
 .KonnectorUpdateInfo__message a
     font-weight bold
     text-decoration none
-    color dodgerBlue
+    color var(--primary)

--- a/src/components/KonnectorUpdateInfo/styles.styl
+++ b/src/components/KonnectorUpdateInfo/styles.styl
@@ -1,0 +1,4 @@
+.KonnectorUpdateInfo__message a
+    font-weight bold
+    text-decoration none
+    color dodgerBlue

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -9,6 +9,7 @@ export const SETTINGS_DOCTYPE = 'io.cozy.bank.settings'
 export const BILLS_DOCTYPE = 'io.cozy.bills'
 export const TRIGGER_DOCTYPE = 'io.cozy.triggers'
 export const APP_DOCTYPE = 'io.cozy.apps'
+export const KONNECTOR_DOCTYPE = 'io.cozy.konnectors'
 
 export const offlineDoctypes = [
   ACCOUNT_DOCTYPE,
@@ -136,6 +137,11 @@ export const schema = {
   },
   apps: {
     doctype: APP_DOCTYPE,
+    attributes: {},
+    relationships: {}
+  },
+  konnectors: {
+    doctype: KONNECTOR_DOCTYPE,
     attributes: {},
     relationships: {}
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -528,5 +528,11 @@
         "description": "Build my balance history chart"
       }
     }
+  },
+
+  "KonnectorUpdateInfo": {
+    "title": "Update of your banking connections",
+    "content": "A latest version of our banking connection has been released. You need to sign the new terms of service. <a href='https://support.cozy.io/article/302-budget' target='_blank'>Learn more</a>.",
+    "cta": "Update my banks"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -481,5 +481,11 @@
         "description": "Voir mon historique de soldes"
       }
     }
+  },
+
+  "KonnectorUpdateInfo": {
+    "title": "Nouveaux connecteurs bancaires",
+    "content": "De nouvelles versions des connecteurs sont disponibles et nécessitent une mise à jour de leurs CGUs. <a href='https://support.cozy.io/article/302-budget' target='_blank'>En savoir plus</a>.",
+    "cta": "Mettre à jour mes banques"
   }
 }


### PR DESCRIPTION
When a change in a connector requires the user to accept new TOS, we want to show an alert with a button that redirects the user to the list of connectors waiting for a manual update.

The `Info` component used is a copy/pasted and improved version of the cozy-ui one. I'm going to have a look with designers to see if we merge the update in cozy-ui or not.

Instance for validation : https://testbanksbiinfo-banks.cozy.works/#/balances
You should activate the flag: `flag('konnector-update-info', true)`. I installed a "Axa Banque" connector and updated it so the alert will be shown. But the whole feature may not whole correctly since the connector is not really waiting for a manual update.