### PR TITLE
Groups and accounts checked/disabled state management

### DIFF
--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -39,7 +39,11 @@ export default withStyles(() => ({
   },
   disabled: {
     '&$switchBase': {
-      color: 'white'
+      color: 'white',
+      '& + $bar': {
+        backgroundColor: 'var(--silver)',
+        opacity: 1
+      }
     }
   }
 }))(Switch)

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -23,15 +23,22 @@ import BalancePanels from './BalancePanels'
 
 function getSwitchesState(groups, currentSwitchesState) {
   const switchesState = groups.reduce((acc, group) => {
+    const groupChecked = get(
+      currentSwitchesState,
+      `[${group._id}].checked`,
+      true
+    )
+
     acc[group._id] = {
-      checked: get(currentSwitchesState, `[${group._id}].checked`, true),
+      checked: groupChecked,
       accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
         acc2[account._id] = {
           checked: get(
             currentSwitchesState,
             `[${group._id}].accounts[${account.id}].checked`,
             true
-          )
+          ),
+          disabled: !groupChecked
         }
 
         return acc2

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -46,7 +46,7 @@ function getSwitchesState(groups, currentSwitchesState) {
 
 class Balance extends PureComponent {
   state = {
-    switchesState: {}
+    switches: {}
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -181,7 +181,11 @@ class Balance extends PureComponent {
           })}
         >
           {showPanels ? (
-            <BalancePanels groups={groups} warningLimit={balanceLower} />
+            <BalancePanels
+              groups={groups}
+              warningLimit={balanceLower}
+              switches={this.state.switches}
+            />
           ) : (
             <BalanceTables
               groups={groups}

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -20,36 +20,7 @@ import History from './History'
 import styles from './Balance.styl'
 import BalanceTables from './BalanceTables'
 import BalancePanels from './BalancePanels'
-
-function getSwitchesState(groups, currentSwitchesState) {
-  const switchesState = groups.reduce((acc, group) => {
-    const groupChecked = get(
-      currentSwitchesState,
-      `[${group._id}].checked`,
-      true
-    )
-
-    acc[group._id] = {
-      checked: groupChecked,
-      accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
-        acc2[account._id] = {
-          checked: get(
-            currentSwitchesState,
-            `[${group._id}].accounts[${account.id}].checked`,
-            true
-          ),
-          disabled: !groupChecked
-        }
-
-        return acc2
-      }, {})
-    }
-
-    return acc
-  }, {})
-
-  return switchesState
-}
+import { getSwitchesState } from './helpers'
 
 class Balance extends PureComponent {
   state = {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -21,7 +21,55 @@ import styles from './Balance.styl'
 import BalanceTables from './BalanceTables'
 import BalancePanels from './BalancePanels'
 
+function getSwitchesState(groups, currentSwitchesState) {
+  const switchesState = groups.reduce((acc, group) => {
+    acc[group._id] = {
+      enabled: get(currentSwitchesState, `[${group._id}].enabled`, true),
+      accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
+        acc2[account._id] = {
+          enabled: get(
+            currentSwitchesState,
+            `[${group._id}][${account.id}]`,
+            true
+          )
+        }
+
+        return acc2
+      }, {})
+    }
+
+    return acc
+  }, {})
+
+  return switchesState
+}
+
 class Balance extends PureComponent {
+  state = {
+    switchesState: {}
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const { groups: groupsCollection, accounts: accountsCollection } = props
+
+    if (!groupsCollection || !accountsCollection) {
+      return null
+    }
+
+    const groups = [
+      ...groupsCollection.data,
+      ...buildVirtualGroups(accountsCollection.data)
+    ]
+
+    const { switchesState: currentSwitchesState } = state
+
+    const newSwitchesState = getSwitchesState(groups, currentSwitchesState)
+
+    return {
+      switches: newSwitchesState
+    }
+  }
+
   render() {
     const {
       t,

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -18,7 +18,7 @@ class BalancePanels extends React.PureComponent {
   goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
-    const { groups, t, warningLimit } = this.props
+    const { groups, t, warningLimit, switches } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
 
@@ -29,6 +29,7 @@ class BalancePanels extends React.PureComponent {
             key={group._id}
             group={group}
             warningLimit={warningLimit}
+            switches={switches[group._id]}
           />
         ))}
         <div className={styles.BalancePanels__actions}>

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -12,13 +12,15 @@ class BalancePanels extends React.PureComponent {
   static propTypes = {
     groups: PropTypes.arrayOf(PropTypes.object).isRequired,
     router: PropTypes.object.isRequired,
-    warningLimit: PropTypes.number.isRequired
+    warningLimit: PropTypes.number.isRequired,
+    switches: PropTypes.object.isRequired,
+    onSwitchChange: PropTypes.func.isRequired
   }
 
   goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
-    const { groups, t, warningLimit, switches } = this.props
+    const { groups, t, warningLimit, switches, onSwitchChange } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
 
@@ -29,7 +31,9 @@ class BalancePanels extends React.PureComponent {
             key={group._id}
             group={group}
             warningLimit={warningLimit}
-            switches={switches[group._id]}
+            checked={switches[group._id].checked}
+            switches={switches[group._id].accounts}
+            onSwitchChange={onSwitchChange}
           />
         ))}
         <div className={styles.BalancePanels__actions}>

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -63,7 +63,8 @@ class AccountRow extends React.PureComponent {
       <li
         className={cx(styles.AccountRow, {
           [styles['AccountRow--hasWarning']]: hasWarning,
-          [styles['AccountRow--hasAlert']]: hasAlert
+          [styles['AccountRow--hasAlert']]: hasAlert,
+          [styles['AccountRow--disabled']]: !checked || disabled
         })}
         onClick={onClick}
       >

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -25,6 +25,7 @@ class AccountRow extends React.PureComponent {
     t: PropTypes.func.isRequired,
     warningLimit: PropTypes.number.isRequired,
     checked: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool.isRequired,
     switchIdPrefix: PropTypes.string.isRequired,
     onSwitchChange: PropTypes.func.isRequired
   }
@@ -41,6 +42,7 @@ class AccountRow extends React.PureComponent {
       t,
       warningLimit,
       checked,
+      disabled,
       switchIdPrefix,
       onSwitchChange
     } = this.props
@@ -129,6 +131,7 @@ class AccountRow extends React.PureComponent {
             currencyClassName={styles.AccountRow__figure}
           />
           <Switch
+            disabled={disabled}
             checked={checked}
             color="primary"
             onClick={this.handleSwitchClick}

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -36,7 +36,8 @@ class AccountRow extends React.PureComponent {
       onClick,
       breakpoints: { isMobile },
       t,
-      warningLimit
+      warningLimit,
+      enabled
     } = this.props
 
     const today = new Date()
@@ -123,7 +124,7 @@ class AccountRow extends React.PureComponent {
             currencyClassName={styles.AccountRow__figure}
           />
           <Switch
-            defaultChecked
+            checked={enabled}
             color="primary"
             onClick={this.handleSwitchClick}
             className={styles.AccountRow__switch}

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -23,7 +23,10 @@ class AccountRow extends React.PureComponent {
     onClick: PropTypes.func.isRequired,
     breakpoints: PropTypes.object.isRequired,
     t: PropTypes.func.isRequired,
-    warningLimit: PropTypes.number.isRequired
+    warningLimit: PropTypes.number.isRequired,
+    checked: PropTypes.bool.isRequired,
+    switchIdPrefix: PropTypes.string.isRequired,
+    onSwitchChange: PropTypes.func.isRequired
   }
 
   handleSwitchClick = e => {
@@ -37,7 +40,9 @@ class AccountRow extends React.PureComponent {
       breakpoints: { isMobile },
       t,
       warningLimit,
-      enabled
+      checked,
+      switchIdPrefix,
+      onSwitchChange
     } = this.props
 
     const today = new Date()
@@ -124,10 +129,12 @@ class AccountRow extends React.PureComponent {
             currencyClassName={styles.AccountRow__figure}
           />
           <Switch
-            checked={enabled}
+            checked={checked}
             color="primary"
             onClick={this.handleSwitchClick}
             className={styles.AccountRow__switch}
+            id={`${switchIdPrefix}.accounts[${account._id}]`}
+            onChange={onSwitchChange}
           />
         </div>
       </li>

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -84,3 +84,6 @@
 
     +small-screen('min')
         margin-left 0.8125rem
+
+.AccountRow--disabled
+    color var(--coolGrey)

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -9,7 +9,10 @@ import styles from './AccountsList.styl'
 class AccountsList extends React.PureComponent {
   static propTypes = {
     accounts: PropTypes.arrayOf(PropTypes.object).isRequired,
-    warningLimit: PropTypes.number.isRequired
+    warningLimit: PropTypes.number.isRequired,
+    switches: PropTypes.object.isRequired,
+    switchesIdPrefix: PropTypes.string.isRequired,
+    onSwitchChange: PropTypes.func.isRequired
   }
 
   goToTransactionsFilteredByDoc = account => () => {
@@ -18,7 +21,13 @@ class AccountsList extends React.PureComponent {
   }
 
   render() {
-    const { accounts, warningLimit, switches } = this.props
+    const {
+      accounts,
+      warningLimit,
+      switches,
+      switchesIdPrefix,
+      onSwitchChange
+    } = this.props
 
     return (
       <ol className={styles.AccountsList}>
@@ -28,7 +37,9 @@ class AccountsList extends React.PureComponent {
             account={a}
             onClick={this.goToTransactionsFilteredByDoc(a)}
             warningLimit={warningLimit}
-            enabled={switches[a._id]}
+            checked={switches[a._id].checked}
+            switchIdPrefix={switchesIdPrefix}
+            onSwitchChange={onSwitchChange}
           />
         ))}
       </ol>

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -38,6 +38,7 @@ class AccountsList extends React.PureComponent {
             onClick={this.goToTransactionsFilteredByDoc(a)}
             warningLimit={warningLimit}
             checked={switches[a._id].checked}
+            disabled={switches[a._id].disabled}
             switchIdPrefix={switchesIdPrefix}
             onSwitchChange={onSwitchChange}
           />

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -18,7 +18,7 @@ class AccountsList extends React.PureComponent {
   }
 
   render() {
-    const { accounts, warningLimit } = this.props
+    const { accounts, warningLimit, switches } = this.props
 
     return (
       <ol className={styles.AccountsList}>
@@ -28,6 +28,7 @@ class AccountsList extends React.PureComponent {
             account={a}
             onClick={this.goToTransactionsFilteredByDoc(a)}
             warningLimit={warningLimit}
+            enabled={switches[a._id]}
           />
         ))}
       </ol>

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -55,7 +55,7 @@ class GroupPanel extends React.PureComponent {
   }
 
   render() {
-    const { group, warningLimit } = this.props
+    const { group, warningLimit, switches } = this.props
 
     return (
       <ExpansionPanel defaultExpanded>
@@ -78,7 +78,7 @@ class GroupPanel extends React.PureComponent {
               />
             </div>
             <Switch
-              defaultChecked
+              checked={switches.enabled}
               color="primary"
               onClick={this.handleSwitchClick}
               className={styles.GroupPanelSummary__switch}
@@ -89,6 +89,7 @@ class GroupPanel extends React.PureComponent {
           <AccountsList
             accounts={group.accounts.data}
             warningLimit={warningLimit}
+            switches={switches.accounts}
           />
         </ExpansionPanelDetails>
       </ExpansionPanel>

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -37,7 +37,10 @@ class GroupPanel extends React.PureComponent {
     group: PropTypes.object.isRequired,
     filterByDoc: PropTypes.func.isRequired,
     router: PropTypes.object.isRequired,
-    warningLimit: PropTypes.number.isRequired
+    warningLimit: PropTypes.number.isRequired,
+    switches: PropTypes.object.isRequired,
+    checked: PropTypes.bool.isRequired,
+    onSwitchChange: PropTypes.func.isRequired
   }
 
   goToTransactionsFilteredByDoc = () => {
@@ -55,7 +58,13 @@ class GroupPanel extends React.PureComponent {
   }
 
   render() {
-    const { group, warningLimit, switches } = this.props
+    const {
+      group,
+      warningLimit,
+      switches,
+      onSwitchChange,
+      checked
+    } = this.props
 
     return (
       <ExpansionPanel defaultExpanded>
@@ -78,10 +87,12 @@ class GroupPanel extends React.PureComponent {
               />
             </div>
             <Switch
-              checked={switches.enabled}
+              checked={checked}
               color="primary"
               onClick={this.handleSwitchClick}
               className={styles.GroupPanelSummary__switch}
+              id={`[${group._id}]`}
+              onChange={onSwitchChange}
             />
           </div>
         </GroupPanelSummary>
@@ -89,7 +100,9 @@ class GroupPanel extends React.PureComponent {
           <AccountsList
             accounts={group.accounts.data}
             warningLimit={warningLimit}
-            switches={switches.accounts}
+            switches={switches}
+            switchesIdPrefix={`[${group._id}]`}
+            onSwitchChange={onSwitchChange}
           />
         </ExpansionPanelDetails>
       </ExpansionPanel>

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -150,3 +150,33 @@ export const getGroupBalance = group => {
 
   return sumBy(accounts, account => get(account, 'balance', 0))
 }
+
+export const getSwitchesState = (groups, currentSwitchesState) => {
+  const switchesState = groups.reduce((acc, group) => {
+    const groupChecked = get(
+      currentSwitchesState,
+      `[${group._id}].checked`,
+      true
+    )
+
+    acc[group._id] = {
+      checked: groupChecked,
+      accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
+        acc2[account._id] = {
+          checked: get(
+            currentSwitchesState,
+            `[${group._id}].accounts[${account.id}].checked`,
+            true
+          ),
+          disabled: !groupChecked
+        }
+
+        return acc2
+      }, {})
+    }
+
+    return acc
+  }, {})
+
+  return switchesState
+}

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -5,7 +5,8 @@ import {
   sumBalanceHistories,
   getAllDates,
   balanceHistoryToChartData,
-  getGroupBalance
+  getGroupBalance,
+  getSwitchesState
 } from './helpers'
 import { format as formatDate, parse as parseDate } from 'date-fns'
 
@@ -269,5 +270,45 @@ describe('getGroupBalance', () => {
     const group = { accounts: { data: accounts } }
 
     expect(getGroupBalance(group)).toBe(8900)
+  })
+})
+
+fdescribe('getSwitchesState', () => {
+  it('should initialize switches state to true', () => {
+    const groups = [{ _id: 'g1', accounts: { data: [{ _id: 'a1' }] } }]
+    const currentSwitchesState = {}
+
+    expect(getSwitchesState(groups, currentSwitchesState)).toEqual({
+      g1: {
+        checked: true,
+        accounts: {
+          a1: {
+            checked: true,
+            disabled: false
+          }
+        }
+      }
+    })
+  })
+
+  it('should disable an account if its group is unchecked', () => {
+    const groups = [{ _id: 'g1', accounts: { data: [{ _id: 'a1' }] } }]
+    const currentSwitchesState = {
+      g1: {
+        checked: false
+      }
+    }
+
+    expect(getSwitchesState(groups, currentSwitchesState)).toEqual({
+      g1: {
+        checked: false,
+        accounts: {
+          a1: {
+            checked: true,
+            disabled: true
+          }
+        }
+      }
+    })
   })
 })


### PR DESCRIPTION
This adds the possibility to check/uncheck groups and accounts.

The rules are the following:

* When we uncheck a group, we want the accounts rows to be disabled, but their checked state remains the same (ie. unchecking a group doesn't uncheck the switches of all its accounts)
* We need to know the state of each account in each group. It means we can't flatten the object holding the state. This is because we still put an account balances in the balance history computation until it is unchecked in all the groups it's part of (this is not part of this PR because I wanted to cut the work to avoid monstrous PR)

I used an object with the following shape to hold the state:
```
{
  [GROUP_ID]: {
    checked: boolean,
    accounts: {
      [ACCOUNT_ID]: {
        checked: boolean,
        disabled: boolean
      }
    }
  }
}
```

The reason is because this object can be serialized and put in the local storage or `io.cozy.bank.settings` to remember the user's choices.

Finally, each `Switch` has an `id` that is the path to its value in the state object. So we can easily update it even if it's nested.

![peek 22-01-2019 15-35](https://user-images.githubusercontent.com/1606068/51542374-619c4800-1e5b-11e9-81f1-65979bcf4ac9.gif)


Result is live on https://testbankshandleswitch-banks.cozy.works