### PR TITLE
Fix debug alert and refresh token on mobile app start

### DIFF
--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { expireToken } from 'ducks/mobile'
 import { connect } from 'react-redux'
+import { Alerter } from 'cozy-ui/react'
 
 class DebugSettings extends React.PureComponent {
   constructor(props) {
@@ -10,6 +11,7 @@ class DebugSettings extends React.PureComponent {
 
   handleMakeTokenExpired() {
     this.props.makeTokenExpired()
+    Alerter.info('Token expired')
   }
 
   render() {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -73,14 +73,14 @@ const setupApp = async persistedState => {
       replaceTitleOnMobile: true
     })
   } else {
-    document.addEventListener(
-      'resume',
-      checkToRefreshToken(client, store, () => {
-        if (flag('debug')) {
-          Alerter.info('Token refreshed')
-        }
-      })
-    )
+    const onStartOrResume = checkToRefreshToken(client, store, () => {
+      if (flag('debug')) {
+        Alerter.info('Token refreshed')
+      }
+    })
+
+    document.addEventListener('deviceready', onStartOrResume)
+    document.addEventListener('resume', onStartOrResume)
   }
 
   if (isReporterEnabled()) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -77,7 +77,7 @@ const setupApp = async persistedState => {
       'resume',
       checkToRefreshToken(client, store, () => {
         if (flag('debug')) {
-          Alerter.show('info', 'Token refreshed')
+          Alerter.info('Token refreshed')
         }
       })
     )


### PR DESCRIPTION
The `Alerter.show` function doesn't seem to exist. I also added the token refresh on app start, because it was only on resume.