### PR TITLE
feat(BalancePanels): Add padding on bottom

### DIFF
--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -22,7 +22,7 @@ class BalancePanels extends React.PureComponent {
     const groupsSorted = translateAndSortGroups(groups, t)
 
     return (
-      <div>
+      <div className={styles.BalancePanels}>
         {groupsSorted.map(group => (
           <GroupPanel key={group._id} group={group} />
         ))}

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -1,5 +1,9 @@
 @require 'settings/breakpoints'
 
+.BalancePanels
+    +small-screen('min')
+        padding-bottom 6rem
+
 .BalancePanels__actions
     display flex
     padding-left 4px


### PR DESCRIPTION
So Claudy does not cover actions

Before:
![image](https://user-images.githubusercontent.com/1606068/50984410-1b152800-1502-11e9-92c5-868b510b60ef.png)

After:
![image](https://user-images.githubusercontent.com/1606068/50984513-692a2b80-1502-11e9-9f4a-7c189663f038.png)
