### PR TITLE
Group panel clickable areas

### DIFF
--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -2,14 +2,8 @@ import Switch from '@material-ui/core/Switch'
 import { withStyles } from '@material-ui/core/styles'
 
 export default withStyles(() => ({
-  root: {
-    width: 40,
-    height: 23
-  },
-  switchBase: {
-    width: 25,
-    height: 23
-  },
+  root: {},
+  switchBase: {},
   checked: {
     '& + $bar': {
       opacity: 1

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -137,7 +137,6 @@ class AccountRow extends React.PureComponent {
             checked={checked}
             color="primary"
             onClick={this.handleSwitchClick}
-            className={styles.AccountRow__switch}
             id={id}
             onChange={onSwitchChange}
           />

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -7,7 +7,6 @@
     height 4rem
     align-items center
     padding-left 1rem
-    padding-right 0.5rem
     background-color white
     color var(--charcoalGrey)
     cursor pointer
@@ -78,12 +77,6 @@
 .AccountRow__figureSwitchWrapper
     display flex
     justify-content flex-end
-
-.AccountRow__switch
-    margin-left 0.5rem
-
-    +small-screen('min')
-        margin-left 0.8125rem
 
 .AccountRow--disabled
     color var(--coolGrey)

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -17,10 +17,12 @@ import styles from './GroupPanel.styl'
 const GroupPanelSummary = withStyles(() => ({
   expanded: {},
   root: {
-    maxHeight: '3.5rem'
+    maxHeight: '3.5rem',
+    height: '3.5rem'
   },
   content: {
-    paddingLeft: '3rem'
+    paddingLeft: '3rem',
+    height: '100%'
   },
   expandIcon: {
     left: '0.375rem',

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -22,6 +22,7 @@ const GroupPanelSummary = withStyles(() => ({
   },
   content: {
     paddingLeft: '3rem',
+    paddingRight: '0',
     height: '100%'
   },
   expandIcon: {
@@ -105,7 +106,6 @@ class GroupPanel extends React.PureComponent {
               checked={checked}
               color="primary"
               onClick={this.handleSwitchClick}
-              className={styles.GroupPanelSummary__switch}
               id={`[${group._id}]`}
               onChange={onSwitchChange}
             />

--- a/src/ducks/balance/components/GroupPanel.styl
+++ b/src/ducks/balance/components/GroupPanel.styl
@@ -15,9 +15,3 @@
 
 .GroupPanelSummary__figureCurrency
     color inherit
-
-.GroupPanelSummary__switch
-    margin-left 0.5rem
-
-    +small-screen('min')
-        margin-left 0.8125rem


### PR DESCRIPTION
* Restore switches clickable area to 48px wide (it increases the dimensions so to keep the design consistent I had to remove some paddings and margins)
* Fix the height of the panel summary content to `3.5rem` so there are no more area above and beyond it that expand/collapse the panel on click. The whole area redirects to the transactions page

https://testbanksfixespanels-banks.cozy.works/