### PR TITLE
feat: Fix mobile konnector icons

### DIFF
--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -5,7 +5,6 @@ import cx from 'classnames'
 import { flowRight as compose } from 'lodash'
 import Switch from 'components/Switch'
 import { translate, Icon } from 'cozy-ui/react'
-import AppIcon from 'cozy-ui/react/AppIcon'
 import { Figure } from 'components/Figure'
 import {
   getAccountLabel,
@@ -16,7 +15,7 @@ import {
   getAccountBalance
 } from 'ducks/account/helpers'
 import styles from './AccountRow.styl'
-import { getCozyURL, isSecureProtocol } from 'cozy-stack-client/dist/urls'
+import KonnectorIcon from './KonnectorIcon'
 
 class AccountRow extends React.PureComponent {
   static propTypes = {
@@ -58,8 +57,6 @@ class AccountRow extends React.PureComponent {
     const hasAlert = account.balance < 0
     const institutionSlug = getAccountInstitutionSlug(account)
 
-    const cozyURL = getCozyURL()
-
     return (
       <li
         className={cx(styles.AccountRow, {
@@ -71,13 +68,7 @@ class AccountRow extends React.PureComponent {
       >
         <div className={styles.AccountRow__column}>
           <div className={styles.AccountRow__logo}>
-            {institutionSlug && (
-              <AppIcon
-                app={institutionSlug}
-                domain={cozyURL.host}
-                secure={isSecureProtocol(cozyURL)}
-              />
-            )}
+            {institutionSlug && <KonnectorIcon slug={institutionSlug} />}
           </div>
           <div className={styles.AccountRow__labelUpdatedAtWrapper}>
             <div className={styles.AccountRow__label}>

--- a/src/ducks/balance/components/KonnectorIcon.jsx
+++ b/src/ducks/balance/components/KonnectorIcon.jsx
@@ -1,0 +1,68 @@
+/* global __TARGET__ */
+
+import React from 'react'
+import UIAppIcon from 'cozy-ui/react/AppIcon'
+import { withClient } from 'cozy-client'
+import { memoize } from './utils'
+import { isSecureProtocol } from 'cozy-stack-client/dist/urls'
+import { logException } from 'lib/sentry'
+
+const fetchKonnectorIconData = memoize(
+  async (client, slug) => {
+    return client.stackClient.fetchJSON('GET', `/konnectors/${slug}/icon`, {
+      credentials: 'include',
+      headers: {
+        Authorization: `Bearer ${client.stackClient.token}`,
+        Accept: 'application/json'
+      }
+    })
+  },
+  {
+    maxDuration: 30 * 1000,
+    key: (client, slug) => {
+      return client.stackClient.uri + '/' + slug
+    }
+  }
+)
+
+class KonnectorIcon extends React.PureComponent {
+  constructor(props) {
+    super(props)
+    this.state = { data: null }
+  }
+
+  componentDidMount() {
+    this.fetchData()
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.slug !== prevProps.slug) {
+      this.fetchData()
+    }
+  }
+
+  async fetchData() {
+    const props = this.props
+    const data = await fetchKonnectorIconData(props.client, props.slug)
+    try {
+      this.setState({ data })
+    } catch (error) {
+      logException(error)
+    }
+  }
+
+  render() {
+    return this.state.data ? (
+      <span dangerouslySetInnerHTML={{ __html: this.state.data }} />
+    ) : null
+  }
+}
+
+const AppIcon = ({ client, slug }) => {
+  const cozyURL = new URL(client.stackClient.uri)
+  const domain = cozyURL.host
+  const secure = isSecureProtocol(cozyURL)
+  return <UIAppIcon app={slug} domain={domain} secure={secure} />
+}
+
+export default withClient(__TARGET__ === 'mobile' ? KonnectorIcon : AppIcon)

--- a/src/ducks/balance/components/utils.js
+++ b/src/ducks/balance/components/utils.js
@@ -1,0 +1,37 @@
+/**
+ * Delete outdated results from cache
+ */
+const garbageCollect = (cache, maxDuration) => {
+  const now = Date.now()
+  for (const key of Object.keys(cache)) {
+    const delta = now - cache[key].date
+    if (delta > maxDuration) {
+      delete cache[key]
+    }
+  }
+}
+
+/**
+ * Memoize with maxDuration and custom key
+ */
+const memoize = (fn, options) => {
+  const cache = {}
+
+  return function() {
+    const key = options.key.apply(null, arguments)
+    garbageCollect(cache, options.maxDuration)
+    const existing = cache[key]
+    if (existing) {
+      return existing.result
+    } else {
+      const result = fn.apply(this, arguments)
+      cache[key] = {
+        result,
+        date: Date.now()
+      }
+      return result
+    }
+  }
+}
+
+export { memoize }

--- a/src/ducks/balance/components/utils.spec.js
+++ b/src/ducks/balance/components/utils.spec.js
@@ -1,0 +1,22 @@
+const { memoize } = require('./utils')
+
+describe('memoize', () => {
+  let now
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockImplementation(() => now)
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should remember results ', () => {
+    now = 0
+    let c = 0
+    const counter = () => c++
+    const mcounter = memoize(counter, { key: () => 'A', maxDuration: 5 })
+    expect(mcounter()).toBe(0)
+    expect(mcounter()).toBe(0)
+    now = 6
+    expect(mcounter()).toBe(1)
+    expect(mcounter()).toBe(1)
+  })
+})

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -244,7 +244,7 @@ class TransactionsPage extends Component {
 
     if (transactions.length === 0) {
       return (
-        <Padded className='u-pt-0'>
+        <Padded className="u-pt-0">
           <p>{t('Transactions.no-movements')}</p>
         </Padded>
       )


### PR DESCRIPTION
AppIcon does not work directly on mobile. To make it work, you need
to provide a special fetchIcon function that returns the URL of the
icon. This cannot be used for konnectors since konnectors do not have
the `links.icon` attribute (when fetching from `/konnectors/slug`).

This is why I implemented a custom way, by fetching directly the SVG
data and setting it in the HTML directly. One improvement IMHO over the
way AppIcon was used is that now we use `withClient` to get the cozyURL,
it is easier for the developer. I think AppIcon could work like that (check
if client exists in the context).

The SVG data is memoized per domain for 30s.