### PR TITLE
Enable movements chart

### DIFF
--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -47,8 +47,8 @@ class Categories extends Component {
     const hasData =
       categories.length > 0 && categories[0].transactionsNumber > 0
 
-    const withChart = flag('transaction-history')
-    const colorProps = { color: withChart ? 'primary' : 'default' }
+    const withPrimary = flag('categories-header-primary')
+    const colorProps = { color: withPrimary ? 'primary' : 'default' }
 
     return (
       <div>

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -18,8 +18,8 @@ class CategoriesHeader extends PureComponent {
   renderAccountSwitch = () => {
     const { selectedCategory, breadcrumbItems } = this.props
     const [previousItem] = breadcrumbItems.slice(-2, 1)
-    const withChart = flag('transaction-history')
-    const colorProps = { color: withChart ? 'primary' : 'default' }
+    const withPrimary = flag('categories-header-primary')
+    const colorProps = { color: withPrimary ? 'primary' : 'default' }
 
     return (
       <Fragment>
@@ -52,8 +52,8 @@ class CategoriesHeader extends PureComponent {
     if (!showIncomeToggle) {
       return null
     }
-    const withChart = flag('transaction-history')
-    const color = withChart ? 'primary' : 'default'
+    const withPrimary = flag('categories-header-primary')
+    const color = withPrimary ? 'primary' : 'default'
 
     return (
       <div className={cx(styles.CategoriesHeader__Toggle, styles[color])}>
@@ -84,8 +84,8 @@ class CategoriesHeader extends PureComponent {
       return null
     }
 
-    const withChart = flag('transaction-history')
-    const color = { color: withChart ? 'primary' : 'default' }
+    const withPrimary = flag('categories-header-primary')
+    const color = { color: withPrimary ? 'primary' : 'default' }
 
     return (
       <CategoriesChart
@@ -113,8 +113,8 @@ class CategoriesHeader extends PureComponent {
     const incomeToggle = this.renderIncomeToggle()
     const chart = this.renderChart()
 
-    const withChart = flag('transaction-history')
-    const colorProps = { color: withChart ? 'primary' : 'default' }
+    const withPrimary = flag('categories-header-primary')
+    const colorProps = { color: withPrimary ? 'primary' : 'default' }
 
     if (isMobile) {
       return (

--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -37,4 +37,7 @@ flag('balance-panels', true)
 // Turn on new Categories page UI
 flag('categories-header-primary', true)
 
+// Turn on history chart on movements page
+flag('transaction-history', true)
+
 window.flag = flag

--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -34,4 +34,7 @@ if (isDemoCozy()) {
 // Turn on new balance panels UI
 flag('balance-panels', true)
 
+// Turn on new Categories page UI
+flag('categories-header-primary', true)
+
 window.flag = flag


### PR DESCRIPTION
* Split `transaction-history` flag into `categories-header-primary` so it's easier to enable or disable each one separately (and because there is no history chart on categories page)
* Enable `transaction-history` and `categories-header-primary` by default