### PR TITLE
feat(transactions): Use realisationDate if the account is CreditCard

### DIFF
--- a/src/ducks/transactions/TransactionSelectDates.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.jsx
@@ -1,7 +1,13 @@
 import React, { PureComponent } from 'react'
 import SelectDates from 'components/SelectDates'
-import { uniq } from 'lodash'
-import { subMonths, format, parse, differenceInCalendarMonths } from 'date-fns'
+import { uniq, last } from 'lodash'
+import {
+  subMonths,
+  format,
+  parse,
+  differenceInCalendarMonths,
+  isAfter
+} from 'date-fns'
 import { getDate } from './helpers'
 
 const rangeMonth = (startDate, endDate) => {
@@ -22,7 +28,9 @@ export const getOptions = transactions => {
   const mAvailableMonths = new Set(availableMonths)
 
   const start = parse(availableMonths[0], 'YYYY-MM')
-  const end = new Date()
+  const lastMonth = parse(last(availableMonths), 'YYYY-MM')
+  const today = new Date()
+  const end = isAfter(lastMonth, today) ? lastMonth : today
 
   return rangeMonth(start, end).map(month => {
     const fmted = format(month, 'YYYY-MM')

--- a/src/ducks/transactions/TransactionSelectDates.spec.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.spec.jsx
@@ -17,10 +17,8 @@ const generateOption = date => {
   }
 }
 
-const generateOptions = () => {
+const generateOptions = (startDate, endDate) => {
   const options = []
-  const startDate = new Date('2017-06-01')
-  const endDate = new Date()
   let currentDate = startDate
   while (isBefore(currentDate, endDate)) {
     options.push(generateOption(currentDate))
@@ -32,6 +30,24 @@ const generateOptions = () => {
 
 describe('options from select dates', () => {
   it('should compute correctly', () => {
-    expect(getOptions(transactions)).toEqual(generateOptions())
+    expect(getOptions(transactions)).toEqual(
+      generateOptions(new Date('2017-06-01'), new Date())
+    )
+  })
+
+  it('should compute correctly with transactions in the future', () => {
+    const transactionInFuture = {
+      _id: 'inthefuture',
+      date: format(addMonths(new Date(), 1), 'YYYY-MM-DD')
+    }
+
+    enabledMonth.unshift(transactionInFuture.date.slice(0, 7))
+
+    expect(getOptions([...transactions, transactionInFuture])).toEqual(
+      generateOptions(
+        new Date('2017-06-01'),
+        new Date(transactionInFuture.date)
+      )
+    )
   })
 })

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -71,16 +71,35 @@ describe('TransactionsPage', () => {
     const tp = root.find(DumbTransactionsPage)
     const instance = tp.instance()
     instance.setState = jest.fn()
+
     instance.handleChangeTopmostTransaction({ date: '2018-01-02T12:00' })
     expect(instance.setState).toHaveBeenCalledWith({
       currentMonth: '2018-01'
     })
+
     instance.handleChangeTopmostTransaction({
       realisationDate: '2018-03-30T12:00',
       date: '2018-04-30T12:00'
     })
     expect(instance.setState).toHaveBeenCalledWith({
-      currentMonth: '2018-03'
+      currentMonth: '2018-04'
+    })
+
+    instance.handleChangeTopmostTransaction({
+      account: { data: { type: 'CreditCard' } },
+      realisationDate: '2019-03-04T12:00',
+      date: '2019-02-03T12:00'
+    })
+    expect(instance.setState).toHaveBeenCalledWith({
+      currentMonth: '2019-03'
+    })
+
+    instance.handleChangeTopmostTransaction({
+      realisationDate: '2019-03-04T12:00',
+      date: '2019-02-03T12:00'
+    })
+    expect(instance.setState).toHaveBeenCalledWith({
+      currentMonth: '2019-02'
     })
   })
 })

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -1,16 +1,28 @@
 import find from 'lodash/find'
 import findLast from 'lodash/findLast'
+import get from 'lodash/get'
 
 export const getLabel = transaction =>
   transaction.label.toLowerCase().replace(/(?:^|\s)\S/g, a => a.toUpperCase())
 
 export const getDisplayDate = transaction => {
-  return transaction.realisationDate || transaction.date
+  if (
+    getAccountType(transaction) === 'CreditCard' &&
+    transaction.realisationDate
+  ) {
+    return transaction.realisationDate
+  }
+
+  return transaction.date
 }
 
 export const getDate = transaction => {
   const date = getDisplayDate(transaction)
   return date.slice(0, 10)
+}
+
+export const getAccountType = transaction => {
+  return get(transaction, 'account.data.type')
 }
 
 /**

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -52,13 +52,20 @@ xdescribe('transaction', () => {
 })
 
 describe('getDate', () => {
-  it('should return realisation date if there is one', () => {
-    const transaction = {
+  it('should return realisation date if there is one and the linked account is a CreditCard one', () => {
+    const transactionCreditCard = {
+      realisationDate: '2019-01-28T00:00:00Z',
+      date: '2019-01-31T00:00:00Z',
+      account: { data: { type: 'CreditCard' } }
+    }
+
+    const transactionOther = {
       realisationDate: '2019-01-28T00:00:00Z',
       date: '2019-01-31T00:00:00Z'
     }
 
-    expect(getDate(transaction)).toBe('2019-01-28')
+    expect(getDate(transactionCreditCard)).toBe('2019-01-28')
+    expect(getDate(transactionOther)).toBe('2019-01-31')
   })
 
   it('should return the date if there is no relation date', () => {

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -158,6 +158,19 @@
       "cozyMetadata": {
         "createdByApp": "hsbc119"
       }
+    },
+    {
+      "_id": "comptelea1",
+      "label": "Léa Credit Card",
+      "institutionLabel": "BNPP",
+      "number": "5293683",
+      "balance": 0,
+      "comingBalance": -250.82,
+      "type": "CreditCard",
+      "cozyMetadata": {
+        "updatedAt": "2019-02-05T00:00:00Z",
+        "createdByApp": "bnpparibas82"
+      }
     }
   ],
   "io.cozy.bank.groups": [
@@ -1659,6 +1672,24 @@
       "currency": "€",
       "date": "2018-11-23T00:00:00Z",
       "label": "Sosh"
+    },
+    {
+      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "account": "comptelea1",
+      "label": "Sosh",
+      "currency": "€",
+      "amount": -60,
+      "date": "2019-02-28T00:00:00Z",
+      "realisationDate": "2019-02-04T00:00:00Z"
+    },
+    {
+      "automaticCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
+      "account": "comptelea1",
+      "label": "Fnac",
+      "currency": "€",
+      "amount": -190.92,
+      "date": "2019-02-28T00:00:00Z",
+      "realisationDate": "2019-02-05T00:00:00Z"
     }
   ],
   "io.cozy.bills": [


### PR DESCRIPTION
Check if the account linked to a transaction if of type `CreditCard` or not to return the date of a transaction.