### PR TITLE
Fix transactions sorting

### DIFF
--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -22,9 +22,12 @@ import TransactionModal from './TransactionModal'
 import { RowDesktop, RowMobile } from './TransactionRow'
 import { getDate } from './helpers'
 
-const groupByDateAndSort = transactions => {
+const sortByDate = (transactions = []) =>
+  sortBy(transactions, getDate).reverse()
+
+const groupByDate = transactions => {
   const byDate = groupBy(transactions, x => getDate(x))
-  return sortBy(toPairs(byDate), x => x[0]).reverse()
+  return toPairs(byDate)
 }
 
 const loadMoreStyle = { textAlign: 'center' }
@@ -152,10 +155,11 @@ class TransactionsD extends React.Component {
       brands,
       urls
     } = this.props
-    const transactions = this.transactions
-      ? this.transactions.slice(limitMin, limitMax)
-      : []
-    const transactionsOrdered = groupByDateAndSort(transactions)
+    const transactionsSorted = sortByDate(this.transactions).slice(
+      limitMin,
+      limitMax
+    )
+    const transactionsGrouped = groupByDate(transactionsSorted)
     const Section = isDesktop ? SectionDesktop : SectionMobile
     const LoadMoreButton = isDesktop ? LoadMoreDesktop : LoadMoreMobile
     const TransactionContainer = isDesktop ? Table : TransactionContainerMobile
@@ -169,7 +173,7 @@ class TransactionsD extends React.Component {
               {t('Transactions.see-more')}
             </LoadMoreButton>
           )}
-        {transactionsOrdered.map(dateAndGroup => {
+        {transactionsGrouped.map(dateAndGroup => {
           const date = dateAndGroup[0]
           const transactionGroup = dateAndGroup[1]
           return (

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -112,7 +112,7 @@ class TransactionsD extends React.Component {
 
   updateTransactions(transactions) {
     this.transactionsById = keyBy(transactions, '_id')
-    this.transactions = transactions
+    this.transactions = sortByDate(transactions)
   }
 
   updateTopMostVisibleTransaction() {
@@ -155,11 +155,9 @@ class TransactionsD extends React.Component {
       brands,
       urls
     } = this.props
-    const transactionsSorted = sortByDate(this.transactions).slice(
-      limitMin,
-      limitMax
+    const transactionsGrouped = groupByDate(
+      this.transactions.slice(limitMin, limitMax)
     )
-    const transactionsGrouped = groupByDate(transactionsSorted)
     const Section = isDesktop ? SectionDesktop : SectionMobile
     const LoadMoreButton = isDesktop ? LoadMoreDesktop : LoadMoreMobile
     const TransactionContainer = isDesktop ? Table : TransactionContainerMobile

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -22,7 +22,7 @@ import TransactionModal from './TransactionModal'
 import { RowDesktop, RowMobile } from './TransactionRow'
 import { getDate } from './helpers'
 
-const sortByDate = (transactions = []) =>
+export const sortByDate = (transactions = []) =>
   sortBy(transactions, getDate).reverse()
 
 const groupByDate = transactions => {
@@ -84,7 +84,7 @@ const shouldRestore = (oldProps, nextProps) => {
   )
 }
 
-class TransactionsD extends React.Component {
+export class TransactionsDumb extends React.Component {
   state = {
     infiniteScrollTop: false
   }
@@ -236,7 +236,7 @@ class TransactionsD extends React.Component {
 const Transactions = compose(
   withBreakpoints(),
   translate()
-)(TransactionsD)
+)(TransactionsDumb)
 
 export class TransactionsWithSelection extends React.Component {
   state = {

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import { RowDesktop, RowMobile } from './TransactionRow'
+import { TransactionsDumb, sortByDate } from './Transactions'
 import data from '../../../test/fixtures'
 import store from '../../../test/store'
 import AppLike from '../../../test/AppLike'
@@ -68,5 +69,29 @@ describe('transaction row', () => {
     )
     expect(root.find(Caption).text()).toBe('Compte courant Isabelle - BNPP')
     expect(handleRef).toHaveBeenCalled()
+  })
+})
+
+describe('Transactions', () => {
+  jest
+    .spyOn(TransactionsDumb.prototype, 'renderTransactions')
+    .mockReturnValue(<div />)
+
+  it('should sort transactions from props on mount and on update', () => {
+    const transactions = data['io.cozy.bank.operations']
+
+    const root = mount(
+      <TransactionsDumb
+        breakpoints={{ isDesktop: false }}
+        transactions={transactions}
+      />
+    )
+
+    expect(root.instance().transactions).toEqual(sortByDate(transactions))
+
+    const slicedTransactions = transactions.slice(0, 10)
+    root.setProps({ transactions: slicedTransactions })
+
+    expect(root.instance().transactions).toEqual(sortByDate(slicedTransactions))
   })
 })

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -239,9 +239,9 @@ class TransactionsPage extends Component {
   displayTransactions() {
     const { limitMin, limitMax, infiniteScrollTop } = this.state
     const { t, urls } = this.props
-    const transations = this.getTransactions()
+    const transactions = this.getTransactions()
 
-    if (transations.length === 0) {
+    if (transactions.length === 0) {
       return <p>{t('Transactions.no-movements')}</p>
     }
 
@@ -254,7 +254,7 @@ class TransactionsPage extends Component {
         infiniteScrollTop={infiniteScrollTop}
         onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
         onScroll={this.checkToActivateTopInfiniteScroll}
-        transactions={transations}
+        transactions={transactions}
         urls={urls}
         brands={this.getBrands()}
         filteringOnAccount={this.getFilteringOnAccount()}


### PR DESCRIPTION
We were not showing the transactions correctly because we were slicing on unordered data. Now we sort the transactions by date, then we slice it, then we do the grouping.