### PR TITLE
feat: Turn on balance panels UI by default

### DIFF
--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -31,4 +31,7 @@ if (isDemoCozy()) {
   flag('demo', true)
 }
 
+// Turn on new balance panels UI
+flag('balance-panels', true)
+
 window.flag = flag


### PR DESCRIPTION
This enable the flag. So for now we still have the old code, but it is silent. We will remove it after the new UI proved it works well for a while on production.