### PR TITLE
Save and get balance panels state with settings

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -24,13 +24,24 @@ import { getPanelsState } from './helpers'
 
 class Balance extends PureComponent {
   state = {
-    panels: {}
+    panels: null
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { groups, accounts } = props
+    const { groups, accounts, settings: settingsCollection } = props
+
+    const isLoading =
+      isCollectionLoading(groups) ||
+      isCollectionLoading(accounts) ||
+      isCollectionLoading(settingsCollection)
+
+    if (isLoading) {
+      return null
+    }
+
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
     const allGroups = [...groups.data, ...buildVirtualGroups(accounts.data)]
-    const { panels: currentPanelsState } = state
+    const currentPanelsState = state.panels || settings.panelsState || {}
     const newPanelsState = getPanelsState(allGroups, currentPanelsState)
 
     return {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -59,6 +59,17 @@ class Balance extends PureComponent {
     })
   }
 
+  handlePanelChange = panelId => (event, expanded) => {
+    const path = panelId + '.expanded'
+
+    this.setState(prevState => {
+      const nextState = { ...prevState }
+      set(nextState.panels, path, expanded)
+
+      return nextState
+    })
+  }
+
   getAccountOccurrencesInState(account) {
     const { panels } = this.state
 
@@ -189,6 +200,7 @@ class Balance extends PureComponent {
               warningLimit={balanceLower}
               panelsState={this.state.panels}
               onSwitchChange={this.handleSwitchChange}
+              onPanelChange={this.handlePanelChange}
             />
           ) : (
             <BalanceTables

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -20,11 +20,11 @@ import History from './History'
 import styles from './Balance.styl'
 import BalanceTables from './BalanceTables'
 import BalancePanels from './BalancePanels'
-import { getSwitchesState } from './helpers'
+import { getPanelsState } from './helpers'
 
 class Balance extends PureComponent {
   state = {
-    switches: {}
+    panels: {}
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -39,12 +39,12 @@ class Balance extends PureComponent {
       ...buildVirtualGroups(accountsCollection.data)
     ]
 
-    const { switches: currentSwitchesState } = state
+    const { panels: currentPanelsState } = state
 
-    const newSwitchesState = getSwitchesState(groups, currentSwitchesState)
+    const newPanelsState = getPanelsState(groups, currentPanelsState)
 
     return {
-      switches: newSwitchesState
+      panels: newPanelsState
     }
   }
 
@@ -53,16 +53,16 @@ class Balance extends PureComponent {
 
     this.setState(prevState => {
       const nextState = { ...prevState }
-      set(nextState.switches, path, checked)
+      set(nextState.panels, path, checked)
 
       return nextState
     })
   }
 
   getAccountOccurrencesInState(account) {
-    const { switches } = this.state
+    const { panels } = this.state
 
-    return Object.values(switches)
+    return Object.values(panels)
       .map(group => group.accounts[account._id])
       .filter(Boolean)
   }
@@ -187,7 +187,7 @@ class Balance extends PureComponent {
             <BalancePanels
               groups={groups}
               warningLimit={balanceLower}
-              switches={this.state.switches}
+              panelsState={this.state.panels}
               onSwitchChange={this.handleSwitchChange}
             />
           ) : (

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -28,20 +28,10 @@ class Balance extends PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { groups: groupsCollection, accounts: accountsCollection } = props
-
-    if (!groupsCollection || !accountsCollection) {
-      return null
-    }
-
-    const groups = [
-      ...groupsCollection.data,
-      ...buildVirtualGroups(accountsCollection.data)
-    ]
-
+    const { groups, accounts } = props
+    const allGroups = [...groups.data, ...buildVirtualGroups(accounts.data)]
     const { panels: currentPanelsState } = state
-
-    const newPanelsState = getPanelsState(groups, currentPanelsState)
+    const newPanelsState = getPanelsState(allGroups, currentPanelsState)
 
     return {
       panels: newPanelsState

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent, Fragment } from 'react'
 import { flowRight as compose, get, sumBy, set } from 'lodash'
 import { translate, withBreakpoints } from 'cozy-ui/react'
-import { queryConnect } from 'cozy-client'
+import { queryConnect, withMutations } from 'cozy-client'
 import flag from 'cozy-flags'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 import cx from 'classnames'
@@ -56,7 +56,7 @@ class Balance extends PureComponent {
       set(nextState.panels, path, checked)
 
       return nextState
-    })
+    }, this.onPanelsStateChange)
   }
 
   handlePanelChange = panelId => (event, expanded) => {
@@ -67,7 +67,23 @@ class Balance extends PureComponent {
       set(nextState.panels, path, expanded)
 
       return nextState
-    })
+    }, this.onPanelsStateChange)
+  }
+
+  onPanelsStateChange() {
+    const { panels } = this.state
+    const settings = this.props.settings.data[0]
+
+    if (!settings) {
+      return
+    }
+
+    const newSettings = {
+      ...settings,
+      panelsState: panels
+    }
+
+    this.props.saveDocument(newSettings)
   }
 
   getAccountOccurrencesInState(account) {
@@ -222,5 +238,6 @@ export default compose(
     accounts: { query: client => client.all(ACCOUNT_DOCTYPE), as: 'accounts' },
     groups: { query: client => client.all(GROUP_DOCTYPE), as: 'groups' },
     settings: { query: client => client.all(SETTINGS_DOCTYPE), as: 'settings' }
-  })
+  }),
+  withMutations()
 )(Balance)

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -13,14 +13,14 @@ class BalancePanels extends React.PureComponent {
     groups: PropTypes.arrayOf(PropTypes.object).isRequired,
     router: PropTypes.object.isRequired,
     warningLimit: PropTypes.number.isRequired,
-    switches: PropTypes.object.isRequired,
+    panelsState: PropTypes.object.isRequired,
     onSwitchChange: PropTypes.func.isRequired
   }
 
   goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
-    const { groups, t, warningLimit, switches, onSwitchChange } = this.props
+    const { groups, t, warningLimit, panelsState, onSwitchChange } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
 
@@ -31,8 +31,8 @@ class BalancePanels extends React.PureComponent {
             key={group._id}
             group={group}
             warningLimit={warningLimit}
-            checked={switches[group._id].checked}
-            switches={switches[group._id].accounts}
+            checked={panelsState[group._id].checked}
+            switches={panelsState[group._id].accounts}
             onSwitchChange={onSwitchChange}
           />
         ))}

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -14,13 +14,21 @@ class BalancePanels extends React.PureComponent {
     router: PropTypes.object.isRequired,
     warningLimit: PropTypes.number.isRequired,
     panelsState: PropTypes.object.isRequired,
-    onSwitchChange: PropTypes.func.isRequired
+    onSwitchChange: PropTypes.func.isRequired,
+    onPanelChange: PropTypes.func.isRequired
   }
 
   goToGroupsSettings = () => this.props.router.push('/settings/groups')
 
   render() {
-    const { groups, t, warningLimit, panelsState, onSwitchChange } = this.props
+    const {
+      groups,
+      t,
+      warningLimit,
+      panelsState,
+      onSwitchChange,
+      onPanelChange
+    } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
 
@@ -31,9 +39,11 @@ class BalancePanels extends React.PureComponent {
             key={group._id}
             group={group}
             warningLimit={warningLimit}
+            expanded={panelsState[group._id].expanded}
             checked={panelsState[group._id].checked}
             switches={panelsState[group._id].accounts}
             onSwitchChange={onSwitchChange}
+            onChange={onPanelChange}
           />
         ))}
         <div className={styles.BalancePanels__actions}>

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -40,7 +40,9 @@ class GroupPanel extends React.PureComponent {
     warningLimit: PropTypes.number.isRequired,
     switches: PropTypes.object.isRequired,
     checked: PropTypes.bool.isRequired,
-    onSwitchChange: PropTypes.func.isRequired
+    expanded: PropTypes.bool.isRequired,
+    onSwitchChange: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired
   }
 
   goToTransactionsFilteredByDoc = () => {
@@ -63,11 +65,13 @@ class GroupPanel extends React.PureComponent {
       warningLimit,
       switches,
       onSwitchChange,
-      checked
+      checked,
+      expanded,
+      onChange
     } = this.props
 
     return (
-      <ExpansionPanel defaultExpanded>
+      <ExpansionPanel expanded={expanded} onChange={onChange(group._id)}>
         <GroupPanelSummary
           expandIcon={<Icon icon="bottom" color="black" width={12} />}
           IconButtonProps={{

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -156,20 +156,16 @@ export const getGroupBalance = group => {
   return sumBy(accounts, account => get(account, 'balance', 0))
 }
 
-export const getSwitchesState = (groups, currentSwitchesState) => {
+export const getPanelsState = (groups, currentPanelsState) => {
   const switchesState = groups.reduce((acc, group) => {
-    const groupChecked = get(
-      currentSwitchesState,
-      `[${group._id}].checked`,
-      true
-    )
+    const groupChecked = get(currentPanelsState, `[${group._id}].checked`, true)
 
     acc[group._id] = {
       checked: groupChecked,
       accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
         acc2[account._id] = {
           checked: get(
-            currentSwitchesState,
+            currentPanelsState,
             `[${group._id}].accounts[${account.id}].checked`,
             true
           ),

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -159,9 +159,15 @@ export const getGroupBalance = group => {
 export const getPanelsState = (groups, currentPanelsState) => {
   const switchesState = groups.reduce((acc, group) => {
     const groupChecked = get(currentPanelsState, `[${group._id}].checked`, true)
+    const groupExpanded = get(
+      currentPanelsState,
+      `[${group._id}].expanded`,
+      true
+    )
 
     acc[group._id] = {
       checked: groupChecked,
+      expanded: groupExpanded,
       accounts: get(group, 'accounts.data', []).reduce((acc2, account) => {
         acc2[account._id] = {
           checked: get(

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -6,7 +6,7 @@ import {
   getAllDates,
   balanceHistoryToChartData,
   getGroupBalance,
-  getSwitchesState
+  getPanelsState
 } from './helpers'
 import { format as formatDate, parse as parseDate } from 'date-fns'
 
@@ -285,12 +285,12 @@ describe('getGroupBalance', () => {
   })
 })
 
-describe('getSwitchesState', () => {
+describe('getPanelsState', () => {
   it('should initialize switches state to true', () => {
     const groups = [{ _id: 'g1', accounts: { data: [{ _id: 'a1' }] } }]
     const currentSwitchesState = {}
 
-    expect(getSwitchesState(groups, currentSwitchesState)).toEqual({
+    expect(getPanelsState(groups, currentSwitchesState)).toEqual({
       g1: {
         checked: true,
         accounts: {
@@ -311,7 +311,7 @@ describe('getSwitchesState', () => {
       }
     }
 
-    expect(getSwitchesState(groups, currentSwitchesState)).toEqual({
+    expect(getPanelsState(groups, currentSwitchesState)).toEqual({
       g1: {
         checked: false,
         accounts: {

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -293,6 +293,7 @@ describe('getPanelsState', () => {
     expect(getPanelsState(groups, currentSwitchesState)).toEqual({
       g1: {
         checked: true,
+        expanded: true,
         accounts: {
           a1: {
             checked: true,
@@ -314,6 +315,7 @@ describe('getPanelsState', () => {
     expect(getPanelsState(groups, currentSwitchesState)).toEqual({
       g1: {
         checked: false,
+        expanded: true,
         accounts: {
           a1: {
             checked: true,


### PR DESCRIPTION
The panels state is now fetch from settings on the initialization, and saved to it when we change something (expand/collapse; switches...). This way the user has the same state on every device.