### PR TITLE
feat(groups): Create virtual group for accounts alone and without type

### DIFF
--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -1,15 +1,31 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import GroupPanel from './components/GroupPanel'
+import { sortBy } from 'lodash'
+import { translate } from 'cozy-ui/react'
 
-export default class BalancePanels extends React.PureComponent {
+class BalancePanels extends React.PureComponent {
   static propTypes = {
     groups: PropTypes.arrayOf(PropTypes.object).isRequired
   }
 
   render() {
-    return this.props.groups.map(group => (
+    const { groups, t } = this.props
+
+    const groupsSorted = sortBy(
+      groups.map(group => ({
+        ...group,
+        label: group.virtual
+          ? t(`Data.accountTypes.${group.label}`)
+          : group.label
+      })),
+      group => group.label
+    )
+
+    return groupsSorted.map(group => (
       <GroupPanel key={group._id} group={group} />
     ))
   }
 }
+
+export default translate()(BalancePanels)

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -5,9 +5,8 @@ import { associateDocuments } from 'ducks/client/utils'
 export const buildVirtualGroups = accounts => {
   const accountsByType = groupBy(accounts, account => account.type)
 
-  const virtualGroups = Object.entries(accountsByType)
-    .filter(([type, accounts]) => type !== 'undefined' && accounts.length > 1)
-    .map(([type, accounts]) => {
+  const virtualGroups = Object.entries(accountsByType).map(
+    ([type, accounts]) => {
       const group = {
         _id: type,
         _type: GROUP_DOCTYPE,
@@ -18,7 +17,8 @@ export const buildVirtualGroups = accounts => {
       associateDocuments(group, 'accounts', ACCOUNT_DOCTYPE, accounts)
 
       return group
-    })
+    }
+  )
 
   return virtualGroups
 }

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -3,34 +3,51 @@ import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 
 describe('buildVirtualGroups', () => {
-  it('should generate a virtual group if there are two accounts with the same type', () => {
+  it('should generate a virtual group for every account types', () => {
     const accounts = [
       { _id: '1', type: 'checkings' },
-      { _id: '2', type: 'checkings' }
+      { _id: '2', type: 'savings' }
     ]
 
     const virtualGroups = buildVirtualGroups(accounts)
-    const expected = {
+
+    const checkingsGroup = {
       _id: 'checkings',
       _type: 'io.cozy.bank.groups',
       label: 'checkings',
       virtual: true
     }
 
-    associateDocuments(expected, 'accounts', ACCOUNT_DOCTYPE, accounts)
+    const savingsGroup = {
+      _id: 'savings',
+      _type: 'io.cozy.bank.groups',
+      label: 'savings',
+      virtual: true
+    }
 
-    expect(virtualGroups).toHaveLength(1)
-    expect(virtualGroups[0]).toEqual(expected)
+    associateDocuments(checkingsGroup, 'accounts', ACCOUNT_DOCTYPE, [
+      accounts[0]
+    ])
+    associateDocuments(savingsGroup, 'accounts', ACCOUNT_DOCTYPE, [accounts[1]])
+
+    const expected = [checkingsGroup, savingsGroup]
+
+    expect(virtualGroups).toEqual(expected)
   })
 
-  it('should generate nothing if there a less than two accounts with the same type', () => {
-    const accounts = [
-      { _id: '1', type: 'checkings' },
-      { _id: '2', type: 'epargne' }
-    ]
-
+  it('should generate a group for accounts that have no type', () => {
+    const accounts = [{ _id: '1' }]
     const virtualGroups = buildVirtualGroups(accounts)
 
-    expect(virtualGroups).toHaveLength(0)
+    const expectedGroup = {
+      _id: 'undefined',
+      _type: 'io.cozy.bank.groups',
+      label: 'undefined',
+      virtual: true
+    }
+
+    associateDocuments(expectedGroup, 'accounts', ACCOUNT_DOCTYPE, accounts)
+
+    expect(virtualGroups).toEqual([expectedGroup])
   })
 })

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -118,7 +118,8 @@
       "credit card": "Credit card accounts",
       "liability": "Liability accounts",
       "none": "None",
-      "savings": "Savings accounts"
+      "savings": "Savings accounts",
+      "undefined": "Other accounts"
     },
     "categories": {
       "uncategorized": "To be categorized",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -186,7 +186,8 @@
       "credit card": "Cartes de crédit",
       "liability": "Comptes de dettes",
       "none": "Aucun type",
-      "savings": "Comptes d'épargne"
+      "savings": "Comptes d'épargne",
+      "undefined": "Autres comptes"
     },
     "categories": {
       "uncategorized": "A catégoriser",


### PR DESCRIPTION
There are new rules for virtual groups:

* We create a virtual group for every type of account that exist on the instance (previously it required at least two accounts with the same type)
* We handle accounts without any type and group them in an "undefined" group

WARNING: the base branch is `expansion-panel` since #713 is not merged for now. This is because this PR is based on the work in #713. I think we must merge #713 before this one.