### PR TITLE
feat(Balance): Panels overflows on chart area

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -4,6 +4,7 @@ import { translate, withBreakpoints } from 'cozy-ui/react'
 import { queryConnect } from 'cozy-client'
 import flag from 'cozy-flags'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
+import cx from 'classnames'
 
 import Loading from 'components/Loading'
 import { Padded } from 'components/Spacing'
@@ -90,6 +91,7 @@ class Balance extends PureComponent {
     })
 
     const balanceLower = get(settings, 'notifications.balanceLower.value')
+    const showPanels = flag('balance-panels')
 
     return (
       <Fragment>
@@ -125,8 +127,12 @@ class Balance extends PureComponent {
             </Padded>
           )}
         </Header>
-        <Padded>
-          {flag('balance-panels') ? (
+        <Padded
+          className={cx({
+            [styles.Balance__panelsContainer]: showPanels && withChart
+          })}
+        >
+          {showPanels ? (
             <BalancePanels groups={groups} />
           ) : (
             <BalanceTables

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -33,3 +33,15 @@
     min-height 1rem
     font-weight bold
     color rgba(255, 255, 255, 0.64)
+
+.Balance__panelsContainer
+    position relative
+
+    &::before
+        content ''
+        position absolute
+        top 0
+        left 0
+        right 0
+        height 44px
+        background-color var(--primary)


### PR DESCRIPTION
Use a pseudo element with the same background color as the chart container so we think the group panel overflows on it.

![image](https://user-images.githubusercontent.com/1606068/50684102-abd89900-1014-11e9-83c1-b74e644f0e36.png)
