### PR TITLE
fix: Gradiant should start on min y

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import * as d3 from 'd3'
-import { maxBy, sortBy } from 'lodash'
+import { maxBy, sortBy, minBy } from 'lodash'
 import styles from './LineChart.styl'
 import Tooltip from './Tooltip'
 
@@ -70,10 +70,11 @@ class LineChart extends Component {
       .attr('transform', `translate(${margin.left}, ${margin.top})`)
 
     if (gradient) {
+      const minY = minBy(data, e => e.y)
       this.areaGenerator = d3
         .area()
         .x(d => this.x(d.x))
-        .y0(() => this.y(0))
+        .y0(() => this.y(minY.y))
         .y1(d => this.y(d.y))
 
       this.mask = this.svg


### PR DESCRIPTION
I change just value of `y0` to start gradient on minimum

![capture d ecran 2019-01-22 a 15 37 34](https://user-images.githubusercontent.com/1135513/51542495-ae801e80-1e5b-11e9-89ba-3ad919bf8706.png)
