### PR TITLE
Group panel click area

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/components/ExpansionPanel/ExpansionPanelSummary.js
@@ -17,9 +17,9 @@ export default withStyles(theme => ({
     margin: `${theme.typography.pxToRem(12)} 0 !important`,
     paddingLeft: theme.typography.pxToRem(36),
     paddingRight: theme.typography.pxToRem(8),
-    display: 'flex',
-    justifyContent: 'space-between',
-    flex: '1'
+    '& > :last-child': {
+      paddingRight: 0
+    }
   },
   expandIcon: {
     left: theme.typography.pxToRem(6),

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -1,17 +1,32 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Icon } from 'cozy-ui/react'
+import { flowRight as compose } from 'lodash'
+import { withRouter } from 'react-router'
 import { Figure } from 'components/Figure'
 import ExpansionPanel from 'components/ExpansionPanel/ExpansionPanel'
 import ExpansionPanelSummary from 'components/ExpansionPanel/ExpansionPanelSummary'
 import ExpansionPanelDetails from 'components/ExpansionPanel/ExpansionPanelDetails'
+import withFilteringDoc from 'components/withFilteringDoc'
 import AccountsList from './AccountsList'
 import { getGroupBalance } from '../helpers'
 import styles from './GroupPanel.styl'
 
 class GroupPanel extends React.PureComponent {
   static propTypes = {
-    group: PropTypes.object.isRequired
+    group: PropTypes.object.isRequired,
+    filterByDoc: PropTypes.func.isRequired,
+    router: PropTypes.object.isRequired
+  }
+
+  goToTransactionsFilteredByDoc = () => {
+    this.props.filterByDoc(this.props.group)
+    this.props.router.push('/transactions')
+  }
+
+  handleSummaryContentClick = e => {
+    e.stopPropagation()
+    this.goToTransactionsFilteredByDoc()
   }
 
   render() {
@@ -22,7 +37,10 @@ class GroupPanel extends React.PureComponent {
         <ExpansionPanelSummary
           expandIcon={<Icon icon="bottom" color="black" width={12} />}
         >
-          <div className={styles.GroupPanelSummary__content}>
+          <div
+            onClick={this.handleSummaryContentClick}
+            className={styles.GroupPanelSummary__content}
+          >
             {group.label}
             <Figure
               currency="€"
@@ -39,4 +57,7 @@ class GroupPanel extends React.PureComponent {
   }
 }
 
-export default GroupPanel
+export default compose(
+  withFilteringDoc,
+  withRouter
+)(GroupPanel)

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -36,6 +36,9 @@ class GroupPanel extends React.PureComponent {
       <ExpansionPanel defaultExpanded>
         <ExpansionPanelSummary
           expandIcon={<Icon icon="bottom" color="black" width={12} />}
+          IconButtonProps={{
+            disableRipple: true
+          }}
         >
           <div
             onClick={this.handleSummaryContentClick}

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -22,13 +22,14 @@ class GroupPanel extends React.PureComponent {
         <ExpansionPanelSummary
           expandIcon={<Icon icon="bottom" color="black" width={12} />}
         >
-          {group.label}
-          <Figure
-            currency="€"
-            total={getGroupBalance(group)}
-            className={styles.GroupPannelSummary__figure}
-            currencyClassName={styles.GroupPannelSummary__figureCurrency}
-          />
+          <div className={styles.GroupPanelSummary__content}>
+            {group.label}
+            <Figure
+              currency="€"
+              total={getGroupBalance(group)}
+              currencyClassName={styles.GroupPanelSummary__figureCurrency}
+            />
+          </div>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>
           <AccountsList accounts={group.accounts.data} />

--- a/src/ducks/balance/components/GroupPanel.styl
+++ b/src/ducks/balance/components/GroupPanel.styl
@@ -3,5 +3,14 @@
     flex 1
     justify-content space-between
 
+    &::before
+        content ''
+        position absolute
+        background-color transparent
+        left 36px
+        top 0
+        right 0
+        bottom 0
+
 .GroupPanelSummary__figureCurrency
     color inherit

--- a/src/ducks/balance/components/GroupPanel.styl
+++ b/src/ducks/balance/components/GroupPanel.styl
@@ -1,5 +1,7 @@
-.GroupPannelSummary__figure
-    padding-right 0 !important
+.GroupPanelSummary__content
+    display flex
+    flex 1
+    justify-content space-between
 
-.GroupPannelSummary__figureCurrency
+.GroupPanelSummary__figureCurrency
     color inherit


### PR DESCRIPTION
We want to be able to click on the group label to go to the filtered transactions view. Since this kind of actions inside the `ExpansionPanelSummary` MUI component doesn't exist, we need to stop the event propagation and manage the click area ourselves. I did it with a pseudo-element that takes the click area we want.

Live here: https://testbanksgrouppanelareas-banks.cozy.works/#/balances