### PR TITLE
fix(History): Check that transaction exists

### DIFF
--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -40,7 +40,7 @@ class History extends Component {
       ...transactions,
       data: transactions.data.filter(t => {
         // Use .date as to get the debit date
-        return isAfter(new Date(t.date), oneYearBefore)
+        return t && t.date && isAfter(new Date(t.date), oneYearBefore)
       })
     }
   }


### PR DESCRIPTION
The balance history was crashing if some transaction was `null`. This fixes it.