### PR TITLE
feat(settings): Enable local categorization model override by default

### DIFF
--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -15,7 +15,7 @@ Object {
       "enabled": false,
     },
     "localModelOverride": Object {
-      "enabled": false,
+      "enabled": true,
     },
   },
   "notifications": Object {

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -35,7 +35,7 @@ export const DEFAULTS_SETTINGS = {
       enabled: false
     },
     localModelOverride: {
-      enabled: false
+      enabled: true
     }
   },
   categorization: {


### PR DESCRIPTION
The local categoriation model is now enabled by default. The setting is still present so the user can disable it if (s)he wants.

This is a WIP because we are waiting for a potential action on the model from @francoisWeber.