### PR TITLE
Add actions on balance page with panels

### DIFF
--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -1,13 +1,19 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import GroupPanel from './components/GroupPanel'
-import { sortBy } from 'lodash'
-import { translate } from 'cozy-ui/react'
+import { sortBy, flowRight as compose } from 'lodash'
+import { translate, ButtonAction } from 'cozy-ui/react'
+import { withRouter } from 'react-router'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
+import styles from './BalancePanels.styl'
 
 class BalancePanels extends React.PureComponent {
   static propTypes = {
-    groups: PropTypes.arrayOf(PropTypes.object).isRequired
+    groups: PropTypes.arrayOf(PropTypes.object).isRequired,
+    router: PropTypes.object.isRequired
   }
+
+  goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
     const { groups, t } = this.props
@@ -22,10 +28,32 @@ class BalancePanels extends React.PureComponent {
       group => group.label
     )
 
-    return groupsSorted.map(group => (
-      <GroupPanel key={group._id} group={group} />
-    ))
+    return (
+      <div>
+        {groupsSorted.map(group => (
+          <GroupPanel key={group._id} group={group} />
+        ))}
+        <div className={styles.BalancePanels__actions}>
+          <AddAccountLink>
+            <ButtonAction
+              type="new"
+              label={t('Accounts.add-account')}
+              className={styles.BalancePanels__action}
+            />
+          </AddAccountLink>
+          <ButtonAction
+            onClick={this.goToGroupsSettings}
+            type="normal"
+            label={t('Groups.manage-groups')}
+            className={styles.BalancePanels__action}
+          />
+        </div>
+      </div>
+    )
   }
 }
 
-export default translate()(BalancePanels)
+export default compose(
+  translate(),
+  withRouter
+)(BalancePanels)

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -1,0 +1,24 @@
+.BalancePanels__actions
+    display flex
+    padding-left 4px
+    padding-right 4px
+    margin-top 2rem
+
+.BalancePanels__action
+    flex 1
+    text-align center
+    max-width none
+    padding-right 1rem
+    padding: 0.375rem 1rem
+    border-radius 4px
+    font-size 12px
+    font-weight bold
+    text-transform uppercase
+    line-height 1.5
+
+    > span
+        justify-content center
+
+        > span
+            padding-right 0
+            white-space normal

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -34,7 +34,7 @@ class SameWindowLink extends Component {
   }
 
   render() {
-    return <span onClick={this.redirect}>{this.props.children}</span>
+    return React.cloneElement(this.props.children, { onClick: this.redirect })
   }
 }
 


### PR DESCRIPTION
Add the buttons to connect a new bank and go to groups settings on the new balance page design.

The buttons are very similar to cozy-ui's `ButtonAction`, but required some customizations. I will see with @joel-costa if that's changes that should be generic or not.

https://testbanksbalancebuttons-banks.cozy.works/