### PR TITLE
Rationalize account panels

### DIFF
--- a/docs/account-types.md
+++ b/docs/account-types.md
@@ -1,0 +1,116 @@
+# Account types
+
+Here is the complete list of the account types managed by the app:
+
+* Asset
+* Bank
+* Capitalisation
+* Cash
+* Checkings
+* ConsumerCredit
+* CreditCard
+* Credit Card
+* Deposit
+* Joint
+* Liability
+* LifeInsurance
+* Loan
+* Madelin
+* Market
+* Mortgage
+* PEA
+* PEE
+* RevolvingCredit
+* RSP
+* Savings
+* Other
+* Unkown
+* None
+* Credit card
+* Perco
+* Perp
+* Article83
+
+## Mapping
+
+Some types are dynamically mapped to other types:
+
+<table>
+  <thead>
+    <tr>
+      <th>Original type</th>
+      <th>Mapped type</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`Article83`</td>
+      <td rowspan="10">`LongTermSavings`</td>
+    </tr>
+    <tr>
+      <td>`LifeInsurance`</td>
+    </tr>
+    <tr>
+      <td>`Madelin`</td>
+    </tr>
+    <tr>
+      <td>`Market`</td>
+    </tr>
+    <tr>
+      <td>`Mortgage`</td>
+    </tr>
+    <tr>
+      <td>`PEA`</td>
+    </tr>
+    <tr>
+      <td>`PEE`</td>
+    </tr>
+    <tr>
+      <td>`Perco`</td>
+    </tr>
+    <tr>
+      <td>`Perp`</td>
+    </tr>
+    <tr>
+      <td>`RSP`</td>
+    </tr>
+    <tr>
+      <td>`Asset`</td>
+      <td rowspan="3">`Business`</td>
+    </tr>
+    <tr>
+      <td>`Capitalisation`</td>
+    </tr>
+    <tr>
+      <td>`Liability`</td>
+    </tr>
+    <tr>
+      <td>`Bank`</td>
+      <td rowspan="3">`Checkings`</td>
+    </tr>
+    <tr>
+      <td>`Cash`</td>
+    </tr>
+    <tr>
+      <td>`Deposit`</td>
+    </tr>
+    <tr>
+      <td>`ConsumerCredit`</td>
+      <td rowspan="2">`Loan`</td>
+    </tr>
+    <tr>
+      <td>`RevolvingCredit`</td>
+    </tr>
+    <tr>
+      <td>`Credit card`</td>
+      <td>`CreditCard`</td>
+    </tr>
+    <tr>
+      <td>`None`</td>
+      <td rowspan="2">`Other`</td>
+    </tr>
+    <tr>
+      <td>`Unkown`</td>
+    </tr>
+  </tbody>
+</table>

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -48,39 +48,39 @@ export const distanceInWords = distance => {
 }
 
 export const accountTypesWithTranslation = [
-  'Asset',
-  'Bank',
-  'Capitalisation',
-  'Cash',
+  'Business',
   'Checkings',
-  'ConsumerCredit',
   'CreditCard',
-  'Credit Card',
-  'Deposit',
   'Joint',
-  'Liability',
-  'LifeInsurance',
   'Loan',
-  'Madelin',
-  'Market',
-  'Mortgage',
-  'PEA',
-  'PEE',
-  'RevolvingCredit',
-  'RSP',
-  'Savings',
+  'LongTermSavings',
   'Other',
-  'RetirementPlan'
+  'Savings'
 ]
 
 export const getAccountType = account => {
   const accountTypesMap = {
-    Unkown: 'Other',
-    None: 'Other',
+    Article83: 'LongTermSavings',
+    Asset: 'Business',
+    Bank: 'Checkings',
+    Capitalisation: 'Business',
+    Cash: 'Checkings',
+    ConsumerCredit: 'Loan',
     'Credit card': 'CreditCard',
-    Perco: 'RetirementPlan',
-    Perp: 'RetirementPlan',
-    Article83: 'RetirementPlan'
+    Deposit: 'Checkings',
+    Liability: 'Business',
+    LifeInsurance: 'LongTermSavings',
+    Madelin: 'LongTermSavings',
+    Market: 'LongTermSavings',
+    Mortgage: 'LongTermSavings',
+    None: 'Other',
+    PEA: 'LongTermSavings',
+    PEE: 'LongTermSavings',
+    Perco: 'LongTermSavings',
+    Perp: 'LongTermSavings',
+    RevolvingCredit: 'Loan',
+    RSP: 'LongTermSavings',
+    Unkown: 'Other'
   }
 
   const mappedType = accountTypesMap[account.type] || account.type || 'Other'

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -34,24 +34,32 @@ describe('distanceInWords', () => {
 })
 
 describe('getAccountType', () => {
-  it('should map Unkown/None to Other', () => {
-    const accounts = [{ type: 'Unkown' }, { type: 'None' }, { type: 'Other' }]
+  it('should map types correctly', () => {
+    const accountTypes = {
+      Other: ['Unkown', 'None'],
+      LongTermSavings: [
+        'Article83',
+        'LifeInsurance',
+        'Madelin',
+        'Market',
+        'Mortgage',
+        'PEA',
+        'PEE',
+        'Perco',
+        'Perp',
+        'RSP'
+      ],
+      Business: ['Asset', 'Capitalisation', 'Liability'],
+      Checkings: ['Bank', 'Cash', 'Deposit'],
+      Loan: ['ConsumerCredit', 'RevolvingCredit'],
+      CreditCard: ['Credit card']
+    }
 
-    expect(getAccountType(accounts[0])).toBe('Other')
-    expect(getAccountType(accounts[1])).toBe('Other')
-    expect(getAccountType(accounts[2])).toBe('Other')
-  })
-
-  it('should map PERCO/PERP/Article83 to RetirementPlan', () => {
-    const accounts = [
-      { type: 'Perco' },
-      { type: 'Perp' },
-      { type: 'Article83' }
-    ]
-
-    expect(getAccountType(accounts[0])).toBe('RetirementPlan')
-    expect(getAccountType(accounts[1])).toBe('RetirementPlan')
-    expect(getAccountType(accounts[2])).toBe('RetirementPlan')
+    for (const [mapped, originals] of Object.entries(accountTypes)) {
+      for (const original of originals) {
+        expect(getAccountType({ type: original })).toBe(mapped)
+      }
+    }
   })
 })
 

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -22,7 +22,7 @@ import styles from './AccountsSettings.styl'
 import { flowRight as compose } from 'lodash'
 import { destroyAccount } from 'actions'
 import spinner from 'assets/icons/icon-spinner.svg'
-import { getAccountInstitutionLabel } from '../account/helpers'
+import { getAccountInstitutionLabel, getAccountType } from '../account/helpers'
 import { getAppUrlById } from 'selectors'
 import { Query } from 'cozy-client'
 import { queryConnect, withClient } from 'cozy-client'
@@ -152,7 +152,7 @@ class _GeneralSettings extends Component {
             <tr>
               <td>{t('AccountDetails.type')}</td>
               <td>
-                {t(`Data.accountTypes.${account.type}`, {
+                {t(`Data.accountTypes.${getAccountType(account)}`, {
                   _: t('Data.accountTypes.Other')
                 })}
               </td>

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -13,7 +13,7 @@ import styles from './AccountsSettings.styl'
 import btnStyles from 'styles/buttons.styl'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
 import cx from 'classnames'
-import { getAccountInstitutionLabel } from '../account/helpers'
+import { getAccountInstitutionLabel, getAccountType } from '../account/helpers'
 
 import { ACCOUNT_DOCTYPE, APP_DOCTYPE } from 'doctypes'
 
@@ -39,7 +39,7 @@ const _AccountLine = ({ account, router, t }) => (
     </td>
     <td className={styles.AcnsStg__number}>{account.number}</td>
     <td className={styles.AcnsStg__type}>
-      {t(`Data.accountTypes.${account.type}`, {
+      {t(`Data.accountTypes.${getAccountType(account)}`, {
         _: t('Data.accountTypes.Other')
       })}
     </td>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -112,29 +112,14 @@
   },
   "Data": {
     "accountTypes": {
-      "Asset": "Assets accounts",
-      "Bank": "Bank accounts",
-      "Capitalisation": "Capitalisation accounts",
-      "Cash": "Cash accounts",
+      "Business": "Business accounts",
       "Checkings": "Checking accounts",
-      "ConsumerCredit": "Consumer credits",
       "CreditCard": "Credit card accounts",
-      "Credit Card": "Credit card accounts",
-      "Deposit": "Deposit accounts",
       "Joint": "Joint accounts",
-      "Liability": "Liability accounts",
-      "LifeInsurance": "Life insurances",
       "Loan": "Loan accounts",
-      "Madelin": "Madelin contracts",
-      "Market": "Markets",
-      "Mortgage": "Mortgages",
-      "PEA": "PEA",
-      "PEE": "PEE",
-      "RevolvingCredit": "Revolving credits",
-      "RSP": "RSP",
-      "Savings": "Savings accounts",
+      "LongTermSavings": "Long term savings",
       "Other": "Other accounts",
-      "RetirementPlan": "PERP & PERCO"
+      "Savings": "Saving accounts"
     },
     "categories": {
       "uncategorized": "To be categorized",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -181,29 +181,14 @@
 
   "Data": {
     "accountTypes": {
-      "Asset": "Comptes d'actifs",
-      "Bank": "Comptes bancaires",
-      "Capitalisation": "Comptes de capitalisation",
-      "Cash": "Liquidités",
+      "Business": "Comptes professionnels",
       "Checkings": "Comptes courants",
-      "ConsumerCredit": "Crédits à la consommation",
       "CreditCard": "Cartes de crédit",
-      "Credit Card": "Cartes de crédit",
-      "Deposit": "Comptes de dépôt",
       "Joint": "Comptes joints",
-      "Liability": "Comptes de dettes",
-      "LifeInsurance": "Assurances vie",
       "Loan": "Emprunts",
-      "Madelin": "Contrats Madelin",
-      "Market": "Comptes titres",
-      "Mortgage": "Prêts immobiliers",
-      "PEA": "PEA",
-      "PEE": "PEE",
-      "RevolvingCredit": "Crédits renouvelables",
-      "RSP": "RSP",
-      "Savings": "Comptes d'épargne",
+      "LongTermSavings": "Épargne long terme",
       "Other": "Autres comptes",
-      "RetirementPlan": "Plans Épargne Retraite"
+      "Savings": "Épargne"
     },
     "categories": {
       "uncategorized": "A catégoriser",


### PR DESCRIPTION
The goal of this PR is to group more account types than before. This way we don't have too much virtual groups that contain only one account type, and the types are more understandable than before.

I added some documentation so we don't lose the original types list.

https://testbanksmergeaccounttypes-banks.cozy.works/#/balances