### PR TITLE
feat(GroupPanels): Show accounts state with colors

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -133,7 +133,7 @@ class Balance extends PureComponent {
           })}
         >
           {showPanels ? (
-            <BalancePanels groups={groups} />
+            <BalancePanels groups={groups} warningLimit={balanceLower} />
           ) : (
             <BalanceTables
               groups={groups}

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -11,20 +11,25 @@ import styles from './BalancePanels.styl'
 class BalancePanels extends React.PureComponent {
   static propTypes = {
     groups: PropTypes.arrayOf(PropTypes.object).isRequired,
-    router: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired,
+    warningLimit: PropTypes.number.isRequired
   }
 
   goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
-    const { groups, t } = this.props
+    const { groups, t, warningLimit } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
 
     return (
       <div className={styles.BalancePanels}>
         {groupsSorted.map(group => (
-          <GroupPanel key={group._id} group={group} />
+          <GroupPanel
+            key={group._id}
+            group={group}
+            warningLimit={warningLimit}
+          />
         ))}
         <div className={styles.BalancePanels__actions}>
           <AddAccountLink>

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -18,7 +18,8 @@ class AccountRow extends React.PureComponent {
     account: PropTypes.object.isRequired,
     onClick: PropTypes.func.isRequired,
     breakpoints: PropTypes.object.isRequired,
-    t: PropTypes.func.isRequired
+    t: PropTypes.func.isRequired,
+    warningLimit: PropTypes.number.isRequired
   }
 
   render() {
@@ -26,7 +27,8 @@ class AccountRow extends React.PureComponent {
       account,
       onClick,
       breakpoints: { isMobile },
-      t
+      t,
+      warningLimit
     } = this.props
 
     const today = new Date()
@@ -35,8 +37,17 @@ class AccountRow extends React.PureComponent {
       nbDays: updateDistance
     })
 
+    const hasWarning = account.balance < warningLimit
+    const hasAlert = account.balance < 0
+
     return (
-      <li className={styles.AccountRow} onClick={onClick}>
+      <li
+        className={cx(styles.AccountRow, {
+          [styles['AccountRow--hasWarning']]: hasWarning,
+          [styles['AccountRow--hasAlert']]: hasAlert
+        })}
+        onClick={onClick}
+      >
         <div className={styles.AccountRow__column}>
           <div className={styles.AccountRow__label}>
             {getAccountLabel(account)}

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -38,6 +38,14 @@
     line-height 1.25
     margin-bottom 0.125rem
 
+.AccountRow--hasWarning
+    .AccountRow__figure
+        color var(--texasRose)
+
+.AccountRow--hasAlert
+    .AccountRow__figure
+        color var(--pomegranate)
+
 .AccountRow__updatedAt
     font-size 0.75rem
     color var(--coolGrey)

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -8,7 +8,8 @@ import styles from './AccountsList.styl'
 
 class AccountsList extends React.PureComponent {
   static propTypes = {
-    accounts: PropTypes.arrayOf(PropTypes.object).isRequired
+    accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
+    warningLimit: PropTypes.number.isRequired
   }
 
   goToTransactionsFilteredByDoc = account => () => {
@@ -17,7 +18,7 @@ class AccountsList extends React.PureComponent {
   }
 
   render() {
-    const { accounts } = this.props
+    const { accounts, warningLimit } = this.props
 
     return (
       <ol className={styles.AccountsList}>
@@ -26,6 +27,7 @@ class AccountsList extends React.PureComponent {
             key={a._id}
             account={a}
             onClick={this.goToTransactionsFilteredByDoc(a)}
+            warningLimit={warningLimit}
           />
         ))}
       </ol>

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -16,7 +16,8 @@ class GroupPanel extends React.PureComponent {
   static propTypes = {
     group: PropTypes.object.isRequired,
     filterByDoc: PropTypes.func.isRequired,
-    router: PropTypes.object.isRequired
+    router: PropTypes.object.isRequired,
+    warningLimit: PropTypes.number.isRequired
   }
 
   goToTransactionsFilteredByDoc = () => {
@@ -30,7 +31,7 @@ class GroupPanel extends React.PureComponent {
   }
 
   render() {
-    const { group } = this.props
+    const { group, warningLimit } = this.props
 
     return (
       <ExpansionPanel defaultExpanded>
@@ -53,7 +54,10 @@ class GroupPanel extends React.PureComponent {
           </div>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>
-          <AccountsList accounts={group.accounts.data} />
+          <AccountsList
+            accounts={group.accounts.data}
+            warningLimit={warningLimit}
+          />
         </ExpansionPanelDetails>
       </ExpansionPanel>
     )


### PR DESCRIPTION
Show the accounts with a balance under the configured limit in orange; and accounts with a negative balance in red.

![image](https://user-images.githubusercontent.com/1606068/51110231-36c94880-17f8-11e9-87ab-79ed08b6e3d6.png)


See https://testbanksaccountrowcolor-banks.cozy.works