### PR TITLE
feat(TransactionRow): Add show-transactions-ids flag

### DIFF
--- a/src/components/List/index.jsx
+++ b/src/components/List/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import styles from './List.styl'
 import { ListItemText } from 'cozy-ui/react'
+import cx from 'classnames'
 
 export const List = props => <div>{props.children}</div>
 
@@ -8,10 +9,8 @@ export const Header = ({ children }) => (
   <div className={styles['c-list-header']}>{children}</div>
 )
 
-export const Row = props => (
-  <div ref={props.onRef} className={styles['c-list-row']}>
-    {props.children}
-  </div>
+export const Row = ({ className, onRef, ...rest }) => (
+  <div ref={onRef} className={cx(styles['c-list-row'], className)} {...rest} />
 )
 
 export const Content = ListItemText

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -78,14 +78,10 @@ class _RowDesktop extends React.PureComponent {
 
     const account = transaction.account.data
     const accountInstitutionLabel = getAccountInstitutionLabel(account)
+    const trRest = flag('show-transactions-ids') ? { id: transaction._id } : {}
+
     return (
-      <tr
-        ref={onRef}
-        className={cx({
-          [styles['TransactionRow--withId']]: flag('show-transactions-ids')
-        })}
-        id={transaction._id}
-      >
+      <tr ref={onRef} {...trRest}>
         <td className={cx(styles.ColumnSizeDesc, 'u-pv-half', 'u-pl-1')}>
           <Media className="u-clickable">
             <Img title={categoryTitle} onClick={showCategoryChoice}>
@@ -158,15 +154,10 @@ class _RowMobile extends React.PureComponent {
     } = this.props
     const account = transaction.account.data
     const accountInstitutionLabel = getAccountInstitutionLabel(account)
+    const rowRest = flag('show-transactions-ids') ? { id: transaction._id } : {}
 
     return (
-      <List.Row
-        onRef={onRef}
-        className={cx({
-          [styles['TransactionRow--withId']]: flag('show-transactions-ids')
-        })}
-        id={transaction._id}
-      >
+      <List.Row onRef={onRef} {...rowRest}>
         <Media className="u-full-width">
           <Img
             className="u-clickable u-mr-half"

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -4,6 +4,7 @@ import cx from 'classnames'
 import compose from 'lodash/flowRight'
 
 import { translate, Media, Bd, Img, Caption, Text } from 'cozy-ui/react'
+import flag from 'cozy-flags'
 
 import { Figure } from 'components/Figure'
 import { TdSecondary } from 'components/Table'
@@ -78,7 +79,13 @@ class _RowDesktop extends React.PureComponent {
     const account = transaction.account.data
     const accountInstitutionLabel = getAccountInstitutionLabel(account)
     return (
-      <tr ref={onRef}>
+      <tr
+        ref={onRef}
+        className={cx({
+          [styles['TransactionRow--withId']]: flag('show-transactions-ids')
+        })}
+        id={transaction._id}
+      >
         <td className={cx(styles.ColumnSizeDesc, 'u-pv-half', 'u-pl-1')}>
           <Media className="u-clickable">
             <Img title={categoryTitle} onClick={showCategoryChoice}>
@@ -153,7 +160,13 @@ class _RowMobile extends React.PureComponent {
     const accountInstitutionLabel = getAccountInstitutionLabel(account)
 
     return (
-      <List.Row onRef={onRef}>
+      <List.Row
+        onRef={onRef}
+        className={cx({
+          [styles['TransactionRow--withId']]: flag('show-transactions-ids')
+        })}
+        id={transaction._id}
+      >
         <Media className="u-full-width">
           <Img
             className="u-clickable u-mr-half"

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -74,6 +74,20 @@ for category in categories
         icon = '../../assets/icons/categories/icon-cat-%s.svg' % category
         background-image embedurl(icon) // @stylint ignore
 
+.TransactionRow--withId
+    position relative
+
+    &::before
+        content attr(id)
+        position absolute
+        top 0
+        left 0
+        padding 0 2px
+        background-color grey
+        color white
+        font-size 0.75rem
+        z-index 1
+
 +medium-screen()
     .c-table-body .c-table-row
         font-size 0.8em

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -74,20 +74,6 @@ for category in categories
         icon = '../../assets/icons/categories/icon-cat-%s.svg' % category
         background-image embedurl(icon) // @stylint ignore
 
-.TransactionRow--withId
-    position relative
-
-    &::before
-        content attr(id)
-        position absolute
-        top 0
-        left 0
-        padding 0 2px
-        background-color grey
-        color white
-        font-size 0.75rem
-        z-index 1
-
 +medium-screen()
     .c-table-body .c-table-row
         font-size 0.8em


### PR DESCRIPTION
By enabling this flag, the id of each transaction is shown. This is
useful for debug purposes.

Particularly, since demo fixtures transactions dates are now dynamic, it can be hard to mentally do the link between a transaction shown in the app and a transaction in the JSON file. With this, we can link them using the ID, which is more straightforward.

![image](https://user-images.githubusercontent.com/1606068/53415614-f998ce80-39d1-11e9-9867-4975fe3f2427.png)

![image](https://user-images.githubusercontent.com/1606068/53415638-04536380-39d2-11e9-8ba0-66dc99a45b90.png)
