### PR TITLE
feat(categories): Enable global categorization model

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -17,6 +17,7 @@ const makeSubcategory = catId => ({
 })
 
 export const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
+export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.8
 
 /**
  * Return the category id of the transaction
@@ -37,6 +38,14 @@ export const getCategoryId = transaction => {
     transaction.localCategoryProba > LOCAL_MODEL_USAGE_THRESHOLD
   ) {
     return transaction.localCategoryId
+  }
+
+  if (
+    transaction.cozyCategoryId &&
+    transaction.cozyCategoryProba &&
+    transaction.cozyCategoryProba > GLOBAL_MODEL_USAGE_THRESHOLD
+  ) {
+    return transaction.cozyCategoryId
   }
 
   return transaction.automaticCategoryId

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -49,4 +49,14 @@ describe('getCategoryId', () => {
     flag.mockReturnValueOnce(false)
     expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
   })
+
+  it('should return the cozyCategoryId if there is one with a high probability, but no localCategoryId', () => {
+    const transaction = {
+      automaticCategoryId: '200120',
+      cozyCategoryId: '200130',
+      cozyCategoryProba: 0.9
+    }
+
+    expect(getCategoryId(transaction)).toBe(transaction.cozyCategoryId)
+  })
 })


### PR DESCRIPTION
In `getCategoryId` helper we now do the following:

* If there's a manual categorization: use it
* Else if the local categorization is enabled and there's a local category with a probability higher than 0.8: use it
* Else if there's a cozy category with a probability higher than 0.8: use it
* Else use the automatic category