### PR TITLE
feat(groups): Put groups with not handled type label in 'other accounts'

### DIFF
--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -33,7 +33,7 @@ export const translateGroup = (group, translate) => {
   return {
     ...group,
     label: group.virtual
-      ? translate(`Data.accountTypes.${group.label}`)
+      ? translate(`Data.accountTypes.${group.label}`, { _: 'other' })
       : group.label
   }
 }


### PR DESCRIPTION
If a group have a type that we don't have a translation for, we put it in the "other accounts" virtual group.