### PR TITLE
feat(mobile): Reset filters on logout

### DIFF
--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -21,6 +21,7 @@ import {
 } from 'ducks/mobile/push'
 import { initBar, resetClient } from 'ducks/mobile/utils'
 import LogoutModal from 'components/LogoutModal'
+import { resetFilterByDoc } from 'ducks/filters'
 
 export const AUTH_PATH = 'authentication'
 
@@ -54,6 +55,7 @@ export const onLogout = async (store, cozyClient) => {
   }
 
   store.dispatch(unlink())
+  store.dispatch(resetFilterByDoc())
 }
 
 const withAuth = Wrapped =>


### PR DESCRIPTION
The filters were not resetted on logout. So if we logged in on an instance, selected a bank account, then logout and login on another instance and go to the transactions page, we had the previously selected account name on the header.