### PR TITLE
fix(SelectDates): Disabled arrow color

### DIFF
--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -31,10 +31,6 @@ select-date-height-small = 2.75rem
     .SelectDates__separator
         border-left 1px solid var(--silver)
 
-    .SelectDates__chip
-        svg
-            color var(--coolGrey)
-
     +small-screen()
         border-bottom 1px solid var(--silver)
         background var(--white)


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/1606068/52555593-76c91e80-2dea-11e9-92e0-27d63fe5ee9a.png)


After:

![image](https://user-images.githubusercontent.com/1606068/52555624-8cd6df00-2dea-11e9-86f0-6523dd060625.png)

Primary color version is OK too:

![image](https://user-images.githubusercontent.com/1606068/52555672-ab3cda80-2dea-11e9-8b9f-a64399401c27.png)
