### PR TITLE
Update refresh token

### DIFF
--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -5,12 +5,12 @@ let client
 
 const lib = __TARGET__ === 'mobile' ? require('./mobile') : require('./web')
 
-export const getClient = state => {
+export const getClient = (state, getStore) => {
   if (client) {
     return client
   }
 
-  client = lib.getClient(state)
+  client = lib.getClient(state, getStore)
 
   const intents = new Intents({ client })
   client.intents = intents

--- a/src/ducks/client/mobile.js
+++ b/src/ducks/client/mobile.js
@@ -6,6 +6,7 @@ import { merge, get } from 'lodash'
 import { getLinks } from './links'
 import { schema } from 'doctypes'
 import manifest from '../../../manifest.webapp'
+import { setToken } from 'ducks/mobile'
 
 const SOFTWARE_ID = 'io.cozy.banks.mobile'
 
@@ -47,7 +48,7 @@ export const getManifestOptions = manifest => {
   }
 }
 
-export const getClient = state => {
+export const getClient = (state, getStore) => {
   const uri = getCozyURIFromState(state)
   const token = getTokenFromState(state)
   const clientInfos = getClientInfosFromState(state)
@@ -69,6 +70,7 @@ export const getClient = state => {
     },
     onTokenRefresh: token => {
       cozy.bar.updateAccessToken(token.accessToken)
+      getStore().dispatch(setToken(token))
     },
     links: getLinks()
   }

--- a/src/ducks/client/mobile.js
+++ b/src/ducks/client/mobile.js
@@ -67,8 +67,8 @@ export const getClient = state => {
       notificationPlatform: 'firebase',
       ...clientInfos
     },
-    onTokenRefresh: accessToken => {
-      cozy.bar.updateAccessToken(accessToken)
+    onTokenRefresh: token => {
+      cozy.bar.updateAccessToken(token.accessToken)
     },
     links: getLinks()
   }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -56,7 +56,7 @@ const setupApp = async persistedState => {
 
   history = setupHistory()
 
-  client = await getClient(persistedState)
+  client = await getClient(persistedState, () => store)
   store = configureStore(client, persistedState)
 
   persistState(store)


### PR DESCRIPTION
Lorsque l'on mettait à jour le token de la __cozy-bar__ on lui passait l'intégralité des informations alors que la bar s'attend juste à recevoir l'`accessToken`.

Nous sauvegardons dans le store le nouveau token.