### PR TITLE
feat: Add lamutuellegeneral to brand dictionnary

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -130,6 +130,11 @@
     "konnectorSlug": "justeat"
   },
   {
+    "name": "La mutuelle générale",
+    "regexp": "\\bla mutuelle gen",
+    "konnectorSlug": "lamutuellegenerale"
+  },
+  {
     "name": "Le Monde Diplomatique",
     "regexp": "\\bmonde-diplomatique\\b",
     "konnectorSlug": "mondediplo"


### PR DESCRIPTION
Adding a brand for an important connector.
No \\b at the end because know identifiers is 'LA MUTUELLE GEN' but we probably want to match something like 'LA MUTUELLE GENERALE' too if it happens.