### PR TITLE
fix(deps): Update cozy-client to v5.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "cordova": "7.1.0",
     "cozy-authentication": "1.4.0-beta1",
     "cozy-bar": "6.10.0",
-    "cozy-client": "5.7.1",
+    "cozy-client": "5.7.2",
     "cozy-client-js": "0.14.2",
     "cozy-device-helper": "1.6.3",
     "cozy-doctypes": "1.28.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4818,7 +4818,22 @@ cozy-client-js@^0.3.4:
   resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.3.21.tgz#d27d0288077ce95139333c41dfb537b8584ff254"
   integrity sha1-0n0CiAd86VE5MzxB37U3uFhP8lQ=
 
-cozy-client@5.7.1, cozy-client@^5.7.1:
+cozy-client@5.7.2:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-5.7.2.tgz#756c3cd49c39ec3c528fdf4bf1149169f41a21cc"
+  integrity sha512-oXnN5hiNp1X73dWvrv1MGxY7BmPx9uBXNW49sZnjv1YavudvX1ZY/aX6px3pS3V+KKgT23bGtTehI4cV82xtbg==
+  dependencies:
+    cozy-device-helper "1.6.3"
+    cozy-stack-client "^5.6.1"
+    lodash "4.17.11"
+    prop-types "15.6.2"
+    react "16.7.0"
+    react-redux "5.0.7"
+    redux "3.7.2"
+    redux-thunk "2.3.0"
+    sift "7.0.1"
+
+cozy-client@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-5.7.1.tgz#13562f16369d4da29f4a3da4fa324985b9a133ee"
   integrity sha512-Phvs5bLfDxDfbJ570e9IjFDdM/ExNVAY+MdzTlg/kGkiJG3LnztHsggMOL3bg5mWMHSet8sHtq5BCYhqmcx7dA==


### PR DESCRIPTION
This fixes the `can't convert undefined to object` error on transactions page.