### PR TITLE
feat: Add error boundary

### DIFF
--- a/src/assets/icons/icon-broken.svg
+++ b/src/assets/icons/icon-broken.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 64 64">
+  <defs>
+    <polygon id="a" points="0 .003 64 .003 64 26.8 0 26.8"/>
+    <polygon id="c" points="0 0 64 0 64 26.795 0 26.795"/>
+  </defs>
+  <g fill="none" fill-rule="evenodd" transform="translate(0 10)">
+    <g transform="translate(0 17.2)">
+      <mask id="b" fill="white">
+        <use xlink:href="#a"/>
+      </mask>
+      <path fill="#FFB3B3" d="M47.84 14L16.04 0 0 7.78v15.04a4 4 0 0 0 4 3.98h56c2.22 0 4-1.78 4-3.98V6.1L47.84 14z" mask="url(#b)"/>
+    </g>
+    <mask id="d" fill="white">
+      <use xlink:href="#c"/>
+    </mask>
+    <path fill="#FFB3B3" d="M15.96 12.8l31.8 14L64 18.86V3.98A4 4 0 0 0 60 0H4C1.78 0 0 1.78 0 3.98v16.56l15.96-7.74z" mask="url(#d)"/>
+    <polygon fill="#FFF2F2" points="15.96 12.797 47.756 26.795 60 20.812 60 4 4 4 4 18.596"/>
+    <polygon fill="#FFF2F2" points="47.844 31.205 16.04 17.203 4 23.041 4 40 60 40 60 25.264"/>
+    <path fill="#FFB3B3" d="M49.47 25.96L53.45 24a4 4 0 1 0-3.98 1.94m-7.7-1.8A10.01 10.01 0 0 0 32 12a9.99 9.99 0 0 0-8.18 4.26l17.94 7.9zM14.37 18l-3.73 1.8A3.98 3.98 0 0 0 14 26a4 4 0 0 0 .38-8m7.84 1.92a10 10 0 0 0 17.92 7.89l-17.92-7.89z"/>
+  </g>
+</svg>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -10,6 +10,7 @@ import { settingsConn } from 'doctypes'
 import { queryConnect } from 'cozy-client'
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 import { Alerter } from 'cozy-ui/react'
+import ErrorBoundary from 'components/ErrorBoundary'
 
 const ReactHint = ReactHintFactory(React)
 
@@ -25,7 +26,11 @@ const App = props => {
       </Sidebar>
 
       <Main>
-        <Content>{props.children}</Content>
+        <Content>
+          <ErrorBoundary>
+            {props.children}
+          </ErrorBoundary>
+        </Content>
       </Main>
 
       {/* Outside every other component to bypass overflow:hidden */}

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Empty } from 'cozy-ui/react'
+import { logException } from 'lib/sentry'
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error, info) {
+    logException({ error, info })
+  }
+
+  componentDidUpdate(prevProps) {
+    const prevPathname = prevProps.children.props.location.pathname
+    const pathname = this.props.children.props.location.pathname
+    if (this.state.hasError && prevPathname !== pathname) {
+      this.setState({ hasError: false })
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <Empty
+          icon="warning"
+          title="An error occured"
+          text="It's maybe nothing, just refresh to be sure" />
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import { Empty } from 'cozy-ui/react'
+import { Empty, translate } from 'cozy-ui/react'
 import { logException } from 'lib/sentry'
+import brokenIcon from 'assets/icons/icon-broken.svg'
+import styles from './ErrorBoundary.styl'
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -26,11 +28,24 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
+      const { t } = this.props
+      const update = t('Error.update')
+        .replace('#{LINK}', `<a onClick="window.location.reload(true)">`)
+        .replace('#{/LINK}', '</a>')
+      const lang = 'fr'
+      const url = `https://cozy.io/${lang === 'fr' ? 'fr' : 'en'}/support/`
+      const contact = t('Error.contact')
+        .replace('#{LINK}', `<a href="${url}" target="_blank">`)
+        .replace('#{/LINK}', '</a>')
+
       return (
-        <Empty
-          icon="warning"
-          title="An error occured"
-          text="It's maybe nothing, just refresh to be sure" />
+        <div className={styles.Error}>
+          <Empty
+            className={styles.Empty}
+            icon={brokenIcon}
+            title={t('Error.title')}
+            text={<div dangerouslySetInnerHTML={{ __html: `${update}</br>${contact}` }} />} />
+        </div>
       )
     }
 
@@ -38,4 +53,4 @@ class ErrorBoundary extends React.Component {
   }
 }
 
-export default ErrorBoundary
+export default translate()(ErrorBoundary)

--- a/src/components/ErrorBoundary.styl
+++ b/src/components/ErrorBoundary.styl
@@ -1,0 +1,19 @@
+.Error
+  position relative
+  transform translateZ(0)
+  height 500px
+  display flex
+
+  a
+  a:visited
+      color var(--primary)
+      text-decoration none
+      cursor pointer
+
+  a:hover
+  a:active
+      text-decoration underline
+
+  .Empty
+    position inherit
+    pointer-events inherit

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -19,7 +19,10 @@
   },
   "Error": {
     "more-information": "More information",
-    "less-information": "Less information"
+    "less-information": "Less information",
+    "title": "We failed to display your bank data",
+    "update": "You can try #{LINK}to reload the page#{/LINK}.",
+    "contact": "Do not hesitate #{LINK}to contact us#{/LINK} if the problem persists."
   },
   "AccountSwitch": {
     "account_counter": "%{smart_count} account |||| %{smart_count} accounts",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -13,7 +13,10 @@
 
   "Error": {
     "more-information": "More information",
-    "less-information": "Less information"
+    "less-information": "Less information",
+    "title": "L'affichages de vos données bancaires a échoué",
+    "update": "Vous pouvez essayer à nouveau #{LINK}en rafraichissant la page#{/LINK}.",
+    "contact": "#{LINK}Contactez-nous#{/LINK} si le problème persiste."
   },
 
   "AccountSwitch": {


### PR DESCRIPTION
Lorsqu'il y a une erreur sur une page on a ce design :

![capture d ecran 2019-02-14 a 18 38 00](https://user-images.githubusercontent.com/1135513/52805815-b6f8fd00-3087-11e9-968b-2cc752006547.png)

Voir [la documentation React](https://reactjs.org/docs/error-boundaries.html)