### PR TITLE
feat: Clean transaction labels

### DIFF
--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -1,15 +1,33 @@
 import find from 'lodash/find'
 import findLast from 'lodash/findLast'
 import get from 'lodash/get'
+import flag from 'cozy-flags'
+
+const prevRecurRx = /\bPRLV SEPA RECU RCUR\b/
+const longNumber = /\b\d{5,}\b/g
+const notWord = /\b[A-Z]*\d+[A-Z]*\b/g
+const tooLong = /\b[A-Z\d]{15,}\b/g
+const punctuations = /[-:++]/g
+const spaces = /\s+/g
+
+const cleanLabel = flag('clean-label')
+  ? label => {
+      return label
+        .replace(prevRecurRx, ' ')
+        .replace(longNumber, ' ')
+        .replace(notWord, '')
+        .replace(punctuations, '')
+        .replace(tooLong, '')
+        .replace(spaces, ' ')
+        .trim()
+    }
+  : x => x
 
 const titleRx = /(?:^|\s)\S/g
 const titleCase = label =>
-  label
-    .toLowerCase()
-    .replace(titleRx, a => a.toUpperCase())
+  label.toLowerCase().replace(titleRx, a => a.toUpperCase())
 
-export const getLabel = transaction =>
-  titleCase(transaction.label)
+export const getLabel = transaction => cleanLabel(titleCase(transaction.label))
 
 export const getDisplayDate = transaction => {
   if (

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -2,8 +2,14 @@ import find from 'lodash/find'
 import findLast from 'lodash/findLast'
 import get from 'lodash/get'
 
+const titleRx = /(?:^|\s)\S/g
+const titleCase = label =>
+  label
+    .toLowerCase()
+    .replace(titleRx, a => a.toUpperCase())
+
 export const getLabel = transaction =>
-  transaction.label.toLowerCase().replace(/(?:^|\s)\S/g, a => a.toUpperCase())
+  titleCase(transaction.label)
 
 export const getDisplayDate = transaction => {
   if (


### PR DESCRIPTION
Sometimes BI does not return labels that are clean. Clean
labels via RegExps. Behind flag `clean-labels`.