### PR TITLE
Always show "today" as account last update date when demo flag is enabled

### DIFF
--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -101,3 +101,14 @@ export const getAccountBalance = account => {
 
   return account.balance
 }
+
+export const getAccountUpdatedAt = account => {
+  const today = new Date()
+  const updateDistance = getAccountUpdateDateDistance(account, today)
+  const updateDistanceInWords = distanceInWords(updateDistance)
+
+  return {
+    translateKey: updateDistanceInWords,
+    params: { nbDays: updateDistance }
+  }
+}

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -1,5 +1,6 @@
 import { get } from 'lodash'
 import { differenceInCalendarDays } from 'date-fns'
+import flag from 'cozy-flags'
 
 const PARTS_TO_DELETE = ['(sans Secure Key)']
 
@@ -103,6 +104,12 @@ export const getAccountBalance = account => {
 }
 
 export const getAccountUpdatedAt = account => {
+  if (flag('demo')) {
+    return {
+      translateKey: distanceInWords(0),
+      params: { nbDays: 0 }
+    }
+  }
   const today = new Date()
   const updateDistance = getAccountUpdateDateDistance(account, today)
   const updateDistanceInWords = distanceInWords(updateDistance)

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -8,8 +8,7 @@ import { translate, Icon } from 'cozy-ui/react'
 import { Figure } from 'components/Figure'
 import {
   getAccountLabel,
-  getAccountUpdateDateDistance,
-  distanceInWords,
+  getAccountUpdatedAt,
   getAccountInstitutionLabel,
   getAccountInstitutionSlug,
   getAccountBalance
@@ -47,12 +46,7 @@ class AccountRow extends React.PureComponent {
       id
     } = this.props
 
-    const today = new Date()
-    const updateDistance = getAccountUpdateDateDistance(account, today)
-    const updatedAt = t(distanceInWords(updateDistance), {
-      nbDays: updateDistance
-    })
-
+    const updatedAt = getAccountUpdatedAt(account)
     const hasWarning = account.balance < warningLimit
     const hasAlert = account.balance < 0
     const institutionSlug = getAccountInstitutionSlug(account)
@@ -76,7 +70,8 @@ class AccountRow extends React.PureComponent {
             </div>
             <div
               className={cx(styles.AccountRow__updatedAt, {
-                [styles['AccountRow__updatedAt--old']]: updateDistance > 1
+                [styles['AccountRow__updatedAt--old']]:
+                  updatedAt.params.nbDays > 1
               })}
             >
               <Icon
@@ -85,7 +80,7 @@ class AccountRow extends React.PureComponent {
                 color="currentColor"
                 className={styles.AccountRow__updatedAtIcon}
               />
-              {updatedAt}
+              {t(updatedAt.translateKey, updatedAt.params)}
             </div>
           </div>
         </div>


### PR DESCRIPTION
The title says it all. You can test it on https://testbanksdemoaccountupdatedat-banks.cozy.works by activating the `demo` flag: `flag('demo', true)`