### PR TITLE
chore: Flags at build time

### DIFF
--- a/config/webpack.config.base.js
+++ b/config/webpack.config.base.js
@@ -5,7 +5,7 @@ const webpack = require('webpack')
 const DuplicatePackageCheckerPlugin = require('duplicate-package-checker-webpack-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
 
-const { production, SRC_DIR } = require('./webpack.vars')
+const { production, SRC_DIR, enabledFlags } = require('./webpack.vars')
 const pkg = require(path.resolve(__dirname, '../package.json'))
 
 module.exports = {
@@ -55,6 +55,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __APP_VERSION__: JSON.stringify(pkg.version),
       __SENTRY_URL__: JSON.stringify('https://ea2067ca88504d9cbc9115b55d0b2d55:e52e64f57486417bb1b5fa6529e1cfcb@sentry.cozycloud.cc/11'),
+      __ENABLED_FLAGS__: JSON.stringify(enabledFlags)
     }),
     // ChartJS uses moment :( To remove when we do not use it anymore
     new webpack.ContextReplacementPlugin(/moment[\/\\]locale$/, /en|fr/),

--- a/config/webpack.vars.js
+++ b/config/webpack.vars.js
@@ -10,6 +10,14 @@ const getTarget = () => {
   }
 }
 
+const getEnabledFlags = () => {
+  try {
+    return process.env.COZY_FLAGS.split(',')
+  } catch (e) {
+    return []
+  }
+}
+
 const production = /:production$/.test(process.env.NODE_ENV)
 const target = getTarget()
 const hotReload = !!process.env.HOT_RELOAD
@@ -22,5 +30,6 @@ module.exports = {
   hotReload,
   analyze: process.env.WEBPACK_ANALYZE,
   skin,
-  SRC_DIR
+  SRC_DIR,
+  enabledFlags: getEnabledFlags()
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,4 +1,4 @@
-/* global cozy, __TARGET__ */
+/* global cozy, __TARGET__, __ENABLED_FLAGS__ */
 
 import 'utils/react-exposer'
 import 'whatwg-fetch'
@@ -17,6 +17,9 @@ import FastClick from 'fastclick'
 import { isReporterEnabled, configureReporter, setURLContext } from 'lib/sentry'
 import * as d3 from 'd3'
 import 'cozy-ui/transpiled/stylesheet.css'
+import flag from 'cozy-flags'
+
+__ENABLED_FLAGS__.forEach(flagName => flag(flagName, true))
 
 const D3_LOCALES_MAP = {
   fr: 'fr-FR',


### PR DESCRIPTION
This adds the possibility to enable some flags at build time.

For example: `COZY_FLAGS=balance-history,transaction-history yarn build` will make a build with `balance-history` and `transaction-history` flags enabled by default.

This can be useful to generate mobile builds with enabled flags, so testing the feature is easier. Or to generate web builds with enabled flags and deploy them with `deploy2cozy`. Maybe this kind of feature can be integrated to CCA in the future (for example when we switch to cozy-scripts :p).

The only downside I don't know how to bypass is that since we use `localStorage` for web flags, when we enable the flag `f` for a build, then we do another build without enabling it, it will remain enabled on the instance.