### PR TITLE
Add freshDate helper in fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "styleguide:deploy": "git-directory-deploy --directory ./docs/build/styleguide --branch master --repo docs",
-    "fixtures": "ACH import test/fixtures/demo.json test/fixtures/helpers.js",
+    "fixtures": "ACH import test/fixtures/demo.json test/fixtures/helpers/index.js",
     "release": "./scripts/release.sh"
   },
   "husky": {

--- a/test/fixtures/README.md
+++ b/test/fixtures/README.md
@@ -19,7 +19,7 @@ Usage
 =====
 
 ```
-ACH import demo.json helpers.js
+ACH import demo.json helpers/index.js
 ```
 
 Other fixtures

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -225,7 +225,7 @@
         "symbol": "€"
       },
       "amount": -70,
-      "date": "2018-08-06T00:00:00Z",
+      "date": "{{ freshDate '2018-08-06T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a388e",
       "bill": "io.cozy.:marsrembourcomplisa2",
       "reimbursements": [
@@ -244,7 +244,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 70,
-      "date": "2018-08-08T00:00:00Z",
+      "date": "{{ freshDate '2018-08-08T00:00:00Z' }}",
       "bills": [
         "io.cozy.bills:b2"
       ],
@@ -257,7 +257,7 @@
       "label": "DR CHOLLET CHQ 18708913",
       "currency": "€",
       "amount": -70,
-      "date": "2018-08-12T00:00:00Z",
+      "date": "{{ freshDate '2018-08-12T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a3985",
       "reimbursements": [
         {
@@ -274,7 +274,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 70,
-      "date": "2018-08-14T00:00:00Z",
+      "date": "{{ freshDate '2018-08-14T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849d350",
       "bill": "io.cozy.:marsrembourcomplisa22"
     },
@@ -285,7 +285,7 @@
       "label": "PAYSLIP DURAND DECEMBER 2017",
       "currency": "€",
       "amount": 3860.44,
-      "date": "2018-09-01T00:00:00Z",
+      "date": "{{ freshDate '2018-09-01T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354aafeb"
     },
     {
@@ -296,7 +296,7 @@
       "label": "ARGENT DE POCHE",
       "currency": "€",
       "amount": -80,
-      "date": "2018-09-01T00:00:00Z",
+      "date": "{{ freshDate '2018-09-01T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a54cf",
       "reimbursements": [
         {
@@ -313,7 +313,7 @@
       "label": "RETRAITE",
       "currency": "€",
       "amount": 2110.81,
-      "date": "2018-09-02T00:00:00Z",
+      "date": "{{ freshDate '2018-09-02T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fc3e4"
     },
     {
@@ -323,7 +323,7 @@
       "label": "ARGENT DE POCHE",
       "currency": "€",
       "amount": 80,
-      "date": "2018-09-02T00:00:00Z",
+      "date": "{{ freshDate '2018-09-02T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f8bd1",
       "reimbursements": [
         {
@@ -341,7 +341,7 @@
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
       "amount": -400,
-      "date": "2018-09-03T00:00:00Z",
+      "date": "{{ freshDate '2018-09-03T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a48b6"
     },
     {
@@ -351,7 +351,7 @@
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
       "amount": 400,
-      "date": "2018-09-03T00:00:00Z",
+      "date": "{{ freshDate '2018-09-03T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04ffa27",
       "bill": "io.cozy.:avrilrembourcla3"
     },
@@ -363,7 +363,7 @@
       "label": "UBER",
       "currency": "€",
       "amount": -18.12,
-      "date": "2018-09-03T00:00:00Z",
+      "date": "{{ freshDate '2018-09-03T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a6256"
     },
     {
@@ -373,7 +373,7 @@
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
       "amount": -80,
-      "date": "2018-09-04T00:00:00Z",
+      "date": "{{ freshDate '2018-09-04T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e05018bb"
     },
     {
@@ -383,7 +383,7 @@
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
       "amount": -20,
-      "date": "2018-09-04T00:00:00Z",
+      "date": "{{ freshDate '2018-09-04T00:00:00Z' }}",
       "bills": [
         "io.cozy.bills:b3"
       ],
@@ -398,7 +398,7 @@
       "label": "AUCHAN",
       "currency": "€",
       "amount": -42.3,
-      "date": "2018-09-04T00:00:00Z"
+      "date": "{{ freshDate '2018-09-04T00:00:00Z' }}"
     },
     {
       "demo": false,
@@ -407,7 +407,7 @@
       "label": "CABINET OSTEOKINESITHERAPIE",
       "currency": "€",
       "amount": -60,
-      "date": "2018-09-06T00:00:00Z",
+      "date": "{{ freshDate '2018-09-06T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fef54",
       "reimbursements": [
         {
@@ -423,7 +423,7 @@
       "amount": -122.4,
       "automaticCategoryId": "400110",
       "currency": "€",
-      "date": "2018-09-06T00:00:00Z",
+      "date": "{{ freshDate '2018-09-06T00:00:00Z' }}",
       "label": "CARREFOUR MARKET",
       "reimbursements": [
         {
@@ -446,7 +446,7 @@
       "label": "FRANPRIX",
       "currency": "€",
       "amount": -18.22,
-      "date": "2018-09-07T00:00:00Z",
+      "date": "{{ freshDate '2018-09-07T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f4428"
     },
     {
@@ -456,7 +456,7 @@
       "label": "LE RICHER",
       "currency": "€",
       "amount": -43.54,
-      "date": "2018-09-08T00:00:00Z",
+      "date": "{{ freshDate '2018-09-08T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e050349e"
     },
     {
@@ -466,7 +466,7 @@
       "label": "kAISER BOULANGERIE",
       "currency": "€",
       "amount": -12.1,
-      "date": "2018-09-08T00:00:00Z",
+      "date": "{{ freshDate '2018-09-08T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e05026b4"
     },
     {
@@ -476,7 +476,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 60,
-      "date": "2018-09-08T00:00:00Z",
+      "date": "{{ freshDate '2018-09-08T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e05004cf",
       "bill": "io.cozy.:avrilrembourcomplisa2"
     },
@@ -487,7 +487,7 @@
       "label": "UGCCINECITE",
       "currency": "€",
       "amount": -7.5,
-      "date": "2018-09-08T00:00:00Z",
+      "date": "{{ freshDate '2018-09-08T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f3d1a"
     },
     {
@@ -497,7 +497,7 @@
       "label": "CABINET CARDIOLOGIE CONSULT",
       "currency": "€",
       "amount": -41,
-      "date": "2018-09-10T00:00:00Z",
+      "date": "{{ freshDate '2018-09-10T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a682f",
       "reimbursements": [
         {
@@ -514,7 +514,7 @@
       "label": "CPAM PARIS",
       "currency": "€",
       "amount": 28.7,
-      "date": "2018-09-11T00:00:00Z",
+      "date": "{{ freshDate '2018-09-11T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fd1eb",
       "bill": "io.cozy.:avrilrembourcla3"
     },
@@ -525,7 +525,7 @@
       "label": "FNAC TERNES",
       "currency": "€",
       "amount": -80.44,
-      "date": "2018-09-11T00:00:00Z",
+      "date": "{{ freshDate '2018-09-11T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a23ff"
     },
     {
@@ -535,7 +535,7 @@
       "label": "CARREFOUR MARKET",
       "currency": "€",
       "amount": -65.13,
-      "date": "2018-09-12T00:00:00Z",
+      "date": "{{ freshDate '2018-09-12T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a82b0"
     },
     {
@@ -545,7 +545,7 @@
       "label": "CABINET OSTEOKINESITHERAPIE",
       "currency": "€",
       "amount": -60,
-      "date": "2018-09-12T00:00:00Z",
+      "date": "{{ freshDate '2018-09-12T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f599d",
       "reimbursements": [
         {
@@ -562,7 +562,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 12.3,
-      "date": "2018-09-12T00:00:00Z",
+      "date": "{{ freshDate '2018-09-12T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849fe32",
       "bills": [
         "io.cozy.bills:b4"
@@ -576,7 +576,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 60,
-      "date": "2018-09-14T00:00:00Z",
+      "date": "{{ freshDate '2018-09-14T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a9105",
       "bill": "io.cozy.:avrilrembourcomplisa22"
     },
@@ -587,7 +587,7 @@
       "label": "LABORATOIRE PUTEAUX",
       "currency": "€",
       "amount": -50,
-      "date": "2018-09-14T00:00:00Z",
+      "date": "{{ freshDate '2018-09-14T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e05012e0",
       "reimbursements": [
         {
@@ -604,7 +604,7 @@
       "label": "FREEMOBILE",
       "currency": "€",
       "amount": -15.99,
-      "date": "2018-09-15T00:00:00Z",
+      "date": "{{ freshDate '2018-09-15T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a61ff",
       "bills": [
         "io.cozy.bills:b1"
@@ -617,7 +617,7 @@
       "label": "CPAM PARIS",
       "currency": "€",
       "amount": 30,
-      "date": "2018-09-16T00:00:00Z",
+      "date": "{{ freshDate '2018-09-16T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849f1ff",
       "bill": "io.cozy.:avrilrembourcla32"
     },
@@ -628,7 +628,7 @@
       "label": "FRANPRIX",
       "currency": "€",
       "amount": -48.12,
-      "date": "2018-09-17T00:00:00Z",
+      "date": "{{ freshDate '2018-09-17T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354ab4a3"
     },
     {
@@ -638,7 +638,7 @@
       "label": "UBER",
       "currency": "€",
       "amount": -9.09,
-      "date": "2018-09-18T00:00:00Z",
+      "date": "{{ freshDate '2018-09-18T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354b018f",
       "reimbursements": [
         {
@@ -655,7 +655,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 18,
-      "date": "2018-09-18T00:00:00Z",
+      "date": "{{ freshDate '2018-09-18T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354aeea2",
       "bill": "io.cozy.:avrilrembourcomplcla32"
     },
@@ -666,7 +666,7 @@
       "label": "kAISER BOULANGERIE",
       "currency": "€",
       "amount": -9.4,
-      "date": "2018-09-18T00:00:00Z",
+      "date": "{{ freshDate '2018-09-18T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f8814",
       "reimbursements": [
         {
@@ -683,7 +683,7 @@
       "label": "FRANCE MENAGE",
       "currency": "€",
       "amount": -40,
-      "date": "2018-09-20T00:00:00Z",
+      "date": "{{ freshDate '2018-09-20T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354ace64",
       "bills": [
         "io.cozy.bills:b0"
@@ -696,7 +696,7 @@
       "label": "KINE REUILLY",
       "currency": "€",
       "amount": -40,
-      "date": "2018-09-21T00:00:00Z",
+      "date": "{{ freshDate '2018-09-21T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354af7f5",
       "bill": "io.cozy.:avrilrembourcomplcla32",
       "reimbursements": [
@@ -714,7 +714,7 @@
       "label": "FRANPRIX",
       "currency": "€",
       "amount": -48.22,
-      "date": "2018-09-21T00:00:00Z",
+      "date": "{{ freshDate '2018-09-21T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354abf44"
     },
     {
@@ -724,7 +724,7 @@
       "label": "ZARA",
       "currency": "€",
       "amount": -32.89,
-      "date": "2018-09-21T00:00:00Z",
+      "date": "{{ freshDate '2018-09-21T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a7a75"
     },
     {
@@ -733,7 +733,7 @@
       "amount": -46.55,
       "automaticCategoryId": "400420",
       "currency": "€",
-      "date": "2018-09-21T00:00:00Z",
+      "date": "{{ freshDate '2018-09-21T00:00:00Z' }}",
       "label": "FRANPRIX",
       "demo": false
     },
@@ -744,7 +744,7 @@
       "label": "KFC",
       "currency": "€",
       "amount": -8.5,
-      "date": "2018-09-22T00:00:00Z",
+      "date": "{{ freshDate '2018-09-22T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e0500a17",
       "reimbursements": [
         {
@@ -762,7 +762,7 @@
       "label": "CARREFOUR CITY",
       "currency": "€",
       "amount": -65.3,
-      "date": "2018-09-22T00:00:00Z",
+      "date": "{{ freshDate '2018-09-22T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a1874"
     },
     {
@@ -772,7 +772,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 40,
-      "date": "2018-09-23T00:00:00Z",
+      "date": "{{ freshDate '2018-09-23T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849ebf5",
       "bill": "io.cozy.:avrilrembourcomplisa23"
     },
@@ -783,7 +783,7 @@
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
       "amount": -1231,
-      "date": "2018-09-25T00:00:00Z",
+      "date": "{{ freshDate '2018-09-25T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a5e78"
     },
     {
@@ -793,7 +793,7 @@
       "label": "CASH WITHDRAWAL BNPPARIBAS",
       "currency": "€",
       "amount": -20,
-      "date": "2018-09-25T00:00:00Z",
+      "date": "{{ freshDate '2018-09-25T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e050427f"
     },
     {
@@ -803,7 +803,7 @@
       "label": "SOMEWHERE",
       "currency": "€",
       "amount": -42.89,
-      "date": "2018-09-29T00:00:00Z",
+      "date": "{{ freshDate '2018-09-29T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fba40"
     },
     {
@@ -813,7 +813,7 @@
       "label": "BOUYGUES TELECOM",
       "currency": "€",
       "amount": -44.9,
-      "date": "2018-09-30T00:00:00Z",
+      "date": "{{ freshDate '2018-09-30T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a6d55",
       "bills": [
         "io.cozy.bills:b3"
@@ -827,7 +827,7 @@
       "label": "ARGENT DE POCHE",
       "currency": "€",
       "amount": -80,
-      "date": "2018-10-01T00:00:00Z",
+      "date": "{{ freshDate '2018-10-01T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a7f3e",
       "reimbursements": [
         {
@@ -844,7 +844,7 @@
       "label": "CANTINE SCOLAIRE",
       "currency": "€",
       "amount": -120.44,
-      "date": "2018-10-01T00:00:00Z",
+      "date": "{{ freshDate '2018-10-01T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849c47a"
     },
     {
@@ -854,7 +854,7 @@
       "label": "ARGENT DE POCHE",
       "currency": "€",
       "amount": 80,
-      "date": "2018-10-02T00:00:00Z",
+      "date": "{{ freshDate '2018-10-02T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a88f5",
       "bills": [
         "io.cozy.bills:b3"
@@ -866,7 +866,7 @@
       "amount": 2110.81,
       "automaticCategoryId": "400460",
       "currency": "€",
-      "date": "2018-10-02T00:00:00Z",
+      "date": "{{ freshDate '2018-10-02T00:00:00Z' }}",
       "label": "RETRAITE",
       "action": {
         "target": "_blank",
@@ -883,7 +883,7 @@
       "label": "UBER",
       "currency": "€",
       "amount": -22.12,
-      "date": "2018-10-03T00:00:00Z",
+      "date": "{{ freshDate '2018-10-03T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354add8c"
     },
     {
@@ -893,7 +893,7 @@
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
       "amount": 400,
-      "date": "2018-10-03T00:00:00Z",
+      "date": "{{ freshDate '2018-10-03T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a772c"
     },
     {
@@ -903,7 +903,7 @@
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
       "amount": -400,
-      "date": "2018-10-03T00:00:00Z",
+      "date": "{{ freshDate '2018-10-03T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a476b"
     },
     {
@@ -913,7 +913,7 @@
       "label": "AUCHAN",
       "currency": "€",
       "amount": -42.3,
-      "date": "2018-10-04T00:00:00Z",
+      "date": "{{ freshDate '2018-10-04T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a5954",
       "reimbursements": [
         {
@@ -930,7 +930,7 @@
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
       "amount": -100,
-      "date": "2018-10-04T00:00:00Z",
+      "date": "{{ freshDate '2018-10-04T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f97d1",
       "action": {
         "target": "_blank",
@@ -947,7 +947,7 @@
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
       "amount": -20,
-      "date": "2018-10-04T00:00:00Z",
+      "date": "{{ freshDate '2018-10-04T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a4cb7"
     },
     {
@@ -958,7 +958,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 70,
-      "date": "2018-10-06T00:00:00Z",
+      "date": "{{ freshDate '2018-10-06T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a3666"
     },
     {
@@ -968,7 +968,7 @@
       "label": "CARREFOUR MARKET",
       "currency": "€",
       "amount": -62.3,
-      "date": "2018-10-06T00:00:00Z",
+      "date": "{{ freshDate '2018-10-06T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fd9ad"
     },
     {
@@ -978,7 +978,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 7.5,
-      "date": "2018-10-07T00:00:00Z",
+      "date": "{{ freshDate '2018-10-07T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a21f7",
       "bill": "io.cozy.:rembourcomplisa1"
     },
@@ -989,7 +989,7 @@
       "label": "FRANPRIX",
       "currency": "€",
       "amount": -18.22,
-      "date": "2018-10-07T00:00:00Z",
+      "date": "{{ freshDate '2018-10-07T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a0a35"
     },
     {
@@ -1000,7 +1000,7 @@
       "label": "KAISER BOULANGERIE",
       "currency": "€",
       "amount": -12.1,
-      "date": "2018-10-08T00:00:00Z",
+      "date": "{{ freshDate '2018-10-08T00:00:00Z' }}",
       "action": {
         "url": "https://www.fnac.com/video.asp#bl=MMvi",
         "trad": "Accéder au site Fnac",
@@ -1015,7 +1015,7 @@
       "label": "LA BELLE ASSIETTE",
       "currency": "€",
       "amount": -78.54,
-      "date": "2018-10-08T00:00:00Z",
+      "date": "{{ freshDate '2018-10-08T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e0501d0d",
       "reimbursements": [
         {
@@ -1032,7 +1032,7 @@
       "label": "CABINET CARDIO CONSULT",
       "currency": "€",
       "amount": -41,
-      "date": "2018-10-10T00:00:00Z",
+      "date": "{{ freshDate '2018-10-10T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f76df",
       "bill": "io.cozy.:rembourcla3",
       "reimbursements": [
@@ -1050,7 +1050,7 @@
       "label": "DR CHOLLET CHQ 18708914",
       "currency": "€",
       "amount": -70,
-      "date": "2018-10-11T00:00:00Z",
+      "date": "{{ freshDate '2018-10-11T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f7a6a",
       "reimbursements": [
         {
@@ -1067,7 +1067,7 @@
       "label": "CPAM PARIS",
       "currency": "€",
       "amount": 28.7,
-      "date": "2018-10-11T00:00:00Z",
+      "date": "{{ freshDate '2018-10-11T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f4f29",
       "bill": "io.cozy.:rembourcla3"
     },
@@ -1079,7 +1079,7 @@
       "label": "FNAC TERNES",
       "currency": "€",
       "amount": -80.44,
-      "date": "2018-10-11T00:00:00Z",
+      "date": "{{ freshDate '2018-10-11T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a3a61"
     },
     {
@@ -1089,7 +1089,7 @@
       "label": "GAUMONTPARNASSE",
       "currency": "€",
       "amount": -7.5,
-      "date": "2018-10-12T00:00:00Z",
+      "date": "{{ freshDate '2018-10-12T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fb267"
     },
     {
@@ -1100,7 +1100,7 @@
       "label": "CARREFOUR MARKET",
       "currency": "€",
       "amount": -165.3,
-      "date": "2018-10-12T00:00:00Z",
+      "date": "{{ freshDate '2018-10-12T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a2ade"
     },
     {
@@ -1110,7 +1110,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 12.3,
-      "date": "2018-10-12T00:00:00Z",
+      "date": "{{ freshDate '2018-10-12T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849c88a",
       "bill": "io.cozy.:rembourcomplcla3"
     },
@@ -1121,7 +1121,7 @@
       "label": "MC DONALDS",
       "currency": "€",
       "amount": -8.5,
-      "date": "2018-10-12T00:00:00Z",
+      "date": "{{ freshDate '2018-10-12T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849bc9d"
     },
     {
@@ -1132,7 +1132,7 @@
       "label": "LA REDOUTE",
       "currency": "€",
       "amount": -42.89,
-      "date": "2018-10-13T00:00:00Z",
+      "date": "{{ freshDate '2018-10-13T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354a3408"
     },
     {
@@ -1142,7 +1142,7 @@
       "label": "UBER",
       "currency": "€",
       "amount": -8.09,
-      "date": "2018-10-14T00:00:00Z",
+      "date": "{{ freshDate '2018-10-14T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a83ea"
     },
     {
@@ -1153,7 +1153,7 @@
       "label": "CARREFOUR CITY",
       "currency": "€",
       "amount": -65.3,
-      "date": "2018-10-14T00:00:00Z",
+      "date": "{{ freshDate '2018-10-14T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a591c"
     },
     {
@@ -1163,7 +1163,7 @@
       "label": "FREEMOBILE",
       "currency": "€",
       "amount": -15.99,
-      "date": "2018-10-15T00:00:00Z",
+      "date": "{{ freshDate '2018-10-15T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354abec5",
       "bills": [
         "io.cozy.bills:b0"
@@ -1176,7 +1176,7 @@
       "label": "MAIF ASSURANCE HABITATION",
       "currency": "€",
       "amount": -243.57,
-      "date": "2018-10-15T00:00:00Z",
+      "date": "{{ freshDate '2018-10-15T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d3849df93",
       "bills": [
         "io.cozy.bills:b4"
@@ -1189,7 +1189,7 @@
       "label": "CPAM PARIS",
       "currency": "€",
       "amount": 17.5,
-      "date": "2018-10-17T00:00:00Z",
+      "date": "{{ freshDate '2018-10-17T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fd1eb",
       "bills": [
         "io.cozy.bills:bill_cpam_demo"
@@ -1202,7 +1202,7 @@
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
       "amount": -1231,
-      "date": "2018-10-17T00:00:00Z",
+      "date": "{{ freshDate '2018-10-17T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e0504963"
     },
     {
@@ -1212,7 +1212,7 @@
       "label": "FRANCK PROVOST MONCEAU",
       "currency": "€",
       "amount": -36,
-      "date": "2018-10-17T00:00:00Z",
+      "date": "{{ freshDate '2018-10-17T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e05017b4",
       "bill": "io.cozy.:avrilrembourcomplisa2"
     },
@@ -1223,7 +1223,7 @@
       "label": "FNAC TERNES",
       "currency": "€",
       "amount": -26,
-      "date": "2018-10-17T00:00:00Z",
+      "date": "{{ freshDate '2018-10-17T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384988ad",
       "action": {
         "target": "_blank",
@@ -1239,7 +1239,7 @@
       "label": "KAISER BOULANGERIE",
       "currency": "€",
       "amount": -9.4,
-      "date": "2018-10-18T00:00:00Z",
+      "date": "{{ freshDate '2018-10-18T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04fa4fc"
     },
     {
@@ -1249,7 +1249,7 @@
       "label": "DOCTEUR LEFEBVRE",
       "currency": "€",
       "amount": -43,
-      "date": "2018-10-18T00:00:00Z",
+      "date": "{{ freshDate '2018-10-18T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f682c"
     },
     {
@@ -1259,7 +1259,7 @@
       "label": "Vente-Privée.com",
       "currency": "EUR",
       "amount": -78.35,
-      "date": "2018-10-18T22:00:00.000Z",
+      "date": "{{ freshDate '2018-10-18T22:00:00.000Z' }}",
       "_id": "demo_venteprivee",
       "bills": [
         "io.cozy.bills:demo_venteprivee"
@@ -1276,7 +1276,7 @@
       "label": "VIREMENT COMPL SANTE",
       "currency": "€",
       "amount": 7.5,
-      "date": "2018-10-19T00:00:00Z",
+      "date": "{{ freshDate '2018-10-19T00:00:00Z' }}",
       "bills": [
         "io.cozy.bills:bill_harmonie_demo"
       ]
@@ -1288,7 +1288,7 @@
       "label": "Docteur Martin",
       "currency": "€",
       "amount": -25,
-      "date": "2018-10-19T00:00:00Z",
+      "date": "{{ freshDate '2018-10-19T00:00:00Z' }}",
       "_id": "paiementdocteur",
       "reimbursements": [
         {
@@ -1311,7 +1311,7 @@
       "label": "BOUYGUES TELECOM MONTHLY SUBSCRIPTION",
       "currency": "€",
       "amount": -44.9,
-      "date": "2018-10-19T00:00:00Z",
+      "date": "{{ freshDate '2018-10-19T00:00:00Z' }}",
       "bills": [
         "io.cozy.bills:b2"
       ]
@@ -1323,7 +1323,7 @@
       "label": "RETRAIT BNPPARIBAS 2018-10-19",
       "currency": "€",
       "amount": -20,
-      "date": "2018-10-19T00:00:00Z",
+      "date": "{{ freshDate '2018-10-19T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a5915"
     },
     {
@@ -1333,7 +1333,7 @@
       "label": "Free Telecom january subs",
       "currency": "€",
       "amount": -34.9,
-      "date": "2018-10-20T00:00:00Z",
+      "date": "{{ freshDate '2018-10-20T00:00:00Z' }}",
       "bills": [
         "io.cozy.bills:b2"
       ],
@@ -1346,7 +1346,7 @@
       "label": "FRANCE MENAGE MONTLY SUBSCRIPTION",
       "currency": "€",
       "amount": -40,
-      "date": "2018-10-20T00:00:00Z",
+      "date": "{{ freshDate '2018-10-20T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354ad158"
     },
     {
@@ -1355,7 +1355,7 @@
       "amount": -120.11,
       "automaticCategoryId": "401080",
       "currency": "€",
-      "date": "2018-10-20T00:00:00Z",
+      "date": "{{ freshDate '2018-10-20T00:00:00Z' }}",
       "label": "EDF CLIENTS PARTICULIERS",
       "bills": [
         "io.cozy.bills:7a8cefd5a1ac1a5aecf862482df0225c"
@@ -1368,7 +1368,7 @@
       "label": "FRANPRIX",
       "currency": "€",
       "amount": -48.22,
-      "date": "2018-10-21T00:00:00Z",
+      "date": "{{ freshDate '2018-10-21T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354ae98d"
     },
     {
@@ -1378,7 +1378,7 @@
       "label": "H&M",
       "currency": "€",
       "amount": -42.89,
-      "date": "2018-10-21T00:00:00Z",
+      "date": "{{ freshDate '2018-10-21T00:00:00Z' }}",
       "_id": "c5d3364d147d8dc5da80fc9e354aa327"
     },
     {
@@ -1388,7 +1388,7 @@
       "label": "PAYSLIP TESLA DURAND JANUARY 2018",
       "currency": "€",
       "amount": 3870.54,
-      "date": "2018-10-21T00:00:00Z",
+      "date": "{{ freshDate '2018-10-21T00:00:00Z' }}",
       "_id": "4bbfe1f845ad1231c7d07aa3e04f8344",
       "action": {
         "target": "_blank",
@@ -1404,7 +1404,7 @@
       "label": "Bouygues Telecom",
       "currency": "€",
       "amount": -44.90,
-      "date": "2018-10-21T00:00:00Z",
+      "date": "{{ freshDate '2018-10-21T00:00:00Z' }}",
       "_id": "446ae26d705b2eb461ca264d384a6ee6",
       "bills": [
         "io.cozy.bills:b2"
@@ -1416,14 +1416,14 @@
       "label": "Salaire novembre 2018",
       "currency": "€",
       "amount": 3870.54,
-      "date": "2018-11-01T00:00:00Z"
+      "date": "{{ freshDate '2018-11-01T00:00:00Z' }}"
     },
     {
       "account": "compteisa1",
       "amount": -80,
       "automaticCategoryId": "400410",
       "currency": "€",
-      "date": "2018-11-01T00:00:00Z",
+      "date": "{{ freshDate '2018-11-01T00:00:00Z' }}",
       "label": "ARGENT DE POCHE"
     },
     {
@@ -1431,7 +1431,7 @@
       "amount": -120.44,
       "automaticCategoryId": "400420",
       "currency": "€",
-      "date": "2018-11-01T00:00:00Z",
+      "date": "{{ freshDate '2018-11-01T00:00:00Z' }}",
       "label": "CANTINE SCOLAIRE"
     },
     {
@@ -1439,7 +1439,7 @@
       "amount": 80,
       "automaticCategoryId": "400180",
       "currency": "€",
-      "date": "2018-11-02T00:00:00Z",
+      "date": "{{ freshDate '2018-11-02T00:00:00Z' }}",
       "label": "ARGENT DE POCHE"
     },
     {
@@ -1447,7 +1447,7 @@
       "amount": 400,
       "automaticCategoryId": "600110",
       "currency": "€",
-      "date": "2018-11-03T00:00:00Z",
+      "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
       "label": "TRANSFERT LIVRET A"
     },
     {
@@ -1455,7 +1455,7 @@
       "amount": -22.12,
       "automaticCategoryId": "400290",
       "currency": "€",
-      "date": "2018-11-03T00:00:00Z",
+      "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
       "label": "UBER"
     },
     {
@@ -1463,7 +1463,7 @@
       "amount": -400,
       "automaticCategoryId": "600110",
       "currency": "€",
-      "date": "2018-11-03T00:00:00Z",
+      "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
       "label": "TRANSFERT LIVRET A"
     },
     {
@@ -1471,7 +1471,7 @@
       "amount": -42.3,
       "automaticCategoryId": "400110",
       "currency": "€",
-      "date": "2018-11-04T00:00:00Z",
+      "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
       "label": "AUCHAN"
     },
     {
@@ -1479,7 +1479,7 @@
       "amount": -7.5,
       "automaticCategoryId": "400620",
       "currency": "€",
-      "date": "2018-11-04T00:00:00Z",
+      "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
       "label": "Generali remboursement médecin"
     },
     {
@@ -1487,7 +1487,7 @@
       "amount": -100,
       "automaticCategoryId": "300",
       "currency": "€",
-      "date": "2018-11-04T00:00:00Z",
+      "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
       "label": "RETRAIT CREDIT AGRICOLE"
     },
     {
@@ -1495,7 +1495,7 @@
       "amount": -20,
       "automaticCategoryId": "300",
       "currency": "€",
-      "date": "2018-11-04T00:00:00Z",
+      "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
       "label": "RETRAIT BNPPARIBAS"
     },
     {
@@ -1503,7 +1503,7 @@
       "amount": -62.3,
       "automaticCategoryId": "400110",
       "currency": "€",
-      "date": "2018-11-06T00:00:00Z",
+      "date": "{{ freshDate '2018-11-06T00:00:00Z' }}",
       "label": "CARREFOUR MARKET"
     },
     {
@@ -1511,7 +1511,7 @@
       "amount": -18.22,
       "automaticCategoryId": "400420",
       "currency": "€",
-      "date": "2018-11-07T00:00:00Z",
+      "date": "{{ freshDate '2018-11-07T00:00:00Z' }}",
       "label": "FRANPRIX"
     },
     {
@@ -1519,7 +1519,7 @@
       "amount": -78.54,
       "automaticCategoryId": "400810",
       "currency": "€",
-      "date": "2018-11-08T00:00:00Z",
+      "date": "{{ freshDate '2018-11-08T00:00:00Z' }}",
       "label": "LA BELLE ASSIETTE"
     },
     {
@@ -1527,7 +1527,7 @@
       "amount": -117,
       "automaticCategoryId": "{{ categoryId 'goingOutAndTravel' }}",
       "currency": "€",
-      "date": "2018-11-08T00:00:00Z",
+      "date": "{{ freshDate '2018-11-08T00:00:00Z' }}",
       "label": "Sncf"
     },
     {
@@ -1535,7 +1535,7 @@
       "amount": -30,
       "automaticCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
-      "date": "2018-11-11T00:00:00Z",
+      "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
       "label": "Free Mobile"
     },
     {
@@ -1543,7 +1543,7 @@
       "amount": -80.44,
       "automaticCategoryId": "400180",
       "currency": "€",
-      "date": "2018-11-11T00:00:00Z",
+      "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
       "label": "FNAC TERNES"
     },
     {
@@ -1551,7 +1551,7 @@
       "amount": -98.22,
       "automaticCategoryId": "400420",
       "currency": "€",
-      "date": "2018-11-11T00:00:00Z",
+      "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
       "label": "FRANPRIX"
     },
     {
@@ -1559,7 +1559,7 @@
       "amount": -7.5,
       "automaticCategoryId": "400740",
       "currency": "€",
-      "date": "2018-11-12T00:00:00Z",
+      "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
       "label": "GAUMONTPARNASSE"
     },
     {
@@ -1567,7 +1567,7 @@
       "amount": -165.3,
       "automaticCategoryId": "400110",
       "currency": "€",
-      "date": "2018-11-12T00:00:00Z",
+      "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
       "label": "CARREFOUR MARKET"
     },
     {
@@ -1575,7 +1575,7 @@
       "amount": -8.5,
       "automaticCategoryId": "400810",
       "currency": "€",
-      "date": "2018-11-12T00:00:00Z",
+      "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
       "label": "MC DONALDS"
     },
     {
@@ -1583,7 +1583,7 @@
       "amount": -42.89,
       "automaticCategoryId": "400130",
       "currency": "€",
-      "date": "2018-11-13T00:00:00Z",
+      "date": "{{ freshDate '2018-11-13T00:00:00Z' }}",
       "label": "LA REDOUTE"
     },
     {
@@ -1591,7 +1591,7 @@
       "amount": -73.5,
       "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
-      "date": "2018-11-13T00:00:00Z",
+      "date": "{{ freshDate '2018-11-13T00:00:00Z' }}",
       "label": "Leclerc Drive"
     },
     {
@@ -1599,7 +1599,7 @@
       "amount": -8.09,
       "automaticCategoryId": "400290",
       "currency": "€",
-      "date": "2018-11-14T00:00:00Z",
+      "date": "{{ freshDate '2018-11-14T00:00:00Z' }}",
       "label": "UBER"
     },
     {
@@ -1607,7 +1607,7 @@
       "amount": -65.3,
       "automaticCategoryId": "400110",
       "currency": "€",
-      "date": "2018-11-14T00:00:00Z",
+      "date": "{{ freshDate '2018-11-14T00:00:00Z' }}",
       "label": "CARREFOUR CITY"
     },
     {
@@ -1615,7 +1615,7 @@
       "amount": -27.9,
       "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
-      "date": "2018-11-15T00:00:00Z",
+      "date": "{{ freshDate '2018-11-15T00:00:00Z' }}",
       "label": "Just Eat"
     },
     {
@@ -1623,7 +1623,7 @@
       "amount": -36,
       "automaticCategoryId": "400130",
       "currency": "€",
-      "date": "2018-11-17T00:00:00Z",
+      "date": "{{ freshDate '2018-11-17T00:00:00Z' }}",
       "label": "FRANCK PROVOST MONCEAU"
     },
     {
@@ -1631,7 +1631,7 @@
       "amount": -1231,
       "automaticCategoryId": "400750",
       "currency": "€",
-      "date": "2018-11-17T00:00:00Z",
+      "date": "{{ freshDate '2018-11-17T00:00:00Z' }}",
       "label": "REMBOURSEMENT PRET LCL"
     },
     {
@@ -1639,7 +1639,7 @@
       "amount": -20,
       "automaticCategoryId": "300",
       "currency": "€",
-      "date": "2018-11-19T00:00:00Z",
+      "date": "{{ freshDate '2018-11-19T00:00:00Z' }}",
       "label": "RETRAIT BNPPARIBAS 2018-10-19"
     },
     {
@@ -1647,7 +1647,7 @@
       "amount": -11.9,
       "automaticCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
       "currency": "€",
-      "date": "2018-11-20T00:00:00Z",
+      "date": "{{ freshDate '2018-11-20T00:00:00Z' }}",
       "label": "Netflix"
     },
     {
@@ -1655,7 +1655,7 @@
       "amount": -40,
       "automaticCategoryId": "400330",
       "currency": "€",
-      "date": "2018-11-20T00:00:00Z",
+      "date": "{{ freshDate '2018-11-20T00:00:00Z' }}",
       "label": "FRANCE MENAGE MONTLY SUBSCRIPTION"
     },
     {
@@ -1663,7 +1663,7 @@
       "amount": -42.89,
       "automaticCategoryId": "400130",
       "currency": "€",
-      "date": "2018-11-21T00:00:00Z",
+      "date": "{{ freshDate '2018-11-21T00:00:00Z' }}",
       "label": "H&M"
     },
     {
@@ -1671,7 +1671,7 @@
       "amount": -48.22,
       "automaticCategoryId": "400420",
       "currency": "€",
-      "date": "2018-11-21T00:00:00Z",
+      "date": "{{ freshDate '2018-11-21T00:00:00Z' }}",
       "label": "FRANPRIX ST LAZARE PR"
     },
     {
@@ -1679,26 +1679,8 @@
       "amount": -9.9,
       "automaticCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
-      "date": "2018-11-23T00:00:00Z",
+      "date": "{{ freshDate '2018-11-23T00:00:00Z' }}",
       "label": "Sosh"
-    },
-    {
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
-      "account": "comptelea1",
-      "label": "Sosh",
-      "currency": "€",
-      "amount": -60,
-      "date": "2019-02-28T00:00:00Z",
-      "realisationDate": "2019-02-04T00:00:00Z"
-    },
-    {
-      "automaticCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
-      "account": "comptelea1",
-      "label": "Fnac",
-      "currency": "€",
-      "amount": -190.92,
-      "date": "2019-02-28T00:00:00Z",
-      "realisationDate": "2019-02-05T00:00:00Z"
     }
   ],
   "io.cozy.bills": [

--- a/test/fixtures/helpers/freshDate.js
+++ b/test/fixtures/helpers/freshDate.js
@@ -1,0 +1,30 @@
+const demoFixtures = require('../demo.json')
+const last = require('lodash/last')
+const differenceInDays = require('date-fns/difference_in_days')
+const addDays = require('date-fns/add_days')
+
+const getMostRecentDate = dates => {
+  const sorted = dates.sort()
+  return new Date(last(sorted))
+}
+
+const stripHelperCall = str =>
+  str.replace(/{{ freshDate '(.*)' }}/g, (_, date) => date)
+
+const getDemoFixtures = () => demoFixtures['io.cozy.bank.operations']
+
+const allDates = getDemoFixtures().map(tr => stripHelperCall(tr.date))
+const mostRecentDate = getMostRecentDate(allDates)
+const today = new Date()
+const difference = differenceInDays(today, mostRecentDate)
+
+const freshDate = originalDate => {
+  const newDate = addDays(originalDate, difference)
+  return newDate.toISOString()
+}
+
+module.exports = {
+  getMostRecentDate,
+  stripHelperCall,
+  freshDate
+}

--- a/test/fixtures/helpers/freshDate.spec.js
+++ b/test/fixtures/helpers/freshDate.spec.js
@@ -1,0 +1,24 @@
+const { getMostRecentDate, stripHelperCall } = require('./freshDate')
+
+describe('getMostRecentDate', () => {
+  it('should return the most recent date', () => {
+    const dates = [
+      '2018-08-06T00:00:00Z',
+      '2018-09-06T00:00:00Z',
+      '2018-10-06T00:00:00Z',
+      '2019-01-06T00:00:00Z',
+      '2019-02-06T00:00:00Z',
+      '2018-12-06T00:00:00Z',
+      '2018-11-06T00:00:00Z'
+    ]
+
+    expect(getMostRecentDate(dates)).toEqual(new Date('2019-02-06T00:00:00Z'))
+  })
+})
+
+describe('stripHelperCall', () => {
+  it('should strip the handlebars helper call to return just the date argument', () => {
+    const str = "{{ freshDate '2019-02-22T00:00:00Z' }}"
+    expect(stripHelperCall(str)).toBe('2019-02-22T00:00:00Z')
+  })
+})

--- a/test/fixtures/helpers/index.js
+++ b/test/fixtures/helpers/index.js
@@ -1,4 +1,4 @@
-const categoryNameToId = inverseObject(require('./linxo-categories'))
+const categoryNameToId = inverseObject(require('../linxo-categories'))
 
 module.exports = {
   helpers: {

--- a/test/fixtures/helpers/index.js
+++ b/test/fixtures/helpers/index.js
@@ -1,10 +1,12 @@
+const { freshDate } = require('./freshDate')
 const categoryNameToId = inverseObject(require('../linxo-categories'))
 
 module.exports = {
   helpers: {
     categoryId: function(catName) {
       return categoryNameToId[catName]
-    }
+    },
+    freshDate
   }
 }
 


### PR DESCRIPTION
This helper's role is to take dates in the past and refresh them. For now it works only for the `demo.json` transactions fixtures, and it works like this:

* Take the latest transaction date
* Get the difference in days between this date and today
* Apply this difference to all transactions

This way, if the latest transaction date is 2019-02-01 and we are currently 2019-02-25, the difference is 24 days. 2019-02-01 becomes 2019-02-25 and 24 days are added to all other transaction dates.