### PR TITLE
fix(mobile): Scroll after logout

### DIFF
--- a/src/ducks/mobile/utils.js
+++ b/src/ducks/mobile/utils.js
@@ -10,6 +10,7 @@ export async function resetClient(cozyClient) {
   // reset cozy-bar
   if (document.getElementById('coz-bar')) {
     document.getElementById('coz-bar').remove()
+    document.body.setAttribute('style', '')
   }
 }
 


### PR DESCRIPTION
The problem was that after logout on the mobile app, we couldn't scroll anymore. This was caused by the fact that when we open the cozy-bar, it sets an `overflow: hidden` (and other stuff to prevent scroll) on the `body`. But on logout, we simply destroy the cozy-bar DOM node. So we still had the `overflow: hidden` on the `body`. Now I just erase all styles applied on `body` on logout, but we may think of a better API like `destroy` or `unmount` directly in the cozy-bar to handle this correctly.