### PR TITLE
Select date overlaps history chart on movements page

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -285,14 +285,19 @@ class LineChart extends Component {
 
   updatePointLine() {
     const item = this.getSelectedItem()
-    const { height, margin, tickPadding } = this.props
+    const { height, margin, tickPadding, showAxis } = this.props
     const x = this.x(item.x)
+    let y2 = height - margin.top + tickPadding
+
+    if (showAxis) {
+      y2 -= margin.bottom
+    }
 
     this.pointLine
       .attr('x1', x)
       .attr('y1', 0)
       .attr('x2', x)
-      .attr('y2', height - margin.top - margin.bottom + tickPadding)
+      .attr('y2', y2)
   }
 
   /**

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -93,6 +93,7 @@ class LineChart extends Component {
   updateScales() {
     this.x.range([0, this.getInnerWidth()])
     this.y.range([this.getInnerHeight(), 0])
+
     this.updateDomains()
   }
 
@@ -180,11 +181,23 @@ class LineChart extends Component {
     if (this.rect) {
       const { data } = this.props
       const minY = this.getDataMin()
-      this.areaGenerator.y0(() => this.y(minY.y))
+      this.areaGenerator.y0(() => {
+        let min = this.y(minY.y)
 
-      this.rect
-        .attr('width', this.getInnerWidth())
-        .attr('height', this.getInnerHeight())
+        if (!this.props.showAxis) {
+          min += this.props.margin.bottom
+        }
+
+        return min
+      })
+
+      let height = this.getInnerHeight()
+
+      if (!this.props.showAxis) {
+        height += this.props.margin.bottom
+      }
+
+      this.rect.attr('width', this.getInnerWidth()).attr('height', height)
 
       this.mask.datum(data).attr('d', this.areaGenerator)
     }

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -184,6 +184,10 @@ class LineChart extends Component {
       this.areaGenerator.y0(() => {
         let min = this.y(minY.y)
 
+        if (min === 0) {
+          min += this.getInnerHeight()
+        }
+
         if (!this.props.showAxis) {
           min += this.props.margin.bottom
         }

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -181,11 +181,12 @@ class LineChart extends Component {
     if (this.rect) {
       const { data, showAxis, margin } = this.props
       const minY = this.getDataMin()
+      const innerHeight = this.getInnerHeight()
       this.areaGenerator.y0(() => {
         let min = this.y(minY.y)
 
         if (min === 0) {
-          min += this.getInnerHeight()
+          min += innerHeight
         }
 
         if (!showAxis) {
@@ -195,7 +196,6 @@ class LineChart extends Component {
         return min
       })
 
-      const innerHeight = this.getInnerHeight()
       const height = innerHeight + (showAxis ? 0 : margin.bottom)
 
       this.rect.attr('width', this.getInnerWidth()).attr('height', height)

--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -179,7 +179,7 @@ class LineChart extends Component {
 
   updateGradient() {
     if (this.rect) {
-      const { data } = this.props
+      const { data, showAxis, margin } = this.props
       const minY = this.getDataMin()
       this.areaGenerator.y0(() => {
         let min = this.y(minY.y)
@@ -188,18 +188,15 @@ class LineChart extends Component {
           min += this.getInnerHeight()
         }
 
-        if (!this.props.showAxis) {
-          min += this.props.margin.bottom
+        if (!showAxis) {
+          min += margin.bottom
         }
 
         return min
       })
 
-      let height = this.getInnerHeight()
-
-      if (!this.props.showAxis) {
-        height += this.props.margin.bottom
-      }
+      const innerHeight = this.getInnerHeight()
+      const height = innerHeight + (showAxis ? 0 : margin.bottom)
 
       this.rect.attr('width', this.getInnerWidth()).attr('height', height)
 

--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -255,7 +255,8 @@ class SelectDates extends PureComponent {
       value,
       color,
       t,
-      breakpoints: { isMobile }
+      breakpoints: { isMobile },
+      className
     } = this.props
     const index = this.getSelectedIndex()
     const options = this.getOptions()
@@ -316,7 +317,8 @@ class SelectDates extends PureComponent {
         className={cx(
           styles.SelectDates,
           styles[`SelectDatesColor_${color}`],
-          scrolling && styles['SelectDates--scrolling']
+          scrolling && styles['SelectDates--scrolling'],
+          className
         )}
       >
         <span className={styles['SelectDates__DateYearSelector']}>

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -5,6 +5,7 @@ import LineChart from 'components/Chart/LineChart'
 import styles from './History.styl'
 import palette from 'cozy-ui/react/palette'
 import { flowRight as compose } from 'lodash'
+import cx from 'classnames'
 
 // on iOS white transparency on SVG failed so we should calculate hexa color
 const gradientStyle = {
@@ -38,9 +39,9 @@ class HistoryChart extends Component {
   }
 
   render() {
-    const { data, height, width } = this.props
+    const { data, height, width, className } = this.props
     return (
-      <div className={styles.HistoryChart} ref={this.container}>
+      <div className={cx(styles.HistoryChart, className)} ref={this.container}>
         <LineChart
           xScale={d3.scaleTime}
           lineColor="white"

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router'
 import { flowRight as compose, max } from 'lodash'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import { withSize } from 'react-sizeme'
+import cx from 'classnames'
 
 import BackButton from 'components/BackButton'
 import Breadcrumb from 'components/Breadcrumb'
@@ -116,6 +117,7 @@ class TransactionHeader extends Component {
         data={chartData}
         height={96 + marginBottom}
         width={max([size.width, intervalBetweenPoints * chartData.length])}
+        className={styles.TransactionsHeader__chart}
       />
     )
   }
@@ -136,7 +138,15 @@ class TransactionHeader extends Component {
           {this.displayAccountSwitch()}
         </Padded>
         {!isSubcategory && this.displayBalanceHistory()}
-        <Padded className={isMobile ? 'u-p-0' : 'u-pv-1'}>
+        <Padded
+          className={cx(
+            {
+              'u-p-0': isMobile,
+              'u-pv-1': !isMobile
+            },
+            styles.TransactionsHeader__selectDates
+          )}
+        >
           {this.displaySelectDates()}
         </Padded>
         {isSubcategory && (

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -103,7 +103,7 @@ class TransactionHeader extends Component {
       return
     }
     const intervalBetweenPoints = 2
-    const marginBottom = 64
+    const marginBottom = isMobile ? 48 : 64
     const historyChartMargin = {
       top: 26,
       bottom: marginBottom,
@@ -111,11 +111,13 @@ class TransactionHeader extends Component {
       right: isMobile ? 16 : 32
     }
 
+    const height = isMobile ? 66 : 96
+
     return (
       <HistoryChart
         margin={historyChartMargin}
         data={chartData}
-        height={96 + marginBottom}
+        height={height + marginBottom}
         width={max([size.width, intervalBetweenPoints * chartData.length])}
         className={styles.TransactionsHeader__chart}
       />

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -146,8 +146,7 @@ class TransactionHeader extends Component {
             {
               'u-ph-half': isMobile,
               'u-pv-0': isMobile,
-              'u-pb-half': isMobile,
-              'u-pv-1': !isMobile
+              'u-pb-half': isMobile
             },
             styles.TransactionsHeader__selectDatesContainer
           )}

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -102,7 +102,7 @@ class TransactionHeader extends Component {
       return
     }
     const intervalBetweenPoints = 2
-    const marginBottom = 10
+    const marginBottom = 64
     const historyChartMargin = {
       top: 26,
       bottom: marginBottom,
@@ -114,7 +114,7 @@ class TransactionHeader extends Component {
       <HistoryChart
         margin={historyChartMargin}
         data={chartData}
-        height={72 + marginBottom}
+        height={96 + marginBottom}
         width={max([size.width, intervalBetweenPoints * chartData.length])}
       />
     )

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -55,6 +55,7 @@ class TransactionHeader extends Component {
         value={currentMonth}
         onChange={handleChangeMonth}
         {...colorProps}
+        className="u-p-0"
       />
     )
   }
@@ -143,10 +144,12 @@ class TransactionHeader extends Component {
         <Padded
           className={cx(
             {
-              'u-p-0': isMobile,
+              'u-ph-half': isMobile,
+              'u-pv-0': isMobile,
+              'u-pb-half': isMobile,
               'u-pv-1': !isMobile
             },
-            styles.TransactionsHeader__selectDates
+            styles.TransactionsHeader__selectDatesContainer
           )}
         >
           {this.displaySelectDates()}

--- a/src/ducks/transactions/TransactionSelectDates.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.jsx
@@ -43,7 +43,7 @@ export const getOptions = transactions => {
 
 class TransactionSelectDates extends PureComponent {
   render() {
-    const { onChange, transactions, value, color } = this.props
+    const { onChange, transactions, value, color, className } = this.props
     const options = getOptions(transactions)
 
     return (
@@ -52,6 +52,7 @@ class TransactionSelectDates extends PureComponent {
         options={options}
         value={value}
         color={color}
+        className={className}
       />
     )
   }

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -27,3 +27,4 @@
 
 .TransactionsHeader__selectDatesContainer
     position relative
+    padding-bottom 12px

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -23,7 +23,7 @@
     margin-bottom -72px
 
     +small-screen()
-        margin-bottom -52px
+        margin-bottom -40px
 
-.TransactionsHeader__selectDates
+.TransactionsHeader__selectDatesContainer
     position relative

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -18,3 +18,12 @@
             &
                 margin 0
                 flex-basis 50%
+
+.TransactionsHeader__chart
+    margin-bottom -72px
+
+    +small-screen()
+        margin-bottom -52px
+
+.TransactionsHeader__selectDates
+    position relative


### PR DESCRIPTION
In this case, screenshots are better than words:

![image](https://user-images.githubusercontent.com/1606068/53157356-9e29a380-35c1-11e9-8ad6-376242524629.png)

![image](https://user-images.githubusercontent.com/1606068/53157574-13957400-35c2-11e9-94ab-c516e49d5e9b.png)

Live on https://testbanksmovementsgradient-banks.cozy.works