### PR TITLE
Debug panel to expire token manually

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "tx": "true || tx pull --all || true",
     "prebuild:browser": "npm run clean:browser",
     "prebuild:mobile": "npm run clean:mobile",
-    "pretest": "npm run lint",
     "prewatch:mobile": "npm run clean:mobile",
     "lint": "npm-run-all --parallel 'lint:*'",
     "lint:js": "eslint --fix 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js'",

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -12,7 +12,8 @@ import {
   GroupsSettings,
   GroupSettings,
   NewGroupSettings,
-  Configuration
+  Configuration,
+  Debug
 } from 'ducks/settings'
 import { Balance } from 'ducks/balance'
 import { EnsureHasAccounts, EnsureIsFirstSynced } from 'ducks/onboarding'
@@ -49,6 +50,7 @@ const AppRoute = (
             <Route path="accounts" component={AccountsSettings} />
             <Route path="groups" component={GroupsSettings} />
             <Route path="configuration" component={Configuration} />
+            <Route path="debug" component={Debug} />
           </Route>
         </Route>
         <Redirect from="*" to={defaultRoute()} />

--- a/src/ducks/mobile/index.js
+++ b/src/ducks/mobile/index.js
@@ -4,6 +4,7 @@ import { startPushNotifications } from './push'
 // constants
 const SET_TOKEN = 'SET_TOKEN'
 const REVOKE_CLIENT = 'REVOKE_CLIENT'
+const EXPIRE_TOKEN = 'EXPIRE_TOKEN'
 export const UNLINK = 'UNLINK'
 const STORE_CREDENTIALS = 'STORE_CREDENTIALS'
 const INITIAL_SYNC_OK = 'INITIAL_SYNC_OK'
@@ -12,6 +13,7 @@ const RECEIVE_UPDATED_DOCUMENTS_FROM_POUCH =
 
 // action creators
 export const setToken = token => ({ type: SET_TOKEN, token })
+export const expireToken = () => ({ type: EXPIRE_TOKEN })
 export const storeCredentials = (url, client, token) => ({
   type: STORE_CREDENTIALS,
   url,
@@ -31,6 +33,8 @@ export const initialState = {
   push: null
 }
 
+const DAY = 1000 * 60 * 60 * 24
+
 const reducer = (state = initialState, action) => {
   switch (action.type) {
     case STORE_CREDENTIALS:
@@ -47,6 +51,14 @@ const reducer = (state = initialState, action) => {
         token: {
           ...action.token,
           issuedAt: new Date()
+        }
+      }
+    case EXPIRE_TOKEN: // Useful for tests
+      return {
+        ...state,
+        token: {
+          ...(state.token || {}),
+          issuedAt: new Date(Date.now() - 8 * DAY)
         }
       }
     case REVOKE_CLIENT:

--- a/src/ducks/settings/AppVersion.jsx
+++ b/src/ducks/settings/AppVersion.jsx
@@ -1,10 +1,54 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styles from './AppVersion.styl'
+import flag from 'cozy-flags'
+import { Alerter } from 'cozy-ui/react'
 
-const AppVersion = ({ version }) => (
-  <div className={styles['app-version']}>Version {version}</div>
-)
+const takeLast = (arr, n) => {
+  const l = arr.length
+  const start = Math.max(0, l - n)
+  const end = l
+  return arr.slice(start, end)
+}
+
+const pairs = function*(arr) {
+  for (let i = 1; i < arr.length; i++) {
+    yield [arr[i - 1], arr[i]]
+  }
+}
+
+class AppVersion extends React.PureComponent {
+  constructor(props) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+    this.clicks = []
+  }
+
+  handleClick() {
+    this.clicks.push({ date: Date.now() })
+    this.clicks = takeLast(this.clicks, 3)
+    if (this.clicks.length < 3) {
+      return
+    }
+    for (const [prevClick, click] of pairs(this.clicks)) {
+      const delta = click.date - prevClick.date
+      if (delta > 1000) {
+        // Clicks are not close enough
+        return
+      }
+    }
+    Alerter.info('Debug flag activated')
+    flag('debug', true)
+  }
+
+  render() {
+    return (
+      <div onClick={this.handleClick} className={styles['app-version']}>
+        Version {this.props.version}
+      </div>
+    )
+  }
+}
 
 AppVersion.propTypes = {
   version: PropTypes.string.isRequired

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -5,13 +5,28 @@ import { connect } from 'react-redux'
 class DebugSettings extends React.PureComponent {
   constructor(props) {
     super(props)
+    this.handleMakeTokenExpired = this.handleMakeTokenExpired.bind(this)
+  }
+
+  handleMakeTokenExpired() {
+    this.props.makeTokenExpired()
   }
 
   render() {
+    return (
+      <div>
+        <button onClick={this.handleMakeTokenExpired}>
+          Make token expired
+        </button>
+      </div>
+    )
   }
 }
 
 const mapDispatchToProps = dispatch => {
+  return {
+    makeTokenExpired: () => dispatch(expireToken())
+  }
 }
 
 export default connect(

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { expireToken } from 'ducks/mobile'
+import { connect } from 'react-redux'
+
+class DebugSettings extends React.PureComponent {
+  constructor(props) {
+    super(props)
+  }
+
+  render() {
+  }
+}
+
+const mapDispatchToProps = dispatch => {
+}
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(DebugSettings)

--- a/src/ducks/settings/Settings.jsx
+++ b/src/ducks/settings/Settings.jsx
@@ -16,17 +16,20 @@ import AppVersion from './AppVersion'
 import { PageTitle } from 'components/Title'
 import { Padded } from 'components/Spacing'
 import cx from 'classnames'
-
-const tabNames = ['configuration', 'accounts', 'groups']
+import flag from 'cozy-flags'
 
 const Settings = ({ t, children, router, breakpoints: { isMobile } }) => {
+  const tabNames = ['configuration', 'accounts', 'groups']
+
   let defaultTab = router.location.pathname.replace('/settings/', '')
   if (tabNames.indexOf(defaultTab) === -1) defaultTab = 'configuration'
 
   const goTo = url => () => {
     router.push(url)
   }
-
+  if (flag('debug')) {
+    tabNames.push('debug')
+  }
   const tabs = tabNames.map(tabName => (
     <Tab key={tabName} name={tabName} onClick={goTo(`/settings/${tabName}`)}>
       {t(`Settings.${tabName}`)}

--- a/src/ducks/settings/index.js
+++ b/src/ducks/settings/index.js
@@ -4,6 +4,7 @@ import AccountsSettings from './AccountsSettings'
 import GroupSettings, { NewGroupSettings } from './GroupSettings'
 import GroupsSettings from './GroupsSettings'
 import Configuration from './Configuration'
+import Debug from './Debug'
 
 export {
   isNotificationEnabled,
@@ -18,5 +19,6 @@ export {
   GroupsSettings,
   GroupSettings,
   NewGroupSettings,
-  Configuration
+  Configuration,
+  Debug
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -415,7 +415,8 @@
     "accounts": "Accounts",
     "groups": "Groups",
     "configuration": "Configuration",
-    "app": "App"
+    "app": "App",
+    "debug": "Debug"
   },
 
   "AppSettings": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -426,7 +426,8 @@
     "title": "Paramètres",
     "accounts": "Comptes",
     "groups": "Groupes",
-    "configuration": "Configuration"
+    "configuration": "Configuration",
+    "debug": "Debug"
   },
 
   "Onboarding": {

--- a/src/utils/token.js
+++ b/src/utils/token.js
@@ -1,0 +1,34 @@
+import { isBefore, subDays, isValid } from 'date-fns'
+
+/**
+ * This check will be removed when we will be able to inject a cozy-client
+ * in the cozy-bar, thus it can renew the token it needed by itself.
+ * For now, we ensure that the token is refreshed before it expires,
+ * so the bar always has a valid token
+ */
+const checkToRefreshToken = (client, store, onRefresh) => () => {
+  const state = store.getState()
+  const token = state.mobile && state.mobile.token
+
+  if (!token) {
+    return
+  }
+
+  // Since the token is valid for a week, we refresh it
+  // if it was issued more than 6 days ago
+  const today = new Date()
+  const sixDaysAgo = subDays(today, 6)
+  const { issuedAt } = token
+
+  if (!issuedAt || !isValid(issuedAt) || isBefore(issuedAt, sixDaysAgo)) {
+    try {
+      client.stackClient.refreshToken()
+      onRefresh && onRefresh()
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Error while refreshing token:' + err)
+    }
+  }
+}
+
+export { checkToRefreshToken }

--- a/src/utils/token.spec.js
+++ b/src/utils/token.spec.js
@@ -1,0 +1,45 @@
+import { checkToRefreshToken } from './token'
+
+const DAY = 1000 * 60 * 60 * 24
+
+describe('refresh token', () => {
+  let client,
+    store,
+    tokenState = {},
+    onRefresh
+  beforeEach(() => {
+    client = {
+      stackClient: {
+        refreshToken: jest.fn()
+      }
+    }
+    onRefresh = jest.fn()
+    store = {
+      getState: () => ({
+        mobile: {
+          token: tokenState
+        }
+      })
+    }
+  })
+
+  it('should refresh token if no issued at', () => {
+    checkToRefreshToken(client, store, onRefresh)()
+    expect(client.stackClient.refreshToken).toHaveBeenCalled()
+    expect(onRefresh).toHaveBeenCalled()
+  })
+
+  it('should refresh token if issued at too long ago', () => {
+    tokenState.issuedAt = new Date(Date.now() - 8 * DAY)
+    checkToRefreshToken(client, store, onRefresh)()
+    expect(client.stackClient.refreshToken).toHaveBeenCalled()
+    expect(onRefresh).toHaveBeenCalled()
+  })
+
+  it('should not refresh token if issued at not too long ago', () => {
+    tokenState.issuedAt = new Date(Date.now() - 5 * DAY)
+    checkToRefreshToken(client, store, onRefresh)()
+    expect(client.stackClient.refreshToken).not.toHaveBeenCalled()
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
- Add a debug panel in settings if flag('debug') is set
- Add a button to expire the token in the redux store
- When refreshing the token, an alert is shown if the flag('debug') is set