### PR TITLE
Fix account type translations in account details

### DIFF
--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -153,7 +153,7 @@ class _GeneralSettings extends Component {
               <td>{t('AccountDetails.type')}</td>
               <td>
                 {t(`Data.accountTypes.${account.type}`, {
-                  _: t('Data.accountTypes.Unknown')
+                  _: t('Data.accountTypes.Other')
                 })}
               </td>
             </tr>

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -151,7 +151,11 @@ class _GeneralSettings extends Component {
             </tr>
             <tr>
               <td>{t('AccountDetails.type')}</td>
-              <td>{t(`AccountDetails.types.${account.type}`)}</td>
+              <td>
+                {t(`Data.accountTypes.${account.type}`, {
+                  _: t('Data.accountTypes.Unknown')
+                })}
+              </td>
             </tr>
           </tbody>
         </table>

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -40,7 +40,7 @@ const _AccountLine = ({ account, router, t }) => (
     <td className={styles.AcnsStg__number}>{account.number}</td>
     <td className={styles.AcnsStg__type}>
       {t(`Data.accountTypes.${account.type}`, {
-        _: t('Data.accountTypes.Unknown')
+        _: t('Data.accountTypes.Other')
       })}
     </td>
     <td className={styles.AcnsStg__shared}>


### PR DESCRIPTION
I forgot to update the accounts details pages when I updated accounts types translations.

https://testbanksfixaccountdetails-banks.cozy.works