### PR TITLE
Balance panels desktop layout

### DIFF
--- a/src/components/ExpansionPanel/ExpansionPanelSummary.js
+++ b/src/components/ExpansionPanel/ExpansionPanelSummary.js
@@ -15,7 +15,7 @@ export default withStyles(theme => ({
   content: {
     // We want the margin to be the same no matter the expanded state
     margin: `${theme.typography.pxToRem(12)} 0 !important`,
-    paddingLeft: theme.typography.pxToRem(36),
+    paddingLeft: theme.typography.pxToRem(48),
     paddingRight: theme.typography.pxToRem(8),
     '& > :last-child': {
       paddingRight: 0

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -45,3 +45,7 @@
         right 0
         height 44px
         background-color var(--primary)
+
+    +small-screen()
+        padding-left 0.5rem
+        padding-right 0.5rem

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -6,6 +6,10 @@
     padding-right 4px
     margin-top 2rem
 
+    +small-screen('min')
+        padding-left 0
+        padding-right 0
+
 .BalancePanels__action
     flex 1
     text-align center
@@ -25,3 +29,10 @@
         > span
             padding-right 0
             white-space normal
+
+    +small-screen('min')
+        &:first-child
+            margin-left 0
+
+        &:last-child
+            margin-right 0

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -9,6 +9,7 @@
     +small-screen('min')
         padding-left 0
         padding-right 0
+        justify-content flex-end
 
 .BalancePanels__action
     flex 1
@@ -30,7 +31,13 @@
             padding-right 0
             white-space normal
 
+            +small-screen('min')
+                white-space nowrap
+
     +small-screen('min')
+        flex-grow 0
+        min-width unset
+
         &:first-child
             margin-left 0
 

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -1,3 +1,5 @@
+@require 'settings/breakpoints'
+
 .BalancePanels__actions
     display flex
     padding-left 4px
@@ -8,6 +10,7 @@
     flex 1
     text-align center
     max-width none
+    min-height 3rem
     padding-right 1rem
     padding: 0.375rem 1rem
     border-radius 4px

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { sortBy, flowRight as compose } from 'lodash'
 import { withRouter } from 'react-router'
+import cx from 'classnames'
 import { Figure } from 'components/Figure'
 import withFilteringDoc from 'components/withFilteringDoc'
 import { getAccountLabel } from 'ducks/account/helpers'
@@ -28,11 +29,16 @@ class AccountsList extends React.PureComponent {
             className={styles.AccountsListItem}
             onClick={this.goToTransactionsFilteredByDoc(a)}
           >
-            <span>{getAccountLabel(a)}</span>
+            <span className={styles.AccountsListItem__column}>
+              {getAccountLabel(a)}
+            </span>
             <Figure
               currency="€"
               total={a.balance}
-              className={styles.AccountsListItem__figure}
+              className={cx(
+                styles.AccountsListItem__figure,
+                styles.AccountsListItem__column
+              )}
               totalClassName={styles.AccountsListItem__figure}
               currencyClassName={styles.AccountsListItem__figure}
             />

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -25,16 +25,16 @@ class AccountsList extends React.PureComponent {
         {sortBy(accounts, a => a.balance).map(a => (
           <li
             key={a._id}
-            className={styles.AccountsList__item}
+            className={styles.AccountsListItem}
             onClick={this.goToTransactionsFilteredByDoc(a)}
           >
             <span>{getAccountLabel(a)}</span>
             <Figure
               currency="€"
               total={a.balance}
-              className={styles.AccountsList__itemFigure}
-              totalClassName={styles.AccountsList__itemFigure}
-              currencyClassName={styles.AccountsList__itemFigure}
+              className={styles.AccountsListItem__figure}
+              totalClassName={styles.AccountsListItem__figure}
+              currencyClassName={styles.AccountsListItem__figure}
             />
           </li>
         ))}

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { sortBy, flowRight as compose } from 'lodash'
 import { withRouter } from 'react-router'
+import { withBreakpoints } from 'cozy-ui/react'
 import cx from 'classnames'
 import { Figure } from 'components/Figure'
 import withFilteringDoc from 'components/withFilteringDoc'
@@ -19,7 +20,10 @@ class AccountsList extends React.PureComponent {
   }
 
   render() {
-    const { accounts } = this.props
+    const {
+      accounts,
+      breakpoints: { isMobile }
+    } = this.props
 
     return (
       <ol className={styles.AccountsList}>
@@ -32,6 +36,27 @@ class AccountsList extends React.PureComponent {
             <span className={styles.AccountsListItem__column}>
               {getAccountLabel(a)}
             </span>
+            {!isMobile && (
+              <span
+                className={cx(
+                  styles.AccountsListItem__column,
+                  styles['AccountsListItem__column--secondary']
+                )}
+              >
+                N°
+                {a.number}
+              </span>
+            )}
+            {!isMobile && (
+              <span
+                className={cx(
+                  styles.AccountsListItem__column,
+                  styles['AccountsListItem__column--secondary']
+                )}
+              >
+                {a.institutionLabel}
+              </span>
+            )}
             <Figure
               currency="€"
               total={a.balance}
@@ -51,5 +76,6 @@ class AccountsList extends React.PureComponent {
 
 export default compose(
   withFilteringDoc,
-  withRouter
+  withRouter,
+  withBreakpoints()
 )(AccountsList)

--- a/src/ducks/balance/components/AccountsList.styl
+++ b/src/ducks/balance/components/AccountsList.styl
@@ -5,10 +5,11 @@
     list-style none
 
 .AccountsListItem
-    display flex
+    display grid
+    grid-template-columns 1fr auto
+    grid-column-gap 21px
     height 4rem
     align-items center
-    justify-content space-between
     border-top 0.0625rem solid var(--silver)
     padding-left 1rem
     padding-right 0.5rem
@@ -20,3 +21,8 @@
     font-size 0.875rem
     font-weight normal
     color inherit
+
+.AccountsListItem__column
+    white-space nowrap
+    overflow hidden
+    text-overflow ellipsis

--- a/src/ducks/balance/components/AccountsList.styl
+++ b/src/ducks/balance/components/AccountsList.styl
@@ -1,3 +1,5 @@
+@require 'settings/breakpoints'
+
 .AccountsList
     flex 1
     margin 0
@@ -17,12 +19,21 @@
     color var(--charcoalGrey)
     cursor pointer
 
+    +small-screen('min')
+        grid-template-columns 3fr 1fr 1fr 1fr
+        grid-column-gap 67px
+
 .AccountsListItem__figure
     font-size 0.875rem
     font-weight normal
     color inherit
+    justify-self end
 
 .AccountsListItem__column
     white-space nowrap
     overflow hidden
     text-overflow ellipsis
+
+.AccountsListItem__column--secondary
+    font-size 0.875rem
+    color var(--coolGrey)

--- a/src/ducks/balance/components/AccountsList.styl
+++ b/src/ducks/balance/components/AccountsList.styl
@@ -4,7 +4,7 @@
     padding-left 0
     list-style none
 
-.AccountsList__item
+.AccountsListItem
     display flex
     height 4rem
     align-items center
@@ -16,7 +16,7 @@
     color var(--charcoalGrey)
     cursor pointer
 
-.AccountsList__itemFigure
+.AccountsListItem__figure
     font-size 0.875rem
     font-weight normal
     color inherit


### PR DESCRIPTION
On desktop we show more informations. I used Grid layout since it's widely compatible and the `fr` unit is very useful here. I tested it via Browserstack to make sure the compatibility is good: it is.

You can see the changes live on https://testbanksgrouppanelsdesktop-banks.cozy.works/#/balances