### PR TITLE
feat(mobile): Ensure the token is refreshed before it expires

### DIFF
--- a/src/ducks/mobile/index.js
+++ b/src/ducks/mobile/index.js
@@ -42,7 +42,13 @@ const reducer = (state = initialState, action) => {
         revoked: false
       }
     case SET_TOKEN:
-      return { ...state, token: action.token }
+      return {
+        ...state,
+        token: {
+          ...action.token,
+          issuedAt: new Date()
+        }
+      }
     case REVOKE_CLIENT:
       return { ...state, revoked: true }
     case UNLINK:


### PR DESCRIPTION
This is a temporary solution to prevent the bar from having an expired
token. See https://github.com/cozy/cozy-bar/issues/449 for more
informations.