### PR TITLE
Add banking category to update redirection

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -26,6 +26,7 @@ class KonnectorUpdateInfo extends React.PureComponent {
     try {
       const url = await this.intents.getRedirectionURL('io.cozy.apps', {
         type: 'konnector',
+        category: 'banking',
         pendingUpdate: true
       })
 


### PR DESCRIPTION
Allow to display only banking konnectors when redirecting to the Store