### PR TITLE
Fixes on balance panels disabled state

### DIFF
--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -80,3 +80,6 @@
 
 .AccountRow--disabled
     color var(--coolGrey)
+
+    .AccountRow__logo
+        opacity 0.5

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -13,6 +13,7 @@ import withFilteringDoc from 'components/withFilteringDoc'
 import AccountsList from './AccountsList'
 import { getGroupBalance } from '../helpers'
 import styles from './GroupPanel.styl'
+import cx from 'classnames'
 
 const GroupPanelSummary = withStyles(() => ({
   expanded: {},
@@ -83,10 +84,19 @@ class GroupPanel extends React.PureComponent {
     return (
       <ExpansionPanel expanded={expanded} onChange={onChange(group._id)}>
         <GroupPanelSummary
-          expandIcon={<Icon icon="bottom" color="black" width={12} />}
+          expandIcon={
+            <Icon
+              icon="bottom"
+              className={styles.GroupPanelSummary__icon}
+              width={12}
+            />
+          }
           IconButtonProps={{
             disableRipple: true
           }}
+          className={cx({
+            [styles['GroupPanelSummary--unchecked']]: !checked
+          })}
         >
           <div className={styles.GroupPanelSummary__content}>
             <div

--- a/src/ducks/balance/components/GroupPanel.styl
+++ b/src/ducks/balance/components/GroupPanel.styl
@@ -1,5 +1,3 @@
-@require 'settings/breakpoints'
-
 .GroupPanelSummary__content
     display flex
     flex 1

--- a/src/ducks/balance/components/GroupPanel.styl
+++ b/src/ducks/balance/components/GroupPanel.styl
@@ -13,3 +13,11 @@
 
 .GroupPanelSummary__figureCurrency
     color inherit
+
+.GroupPanelSummary__icon
+    color var(--charcoalGrey)
+
+.GroupPanelSummary--unchecked
+    .GroupPanelSummary__content,
+    .GroupPanelSummary__icon
+        color var(--coolGrey)


### PR DESCRIPTION
* The panel summary and arrow should be grey when not checked
* The bank logo should be opacified when the line is not checked

https://testbankspaneldisabled-banks.cozy.works