### PR TITLE
Update chart when checking/unchecking groups/acounts

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -25,8 +25,6 @@ class LineChart extends Component {
 
     this.updateData()
     this.enterAnimation()
-
-    this.forceUpdate()
   }
 
   componentDidUpdate() {

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -330,7 +330,7 @@ class LineChart extends Component {
     }
 
     const [mouseX] = d3.mouse(this.svg.node())
-    this.setState({ x: mouseX })
+    this.setState({ x: Math.min(mouseX, this.getInnerWidth()) })
   }
 
   stopPointDrag = () => {

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -21,16 +21,6 @@ class LineChart extends Component {
     this.updateData()
   }
 
-  getRootWidth() {
-    if (typeof this.props.width === 'number') {
-      return this.props.width
-    }
-
-    const { width } = getComputedStyle(this.root)
-
-    return parseInt(width)
-  }
-
   createChart() {
     const {
       data,
@@ -51,10 +41,9 @@ class LineChart extends Component {
       pointRadius,
       pointFillColor,
       pointStrokeWidth,
-      pointStrokeColor
+      pointStrokeColor,
+      width
     } = this.props
-
-    const width = this.getRootWidth()
 
     const innerWidth = width - margin.left - margin.right
     const innerHeight = height - margin.top - margin.bottom
@@ -354,7 +343,7 @@ LineChart.propTypes = {
       y: PropTypes.any
     })
   ).isRequired,
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+  width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   margin: PropTypes.shape({
     top: PropTypes.number,

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import * as d3 from 'd3'
-import { maxBy, sortBy, minBy } from 'lodash'
+import { maxBy, minBy } from 'lodash'
 import styles from './LineChart.styl'
 import Tooltip from './Tooltip'
 
@@ -154,8 +154,6 @@ class LineChart extends Component {
   }
 
   setData(data, animate) {
-    const sortedData = sortBy(data, d => d.x)
-
     this.x.domain(d3.extent(data, d => d.x))
 
     let yDomain = d3.extent(data, d => d.y)
@@ -169,11 +167,11 @@ class LineChart extends Component {
 
     this.y.domain(yDomain)
 
-    this.line.datum(sortedData).attr('d', this.lineGenerator)
-    this.clickLine.datum(sortedData).attr('d', this.lineGenerator)
+    this.line.datum(data).attr('d', this.lineGenerator)
+    this.clickLine.datum(data).attr('d', this.lineGenerator)
 
     if (this.mask) {
-      this.mask.datum(sortedData).attr('d', this.areaGenerator)
+      this.mask.datum(data).attr('d', this.areaGenerator)
     }
 
     if (animate) {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -149,7 +149,7 @@ class Balance extends PureComponent {
               <div className={styles.Balance__subtitle}>
                 {t('BalanceHistory.subtitle')}
               </div>
-              <History accounts={accountsCollection} />
+              <History accounts={accountsCollection.data} />
             </Fragment>
           ) : (
             <Padded className="u-pb-0">

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -62,15 +62,9 @@ class Balance extends PureComponent {
   getAccountOccurrencesInState(account) {
     const { switches } = this.state
 
-    return Object.values(switches).reduce((occurrences, group) => {
-      const occurrence = group.accounts[account._id]
-
-      if (occurrence) {
-        return [...occurrences, occurrence]
-      }
-
-      return occurrences
-    }, [])
+    return Object.values(switches)
+      .map(group => group.accounts[account._id])
+      .filter(Boolean)
   }
 
   getCheckedAccounts() {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -108,9 +108,6 @@ class Balance extends PureComponent {
       color: withChart && !isMobile ? 'primary' : 'default'
     }
     const titlePaddedClass = isMobile ? 'u-p-0' : 'u-pb-0'
-    const currentBalance = isCollectionLoading(accounts)
-      ? 0
-      : sumBy(this.props.accounts.data, a => a.balance)
 
     if (
       isCollectionLoading(accountsCollection) ||
@@ -123,20 +120,6 @@ class Balance extends PureComponent {
               <Padded className={titlePaddedClass}>
                 <PageTitle {...titleColorProps}>{t('Balance.title')}</PageTitle>
               </Padded>
-            )}
-            {withChart && (
-              <Fragment>
-                <Figure
-                  className={styles.Balance__currentBalance}
-                  currencyClassName={styles.Balance__currentBalanceCurrency}
-                  total={currentBalance}
-                  currency="€"
-                />
-                <div className={styles.Balance__subtitle}>
-                  {t('BalanceHistory.subtitle')}
-                </div>
-                <History accounts={accountsCollection} />
-              </Fragment>
             )}
           </Header>
           <Loading />
@@ -158,6 +141,9 @@ class Balance extends PureComponent {
     const showPanels = flag('balance-panels')
 
     const checkedAccounts = this.getCheckedAccounts()
+    const checkedAccountsBalance = isCollectionLoading(accounts)
+      ? 0
+      : sumBy(checkedAccounts, a => a.balance)
 
     return (
       <Fragment>
@@ -172,7 +158,7 @@ class Balance extends PureComponent {
               <Figure
                 className={styles.Balance__currentBalance}
                 currencyClassName={styles.Balance__currentBalanceCurrency}
-                total={currentBalance}
+                total={checkedAccountsBalance}
                 currency="€"
               />
               <div className={styles.Balance__subtitle}>

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -59,6 +59,33 @@ class Balance extends PureComponent {
     })
   }
 
+  getAccountOccurrencesInState(account) {
+    const { switches } = this.state
+
+    return Object.values(switches).reduce((occurrences, group) => {
+      const occurrence = group.accounts[account._id]
+
+      if (occurrence) {
+        return [...occurrences, occurrence]
+      }
+
+      return occurrences
+    }, [])
+  }
+
+  getCheckedAccounts() {
+    const { accounts: accountsCollection } = this.props
+    const accounts = accountsCollection.data
+
+    return accounts.filter(account => {
+      const occurrences = this.getAccountOccurrencesInState(account)
+
+      return occurrences.some(
+        occurrence => occurrence.checked && !occurrence.disabled
+      )
+    })
+  }
+
   render() {
     const {
       t,
@@ -130,6 +157,8 @@ class Balance extends PureComponent {
     const balanceLower = get(settings, 'notifications.balanceLower.value')
     const showPanels = flag('balance-panels')
 
+    const checkedAccounts = this.getCheckedAccounts()
+
     return (
       <Fragment>
         <Header className={headerClassName} {...headerColorProps}>
@@ -149,7 +178,7 @@ class Balance extends PureComponent {
               <div className={styles.Balance__subtitle}>
                 {t('BalanceHistory.subtitle')}
               </div>
-              <History accounts={accountsCollection.data} />
+              <History accounts={checkedAccounts} />
             </Fragment>
           ) : (
             <Padded className="u-pb-0">

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -162,7 +162,12 @@ class Balance extends PureComponent {
                 currency="€"
               />
               <div className={styles.Balance__subtitle}>
-                {t('BalanceHistory.subtitle')}
+                {checkedAccounts.length === accounts.length
+                  ? t('BalanceHistory.all_accounts')
+                  : t('BalanceHistory.checked_accounts', {
+                      nbCheckedAccounts: checkedAccounts.length,
+                      nbAccounts: accounts.length
+                    })}
               </div>
               <History accounts={checkedAccounts} />
             </Fragment>

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -47,7 +47,7 @@ class History extends Component {
   getChartData() {
     const { accounts } = this.props
     const transactions = this.getTransactionsFiltered()
-    const history = this.getBalanceHistory(accounts.data, transactions.data)
+    const history = this.getBalanceHistory(accounts, transactions.data)
     const data = balanceHistoryToChartData(history)
 
     return data
@@ -104,7 +104,7 @@ class History extends Component {
 }
 
 History.propTypes = {
-  accounts: PropTypes.object.isRequired,
+  accounts: PropTypes.array.isRequired,
   className: PropTypes.string,
   transactions: PropTypes.object.isRequired
 }

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -13,10 +13,7 @@ const gradientStyle = {
 }
 
 class HistoryChart extends Component {
-  constructor(props) {
-    super(props)
-    this.container = React.createRef()
-  }
+  container = React.createRef()
 
   getTooltipContent = item => {
     const date = formatDate(item.x, 'DD  MMM')

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -19,7 +19,14 @@ import {
  */
 export const getBalanceHistories = (accounts, transactions, to, from) => {
   if (accounts.length === 0) {
-    return null
+    return {
+      __no_accounts__: getBalanceHistory(
+        { _id: '__no_accounts__', balance: 0 },
+        [],
+        to,
+        from
+      )
+    }
   }
 
   const balances = accounts.reduce((balances, account) => {

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -124,9 +124,7 @@ export const sumBalanceHistories = histories => {
  * @returns {Object[]}
  */
 export const balanceHistoryToChartData = history => {
-  const dates = getAllDates([history])
-    .sort()
-    .reverse()
+  const dates = getAllDates([history]).sort()
 
   const data = dates.map(date => ({
     x: parseDate(date),

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -154,8 +154,20 @@ describe('sumBalanceHistories', () => {
 })
 
 describe('getBalanceHistories', () => {
-  it('should return null if there is no account', () => {
-    expect(getBalanceHistories([], [{ amount: 42 }])).toBeNull()
+  it('should an empty history if there is no account', () => {
+    expect(
+      getBalanceHistories(
+        [],
+        [],
+        parseDate('2019-01-02'),
+        parseDate('2019-01-01')
+      )
+    ).toEqual({
+      __no_accounts__: {
+        '2019-01-01': 0,
+        '2019-01-02': 0
+      }
+    })
   })
 
   it('should return an object with a property for each account id', () => {

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -238,7 +238,7 @@ describe('getBalanceHistories', () => {
 describe('balanceHistoryToChartData', () => {
   it('should sort by date desc', () => {
     const history = { '2018-11-22': 1000, '2018-11-21': 500, '2018-11-20': 600 }
-    const expected = ['2018-11-22', '2018-11-21', '2018-11-20']
+    const expected = ['2018-11-20', '2018-11-21', '2018-11-22']
     const chartData = balanceHistoryToChartData(history)
     const dates = chartData.map(item => formatDate(item.x, 'YYYY-MM-DD'))
 
@@ -247,7 +247,7 @@ describe('balanceHistoryToChartData', () => {
 
   it('should return the right data', () => {
     const history = { '2018-11-22': 1000, '2018-11-21': 500, '2018-11-20': 600 }
-    const expected = [1000, 500, 600]
+    const expected = [600, 500, 1000]
     const chartData = balanceHistoryToChartData(history)
     const values = chartData.map(item => item.y)
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -522,7 +522,8 @@
   },
 
   "BalanceHistory": {
-    "subtitle": "All accounts"
+    "all_accounts": "All accounts",
+    "checked_accounts": "%{nbCheckedAccounts}/%{nbAccounts} accounts"
   },
 
   "LogoutModal": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -475,7 +475,8 @@
   },
 
   "BalanceHistory": {
-    "subtitle": "Tous les comptes"
+    "all_accounts": "Tous les comptes",
+    "checked_accounts": "%{nbCheckedAccounts}/%{nbAccounts} comptes"
   },
 
   "LogoutModal": {


### PR DESCRIPTION
This adds the link between groups/accounts switch and the balance history chart on the balance page.

We look the switches state object to find which accounts are enabled, then we pass them to the chart and we compute the balance only on them.