### PR TITLE
Fix filters realisation date

### DIFF
--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -39,6 +39,7 @@ class History extends Component {
     return {
       ...transactions,
       data: transactions.data.filter(t => {
+        // Use .date as to get the debit date
         return isAfter(new Date(t.date), oneYearBefore)
       })
     }

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -71,7 +71,11 @@ export const getBalanceHistory = (account, transactions, to, from) => {
   const DATE_FORMAT = 'YYYY-MM-DD'
 
   const transactionsByDate = groupBy(transactions, t =>
-    formatDate(t.date, DATE_FORMAT)
+    formatDate(
+      // do not take .realisationDate as we are interested in the debit date
+      t.date,
+      DATE_FORMAT
+    )
   )
 
   if (!from) {

--- a/src/ducks/balance/helpers.spec.js
+++ b/src/ducks/balance/helpers.spec.js
@@ -79,17 +79,24 @@ describe('getBalanceHistory', () => {
   })
 
   it('should return history from the earliest transaction date if from is not specified', () => {
-    const account = { _id: 'test', balance: 8000 }
+    const account = { _id: 'test', balance: 7985 }
     const transactions = [
       { date: '2018-06-25T00:00:00Z', amount: 100 },
       { date: '2018-06-24T00:00:00Z', amount: 10 },
       { date: '2018-06-23T00:00:00Z', amount: -300 },
-      { date: '2018-06-22T00:00:00Z', amount: -15 }
+      { date: '2018-06-22T00:00:00Z', amount: -15 },
+      // date should be taken into account as it is the effective debit date
+      {
+        date: '2018-06-26T00:00:00Z',
+        realisationDate: '2018-06-01T00:00:00Z',
+        amount: -15
+      }
     ]
-    const to = parseDate('2018-06-26')
+    const to = parseDate('2018-06-27')
     const history = getBalanceHistory(account, transactions, to)
 
     expect(history).toEqual({
+      '2018-06-27': 7985,
       '2018-06-26': 8000,
       '2018-06-25': 7900,
       '2018-06-24': 7890,

--- a/src/ducks/filters/index.js
+++ b/src/ducks/filters/index.js
@@ -6,6 +6,7 @@ import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { sortBy, last, keyBy, find } from 'lodash'
 import { DESTROY_ACCOUNT } from 'actions/accounts'
 import { dehydrate } from 'cozy-client'
+import { getDisplayDate } from 'ducks/transactions/helpers'
 
 // constants
 const FILTER_BY_PERIOD = 'FILTER_BY_PERIOD'
@@ -58,10 +59,10 @@ export const getFilteredAccounts = state => {
 
 const filterByAccountIds = (transactions, accountIds) =>
   transactions.filter(transaction => {
-    return accountIds.indexOf(transaction.account.raw) !== -1
+    return transaction && accountIds.indexOf(transaction.account.raw) !== -1
   })
 
-const recentToAncient = transaction => -new Date(transaction.date)
+const recentToAncient = transaction => -new Date(getDisplayDate(transaction))
 export const getTransactionsFilteredByAccount = createSelector(
   [getTransactions, getFilteredAccountIds],
   (transactions, accountIds) => {
@@ -111,7 +112,7 @@ const filterByPeriod = (transactions, period) => {
   }
 
   return transactions.filter(transaction => {
-    const date = transaction.date
+    const date = getDisplayDate(transaction)
     if (!date) {
       return false
     }
@@ -133,9 +134,9 @@ export const addFilterForMostRecentTransactions = () => (
 ) => {
   const state = getState()
   const transactions = getTransactionsFilteredByAccount(state)
-  const mostRecentTransaction = last(sortBy(transactions, 'date'))
+  const mostRecentTransaction = last(sortBy(transactions, getDisplayDate))
   if (mostRecentTransaction) {
-    const date = mostRecentTransaction.date
+    const date = getDisplayDate(mostRecentTransaction)
     const period = monthFormat(date)
     return dispatch(addFilterByPeriod(period))
   }

--- a/src/ducks/filters/index.spec.js
+++ b/src/ducks/filters/index.spec.js
@@ -145,6 +145,13 @@ describe('filter selectors', () => {
         account: mockRelationship('a1', 'account'),
         label: 'Transaction 11',
         date: parisDateStr('2019-01-02')
+      },
+      {
+        _id: 't12',
+        account: mockRelationship('a1', 'account'),
+        label: 'Transaction 12',
+        date: parisDateStr('2019-02-28'),
+        realisationDate: parisDateStr('2019-01-28')
       }
     ]
     const accounts = [
@@ -240,6 +247,7 @@ describe('filter selectors', () => {
       ])
       dispatchOnFilters(addFilterByPeriod('2019'))
       expect(getFilteredTransactions(state).map(x => x._id)).toEqual([
+        't12',
         't11',
         't10'
       ])

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -26,6 +26,27 @@ import { withUpdateCategory } from 'ducks/categories'
 import { getLabel, getDate } from './helpers'
 import styles from './Transactions.styl'
 
+const WILL_BE_DEBITED = 'Transactions.will-be-debited-on'
+
+class _TransactionDate extends React.PureComponent {
+  render() {
+    const { t, f, isExtraLarge, transaction } = this.props
+    return (
+      <span
+        title={
+          transaction.realisationDate &&
+          transaction.date !== transaction.realisationDate
+            ? t(WILL_BE_DEBITED, { date: f(transaction.date, 'D MMMM YYYY') })
+            : null
+        }
+      >
+        {f(getDate(transaction), `D ${isExtraLarge ? 'MMMM' : 'MMM'} YYYY`)}
+      </span>
+    )
+  }
+}
+const TransactionDate = translate()(_TransactionDate)
+
 class _RowDesktop extends React.PureComponent {
   constructor(props) {
     super(props)
@@ -39,7 +60,6 @@ class _RowDesktop extends React.PureComponent {
   render() {
     const {
       t,
-      f,
       transaction,
       isExtraLarge,
       showCategoryChoice,
@@ -83,7 +103,10 @@ class _RowDesktop extends React.PureComponent {
           className={cx(styles.ColumnSizeDate, 'u-clickable')}
           onClick={this.onSelectTransaction}
         >
-          {f(getDate(transaction), `D ${isExtraLarge ? 'MMMM' : 'MMM'} YYYY`)}
+          <TransactionDate
+            isExtraLarge={isExtraLarge}
+            transaction={transaction}
+          />
         </TdSecondary>
         <TdSecondary
           className={cx(styles.ColumnSizeAmount, 'u-clickable')}

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -28,7 +28,7 @@ import {
 
 import { getAppUrlById } from 'selectors'
 import { getCategoryIdFromName } from 'ducks/categories/categoriesMap'
-import { getDate } from 'ducks/transactions/helpers'
+import { getDate, getDisplayDate } from 'ducks/transactions/helpers'
 import { getCategoryId } from 'ducks/categories/helpers'
 
 import Loading from 'components/Loading'
@@ -87,12 +87,12 @@ class TransactionsPage extends Component {
     if (!transactions || transactions.length === 0) {
       return
     }
-    const mostRecentTransaction = maxBy(transactions, x => x.date)
+    const mostRecentTransaction = maxBy(transactions, getDisplayDate)
     if (!mostRecentTransaction) {
       return
     }
     this.setState({
-      currentMonth: getMonth(mostRecentTransaction.date)
+      currentMonth: getMonth(getDisplayDate(mostRecentTransaction))
     })
   }
 
@@ -123,7 +123,7 @@ class TransactionsPage extends Component {
 
   handleChangeTopmostTransaction(transaction) {
     this.setState({
-      currentMonth: getMonth(transaction.date)
+      currentMonth: getMonth(getDisplayDate(transaction))
     })
   }
 
@@ -152,12 +152,12 @@ class TransactionsPage extends Component {
   handleChangeMonth(month) {
     const transactions = this.props.filteredTransactions
     const findMonthIndex = month =>
-      findIndex(transactions, t => t.date.indexOf(month) === 0)
+      findIndex(transactions, t => getDisplayDate(t).indexOf(month) === 0)
     let limitMin = findMonthIndex(month)
 
     if (limitMin == -1) {
       const monthsWithOperations = uniq(
-        transactions.map(x => getMonth(x.date))
+        transactions.map(x => getMonth(getDisplayDate(x)))
       ).sort()
       const nearestMonth = findNearestMonth(
         month,

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -65,4 +65,22 @@ describe('TransactionsPage', () => {
     setup()
     expect(root.find(TransactionsPageBar).length).toBe(0)
   })
+
+  it('should handle change in top most transaction', () => {
+    setup()
+    const tp = root.find(DumbTransactionsPage)
+    const instance = tp.instance()
+    instance.setState = jest.fn()
+    instance.handleChangeTopmostTransaction({ date: '2018-01-02T12:00' })
+    expect(instance.setState).toHaveBeenCalledWith({
+      currentMonth: '2018-01'
+    })
+    instance.handleChangeTopmostTransaction({
+      realisationDate: '2018-03-30T12:00',
+      date: '2018-04-30T12:00'
+    })
+    expect(instance.setState).toHaveBeenCalledWith({
+      currentMonth: '2018-03'
+    })
+  })
 })

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -4,9 +4,12 @@ import findLast from 'lodash/findLast'
 export const getLabel = transaction =>
   transaction.label.toLowerCase().replace(/(?:^|\s)\S/g, a => a.toUpperCase())
 
-export const getDate = transaction => {
-  const date = transaction.realisationDate || transaction.date
+export const getDisplayDate = transaction => {
+  return transaction.realisationDate || transaction.date
+}
 
+export const getDate = transaction => {
+  const date = getDisplayDate(transaction)
   return date.slice(0, 10)
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -286,6 +286,7 @@
     "no-movements": "No movements to display",
     "total": "Total",
     "transactions": "Transactions",
+    "will-be-debited-on": "Will be debited on %{date}",
     "debit": "Debit",
     "credit": "Credit",
     "header": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -95,6 +95,7 @@
     "no-movements": "Pas de mouvements à afficher",
     "total": "Total",
     "transactions": "Opérations",
+    "will-be-debited-on": "Sera débitée le %{date}",
     "debit": "Débit",
     "credit": "Crédit",
     "header": {


### PR DESCRIPTION
- Use .date || .realisationDate in filters
- Use .date for history
- Added tests
- Show debitDate as tooltip if different from realisationDate