### PR TITLE
Group account disabled

### DIFF
--- a/src/components/Switch.jsx
+++ b/src/components/Switch.jsx
@@ -1,6 +1,16 @@
 import Switch from '@material-ui/core/Switch'
 import { withStyles } from '@material-ui/core/styles'
 
+const disabledStyle = {
+  '&$switchBase': {
+    color: 'white',
+    '& + $bar': {
+      backgroundColor: 'var(--silver)',
+      opacity: 1
+    }
+  }
+}
+
 export default withStyles(() => ({
   root: {
     width: 40,
@@ -37,13 +47,6 @@ export default withStyles(() => ({
       color: 'white'
     }
   },
-  disabled: {
-    '&$switchBase': {
-      color: 'white',
-      '& + $bar': {
-        backgroundColor: 'var(--silver)',
-        opacity: 1
-      }
-    }
-  }
+  colorDisabled: disabledStyle,
+  disabled: disabledStyle
 }))(Switch)

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -133,9 +133,10 @@ class AccountRow extends React.PureComponent {
             currencyClassName={styles.AccountRow__figure}
           />
           <Switch
-            disabled={disabled}
             checked={checked}
-            color="primary"
+            // Do not deactivate interactions with the button,
+            // only color it to look disabled
+            color={disabled ? 'disabled' : 'primary'}
             onClick={this.handleSwitchClick}
             className={styles.AccountRow__switch}
             id={id}

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110602" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.6.2" version="0.11.6" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="110604" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.11.6.4" version="0.11.6" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/src/targets/mobile/fastlane/Fastfile
+++ b/src/targets/mobile/fastlane/Fastfile
@@ -15,7 +15,7 @@ platform :ios do
       git_url: "git@gitlab.cozycloud.cc:labs/mobile-certificates.git"
     )
     cordova(platform: 'ios', build_flag: ['-UseModernBuildSystem=0'])
-    appstore(ipa: ENV['CORDOVA_IOS_RELEASE_BUILD_PATH'])
+    appstore(ipa: ENV['CORDOVA_IOS_RELEASE_BUILD_PATH'], skip_screenshots: true)
   end
 end
 


### PR DESCRIPTION
Click were passing through account switches when their group was
disabled,because the account switch was disabled. We decided that
it was better for the switch to be still switchable, but in a grey
color to show the fact that its group is disabled, and that it is
not shown on the curve.