### PR TITLE
feat(BalancePanels): Sort groups with undefined last

### DIFF
--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -5,7 +5,7 @@ import { flowRight as compose } from 'lodash'
 import { translate, ButtonAction } from 'cozy-ui/react'
 import { withRouter } from 'react-router'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
-import { sortGroups } from 'ducks/groups/helpers'
+import { translateAndSortGroups } from 'ducks/groups/helpers'
 import styles from './BalancePanels.styl'
 
 class BalancePanels extends React.PureComponent {
@@ -19,7 +19,7 @@ class BalancePanels extends React.PureComponent {
   render() {
     const { groups, t } = this.props
 
-    const groupsSorted = sortGroups(groups, t)
+    const groupsSorted = translateAndSortGroups(groups, t)
 
     return (
       <div>

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import GroupPanel from './components/GroupPanel'
-import { sortBy, flowRight as compose } from 'lodash'
+import { flowRight as compose } from 'lodash'
 import { translate, ButtonAction } from 'cozy-ui/react'
 import { withRouter } from 'react-router'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
+import { sortGroups } from 'ducks/groups/helpers'
 import styles from './BalancePanels.styl'
 
 class BalancePanels extends React.PureComponent {
@@ -18,15 +19,7 @@ class BalancePanels extends React.PureComponent {
   render() {
     const { groups, t } = this.props
 
-    const groupsSorted = sortBy(
-      groups.map(group => ({
-        ...group,
-        label: group.virtual
-          ? t(`Data.accountTypes.${group.label}`)
-          : group.label
-      })),
-      group => group.label
-    )
+    const groupsSorted = sortGroups(groups, t)
 
     return (
       <div>

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -1,4 +1,4 @@
-import { groupBy } from 'lodash'
+import { groupBy, sortBy } from 'lodash'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { associateDocuments } from 'ducks/client/utils'
 
@@ -21,4 +21,41 @@ export const buildVirtualGroups = accounts => {
   )
 
   return virtualGroups
+}
+
+/**
+ * Translate group properties
+ * @param {Object} group - The group to translate
+ * @param {Function} translate - The translation function
+ * @returns {Object} The translated group
+ */
+export const translateGroup = (group, translate) => {
+  return {
+    ...group,
+    label: group.virtual
+      ? translate(`Data.accountTypes.${group.label}`)
+      : group.label
+  }
+}
+/**
+ * Sort groups on their translated label. But always put "others accounts" last
+ * @param {Object[]} groups - The groups to sort
+ * @param {Function} translate - The translation function
+ * @returns {Object[]} The sorted groups
+ */
+export const sortGroups = (groups, translate) => {
+  const [othersGroup] = groups.filter(g => g.virtual && g.label === 'undefined')
+
+  const sortedGroups = sortBy(
+    groups
+      .filter(g => g !== othersGroup)
+      .map(g => translateGroup(g, translate)),
+    g => g.label
+  )
+
+  if (othersGroup) {
+    sortedGroups.push(translateGroup(othersGroup, translate))
+  }
+
+  return sortedGroups
 }

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -3,7 +3,7 @@ import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { associateDocuments } from 'ducks/client/utils'
 
 export const buildVirtualGroups = accounts => {
-  const accountsByType = groupBy(accounts, account => account.type)
+  const accountsByType = groupBy(accounts, account => account.type || 'other')
 
   const virtualGroups = Object.entries(accountsByType).map(
     ([type, accounts]) => {
@@ -44,7 +44,7 @@ export const translateGroup = (group, translate) => {
  * @returns {Object[]} The sorted groups
  */
 export const translateAndSortGroups = (groups, translate) => {
-  const othersGroup = groups.find(g => g.virtual && g.label === 'undefined')
+  const othersGroup = groups.find(g => g.virtual && g.label === 'other')
 
   const sortedGroups = sortBy(
     groups

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -44,7 +44,7 @@ export const translateGroup = (group, translate) => {
  * @returns {Object[]} The sorted groups
  */
 export const translateAndSortGroups = (groups, translate) => {
-  const [othersGroup] = groups.filter(g => g.virtual && g.label === 'undefined')
+  const othersGroup = groups.find(g => g.virtual && g.label === 'undefined')
 
   const sortedGroups = sortBy(
     groups

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -38,12 +38,12 @@ export const translateGroup = (group, translate) => {
   }
 }
 /**
- * Sort groups on their translated label. But always put "others accounts" last
+ * Translate groups labels then sort them on their translated label. But always put "others accounts" last
  * @param {Object[]} groups - The groups to sort
  * @param {Function} translate - The translation function
  * @returns {Object[]} The sorted groups
  */
-export const sortGroups = (groups, translate) => {
+export const translateAndSortGroups = (groups, translate) => {
   const [othersGroup] = groups.filter(g => g.virtual && g.label === 'undefined')
 
   const sortedGroups = sortBy(

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -37,6 +37,9 @@ export const translateGroup = (group, translate) => {
       : group.label
   }
 }
+
+const isOtherVirtualGroup = group => group.virtual && group.label === 'other'
+
 /**
  * Translate groups labels then sort them on their translated label. But always put "others accounts" last
  * @param {Object[]} groups - The groups to sort
@@ -44,17 +47,16 @@ export const translateGroup = (group, translate) => {
  * @returns {Object[]} The sorted groups
  */
 export const translateAndSortGroups = (groups, translate) => {
-  const othersGroup = groups.find(g => g.virtual && g.label === 'other')
+  const groupsToSort = groups
+    .filter(group => !isOtherVirtualGroup(group))
+    .map(group => translateGroup(group, translate))
 
-  const sortedGroups = sortBy(
-    groups
-      .filter(g => g !== othersGroup)
-      .map(g => translateGroup(g, translate)),
-    g => g.label
-  )
+  const sortedGroups = sortBy(groupsToSort, group => group.label)
 
-  if (othersGroup) {
-    sortedGroups.push(translateGroup(othersGroup, translate))
+  const otherGroup = groups.find(isOtherVirtualGroup)
+
+  if (otherGroup) {
+    sortedGroups.push(translateGroup(otherGroup, translate))
   }
 
   return sortedGroups

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -1,4 +1,4 @@
-import { buildVirtualGroups } from './helpers'
+import { buildVirtualGroups, translateGroup, sortGroups } from './helpers'
 import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 
@@ -49,5 +49,73 @@ describe('buildVirtualGroups', () => {
     associateDocuments(expectedGroup, 'accounts', ACCOUNT_DOCTYPE, accounts)
 
     expect(virtualGroups).toEqual([expectedGroup])
+  })
+})
+
+describe('translateGroup', () => {
+  const translate = jest.fn().mockReturnValue('translated')
+
+  afterEach(() => {
+    translate.mockReset()
+  })
+
+  it("should translate the group label only if it's a virtual group", () => {
+    const virtualGroup = {
+      virtual: true,
+      label: 'label'
+    }
+
+    const normalGroup = {
+      virtual: false,
+      label: 'label'
+    }
+
+    expect(translateGroup(virtualGroup, translate)).toEqual({
+      ...virtualGroup,
+      label: 'translated'
+    })
+    expect(translateGroup(normalGroup, translate)).toEqual(normalGroup)
+  })
+})
+
+describe('sortGroups', () => {
+  const translate = jest.fn(key => key)
+
+  afterEach(() => {
+    translate.mockClear()
+  })
+
+  it('should sort groups by translated label', () => {
+    const groups = [
+      { virtual: true, label: 'C' },
+      { virtual: false, label: 'A' },
+      { virtual: false, label: 'B' }
+    ]
+
+    const expected = [
+      { virtual: false, label: 'A' },
+      { virtual: false, label: 'B' },
+      { virtual: true, label: 'Data.accountTypes.C' }
+    ]
+
+    expect(sortGroups(groups, translate)).toEqual(expected)
+  })
+
+  it('should put group with label "undefined" at the end', () => {
+    const groups = [
+      { virtual: true, label: 'C' },
+      { virtual: false, label: 'A' },
+      { virtual: false, label: 'B' },
+      { virtual: true, label: 'undefined' }
+    ]
+
+    const expected = [
+      { virtual: false, label: 'A' },
+      { virtual: false, label: 'B' },
+      { virtual: true, label: 'Data.accountTypes.C' },
+      { virtual: true, label: 'Data.accountTypes.undefined' }
+    ]
+
+    expect(sortGroups(groups, translate)).toEqual(expected)
   })
 })

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -1,4 +1,4 @@
-import { buildVirtualGroups, translateGroup, sortGroups } from './helpers'
+import { buildVirtualGroups, translateGroup, translateAndSortGroups } from './helpers'
 import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 
@@ -78,7 +78,7 @@ describe('translateGroup', () => {
   })
 })
 
-describe('sortGroups', () => {
+describe('translateAndSortGroups', () => {
   const translate = jest.fn(key => key)
 
   afterEach(() => {
@@ -98,7 +98,7 @@ describe('sortGroups', () => {
       { virtual: true, label: 'Data.accountTypes.C' }
     ]
 
-    expect(sortGroups(groups, translate)).toEqual(expected)
+    expect(translateAndSortGroups(groups, translate)).toEqual(expected)
   })
 
   it('should put group with label "undefined" at the end', () => {
@@ -116,6 +116,6 @@ describe('sortGroups', () => {
       { virtual: true, label: 'Data.accountTypes.undefined' }
     ]
 
-    expect(sortGroups(groups, translate)).toEqual(expected)
+    expect(translateAndSortGroups(groups, translate)).toEqual(expected)
   })
 })

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -1,4 +1,8 @@
-import { buildVirtualGroups, translateGroup, translateAndSortGroups } from './helpers'
+import {
+  buildVirtualGroups,
+  translateGroup,
+  translateAndSortGroups
+} from './helpers'
 import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 
@@ -40,9 +44,9 @@ describe('buildVirtualGroups', () => {
     const virtualGroups = buildVirtualGroups(accounts)
 
     const expectedGroup = {
-      _id: 'undefined',
+      _id: 'other',
       _type: 'io.cozy.bank.groups',
-      label: 'undefined',
+      label: 'other',
       virtual: true
     }
 
@@ -53,7 +57,7 @@ describe('buildVirtualGroups', () => {
 })
 
 describe('translateGroup', () => {
-  const translate = jest.fn().mockReturnValue('translated')
+  const translate = jest.fn(key => key)
 
   afterEach(() => {
     translate.mockReset()
@@ -72,7 +76,7 @@ describe('translateGroup', () => {
 
     expect(translateGroup(virtualGroup, translate)).toEqual({
       ...virtualGroup,
-      label: 'translated'
+      label: 'Data.accountTypes.label'
     })
     expect(translateGroup(normalGroup, translate)).toEqual(normalGroup)
   })
@@ -103,17 +107,17 @@ describe('translateAndSortGroups', () => {
 
   it('should put group with label "undefined" at the end', () => {
     const groups = [
-      { virtual: true, label: 'C' },
-      { virtual: false, label: 'A' },
       { virtual: false, label: 'B' },
-      { virtual: true, label: 'undefined' }
+      { virtual: false, label: 'A' },
+      { virtual: true, label: 'other' },
+      { virtual: true, label: 'Z' }
     ]
 
     const expected = [
       { virtual: false, label: 'A' },
       { virtual: false, label: 'B' },
-      { virtual: true, label: 'Data.accountTypes.C' },
-      { virtual: true, label: 'Data.accountTypes.undefined' }
+      { virtual: true, label: 'Data.accountTypes.Z' },
+      { virtual: true, label: 'Data.accountTypes.other' }
     ]
 
     expect(translateAndSortGroups(groups, translate)).toEqual(expected)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -119,7 +119,7 @@
       "liability": "Liability accounts",
       "none": "None",
       "savings": "Savings accounts",
-      "undefined": "Other accounts"
+      "other": "Other accounts"
     },
     "categories": {
       "uncategorized": "To be categorized",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -187,7 +187,7 @@
       "liability": "Comptes de dettes",
       "none": "Aucun type",
       "savings": "Comptes d'épargne",
-      "undefined": "Autres comptes"
+      "other": "Autres comptes"
     },
     "categories": {
       "uncategorized": "A catégoriser",


### PR DESCRIPTION
Groups were sorted on their translated label. So "other accounts" was not always the last group.