### PR TITLE
fix(BalanceTable): Account column was not 100% width on small screen

### DIFF
--- a/src/ducks/balance/components/BalanceTable.styl
+++ b/src/ducks/balance/components/BalanceTable.styl
@@ -28,6 +28,9 @@
     color coolGrey
     composes mobile-row-label from '../../../components/Table/styles.styl'
 
+    +small-screen()
+        maxed-flex-basis 100%
+
 .ColumnBank
     maxed-flex-basis 30%
     color coolGrey


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1606068/51255476-a0398a80-19a3-11e9-9dc1-c0d215e88d50.png)


After:
![image](https://user-images.githubusercontent.com/1606068/51255445-9021ab00-19a3-11e9-9803-3c2053b71170.png)
