### PR TITLE
Enable history chart on current balance page for everybody

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -9,7 +9,7 @@ import cx from 'classnames'
 import Loading from 'components/Loading'
 import { Padded } from 'components/Spacing'
 import Header from 'components/Header'
-import { Figure, FigureBlock } from 'components/Figure'
+import { Figure } from 'components/Figure'
 import { PageTitle } from 'components/Title'
 
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
@@ -123,12 +123,11 @@ class Balance extends PureComponent {
     }
 
     const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    const withChart = settings.balanceHistory.enabled
-    const color = withChart ? 'primary' : 'default'
+    const color = 'primary'
     const headerColorProps = { color }
     const headerClassName = styles[`Balance_HeaderColor_${color}`]
     const titleColorProps = {
-      color: withChart && !isMobile ? 'primary' : 'default'
+      color: isMobile ? 'default' : 'primay'
     }
     const titlePaddedClass = isMobile ? 'u-p-0' : 'u-pb-0'
 
@@ -139,7 +138,7 @@ class Balance extends PureComponent {
       return (
         <Fragment>
           <Header className={headerClassName} {...headerColorProps}>
-            {(isMobile || !withChart) && (
+            {isMobile && (
               <Padded className={titlePaddedClass}>
                 <PageTitle {...titleColorProps}>{t('Balance.title')}</PageTitle>
               </Padded>
@@ -153,8 +152,6 @@ class Balance extends PureComponent {
     const accounts = accountsCollection.data
     const groups = [...groupsCollection.data, ...buildVirtualGroups(accounts)]
 
-    const total = sumBy(accounts, getAccountBalance)
-
     const balanceLower = get(settings, 'notifications.balanceLower.value')
     const showPanels = flag('balance-panels')
 
@@ -166,45 +163,32 @@ class Balance extends PureComponent {
     return (
       <Fragment>
         <Header className={headerClassName} {...headerColorProps}>
-          {(isMobile || !withChart) && (
+          {isMobile && (
             <Padded className={titlePaddedClass}>
               <PageTitle {...titleColorProps}>{t('Balance.title')}</PageTitle>
             </Padded>
           )}
-          {withChart ? (
-            <Fragment>
-              <Figure
-                className={styles.Balance__currentBalance}
-                currencyClassName={styles.Balance__currentBalanceCurrency}
-                total={checkedAccountsBalance}
-                currency="€"
-              />
-              <div className={styles.Balance__subtitle}>
-                {checkedAccounts.length === accounts.length
-                  ? t('BalanceHistory.all_accounts')
-                  : t('BalanceHistory.checked_accounts', {
-                      nbCheckedAccounts: checkedAccounts.length,
-                      nbAccounts: accounts.length
-                    })}
-              </div>
-              <History accounts={checkedAccounts} />
-            </Fragment>
-          ) : (
-            <Padded className="u-pb-0">
-              <FigureBlock
-                label={t('Balance.subtitle.all')}
-                total={total}
-                currency="€"
-                coloredPositive
-                coloredNegative
-                signed
-              />
-            </Padded>
-          )}
+          <Fragment>
+            <Figure
+              className={styles.Balance__currentBalance}
+              currencyClassName={styles.Balance__currentBalanceCurrency}
+              total={checkedAccountsBalance}
+              currency="€"
+            />
+            <div className={styles.Balance__subtitle}>
+              {checkedAccounts.length === accounts.length
+                ? t('BalanceHistory.all_accounts')
+                : t('BalanceHistory.checked_accounts', {
+                    nbCheckedAccounts: checkedAccounts.length,
+                    nbAccounts: accounts.length
+                  })}
+            </div>
+            <History accounts={checkedAccounts} />
+          </Fragment>
         </Header>
         <Padded
           className={cx({
-            [styles.Balance__panelsContainer]: showPanels && withChart
+            [styles.Balance__panelsContainer]: showPanels
           })}
         >
           {showPanels ? (

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -103,17 +103,6 @@ class Configuration extends React.PureComponent {
             enabled={settings.community.autoCategorization.enabled}
             name="autoCategorization"
           />
-          <TogglePaneSubtitle>
-            {t('AdvancedFeaturesSettings.balance_history.title')}
-          </TogglePaneSubtitle>
-          <ToggleRow
-            description={t(
-              'AdvancedFeaturesSettings.balance_history.show_chart.description'
-            )}
-            onToggle={this.onToggle('balanceHistory')}
-            enabled={settings.balanceHistory.enabled}
-            name="balanceHistory"
-          />
         </TogglePane>
       </div>
     )

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -3,9 +3,6 @@
 exports[`defaulted settings should return defaulted settings 1`] = `
 Object {
   "_type": "io.cozy.bank.settings",
-  "balanceHistory": Object {
-    "enabled": false,
-  },
   "billsMatching": Object {
     "billsLastSeq": "0",
     "transactionsLastSeq": "0",

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -41,8 +41,5 @@ export const DEFAULTS_SETTINGS = {
   categorization: {
     lastSeq: 0
   },
-  showIncomeCategory: true,
-  balanceHistory: {
-    enabled: false
-  }
+  showIncomeCategory: true
 }


### PR DESCRIPTION
This removes the setting to enable/disable the history chart on current balance page. We now always show it.