### PR TITLE
Release 0.13.0

### DIFF
--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
@@ -12,7 +12,11 @@ const HEALTH_VENDORS = [
   'Harmonie',
   'Malakoff Mederic',
   'MGEN',
-  'Generali'
+  'Generali',
+  'ascoreSante',
+  'EoviMCD',
+  'Humanis',
+  'Alan'
 ] // TODO: to import from each konnector
 const HEALTH_EXPENSE_CAT = '400610'
 const HEALTH_INSURANCE_CAT = '400620'

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
@@ -16,7 +16,8 @@ const HEALTH_VENDORS = [
   'ascoreSante',
   'EoviMCD',
   'Humanis',
-  'Alan'
+  'Alan',
+  'lamutuellegenerale'
 ] // TODO: to import from each konnector
 const HEALTH_EXPENSE_CAT = '400610'
 const HEALTH_INSURANCE_CAT = '400620'

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -202,11 +202,6 @@
     "konnectorSlug": "opngo"
   },
   {
-    "name": "Orange Factures",
-    "regexp": "\\borange\\b",
-    "konnectorSlug": "orange"
-  },
-  {
     "name": "OVH",
     "regexp": "\\bovh\\b",
     "konnectorSlug": "ovh"
@@ -235,11 +230,6 @@
     "name": "Showroom Privé",
     "regexp": "\\bshowroomprive\\b",
     "konnectorSlug": "showroomprive"
-  },
-  {
-    "name": "Sosh",
-    "regexp": "\\b(sosh|orange)\\b",
-    "konnectorSlug": "sosh"
   },
   {
     "name": "Spartoo",

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -5,7 +5,9 @@
   <title>Cozy Banks</title>
   <% if (__TARGET__ !== 'mobile') { %>
   {{.ThemeCSS}}
-  {{.Favicon}}
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
   <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
   <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#16B52D">
   <% } %>

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="130001" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.13.0.1" version="0.13.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="130002" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.13.0.2" version="0.13.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="130002" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.13.0.2" version="0.13.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="130004" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="0.13.0.4" version="0.13.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -1423,7 +1423,8 @@
       "label": "Salaire novembre 2018",
       "currency": "€",
       "amount": 3870.54,
-      "date": "{{ freshDate '2018-11-01T00:00:00Z' }}"
+      "date": "{{ freshDate '2018-11-01T00:00:00Z' }}",
+      "_id": "isa_salaire_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1431,7 +1432,8 @@
       "automaticCategoryId": "400410",
       "currency": "€",
       "date": "{{ freshDate '2018-11-01T00:00:00Z' }}",
-      "label": "ARGENT DE POCHE"
+      "label": "ARGENT DE POCHE",
+      "_id": "isa_argent_de_poche_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1439,7 +1441,8 @@
       "automaticCategoryId": "400420",
       "currency": "€",
       "date": "{{ freshDate '2018-11-01T00:00:00Z' }}",
-      "label": "CANTINE SCOLAIRE"
+      "label": "CANTINE SCOLAIRE",
+      "_id": "isa_cantine_scolaire_nov_2018"
     },
     {
       "account": "comptelou1",
@@ -1447,7 +1450,8 @@
       "automaticCategoryId": "400180",
       "currency": "€",
       "date": "{{ freshDate '2018-11-02T00:00:00Z' }}",
-      "label": "ARGENT DE POCHE"
+      "label": "ARGENT DE POCHE",
+      "_id": "lou_argent_de_poche_nov_2018"
     },
     {
       "account": "compteisa3",
@@ -1455,7 +1459,8 @@
       "automaticCategoryId": "600110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
-      "label": "TRANSFERT LIVRET A"
+      "label": "TRANSFERT LIVRET A",
+      "_id": "isa_transfert_livret_a_credit_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1463,7 +1468,8 @@
       "automaticCategoryId": "400290",
       "currency": "€",
       "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
-      "label": "UBER"
+      "label": "UBER",
+      "_id": "isa_uber_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1471,7 +1477,8 @@
       "automaticCategoryId": "600110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-03T00:00:00Z' }}",
-      "label": "TRANSFERT LIVRET A"
+      "label": "TRANSFERT LIVRET A",
+      "_id": "isa_transfert_livret_a_debit_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1479,7 +1486,8 @@
       "automaticCategoryId": "400110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
-      "label": "AUCHAN"
+      "label": "AUCHAN",
+      "_id": "gene_auchan_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1487,7 +1495,8 @@
       "automaticCategoryId": "400620",
       "currency": "€",
       "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
-      "label": "Generali remboursement médecin"
+      "label": "Generali remboursement médecin",
+      "_id": "isa_generali_remb_medecin_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1495,7 +1504,8 @@
       "automaticCategoryId": "300",
       "currency": "€",
       "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
-      "label": "RETRAIT CREDIT AGRICOLE"
+      "label": "RETRAIT CREDIT AGRICOLE",
+      "_id": "gene_retrait_credit_agricole_nov_2018"
     },
     {
       "account": "comptelou1",
@@ -1503,7 +1513,8 @@
       "automaticCategoryId": "300",
       "currency": "€",
       "date": "{{ freshDate '2018-11-04T00:00:00Z' }}",
-      "label": "RETRAIT BNPPARIBAS"
+      "label": "RETRAIT BNPPARIBAS",
+      "_id": "lou_retrait_bnpparibas_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1511,7 +1522,8 @@
       "automaticCategoryId": "400110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-06T00:00:00Z' }}",
-      "label": "CARREFOUR MARKET"
+      "label": "CARREFOUR MARKET",
+      "_id": "isa_carrefour_market_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1519,7 +1531,8 @@
       "automaticCategoryId": "400420",
       "currency": "€",
       "date": "{{ freshDate '2018-11-07T00:00:00Z' }}",
-      "label": "FRANPRIX"
+      "label": "FRANPRIX",
+      "_id": "gene_franprix_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1527,7 +1540,8 @@
       "automaticCategoryId": "400810",
       "currency": "€",
       "date": "{{ freshDate '2018-11-08T00:00:00Z' }}",
-      "label": "LA BELLE ASSIETTE"
+      "label": "LA BELLE ASSIETTE",
+      "_id": "isa_la_belle_assiette_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1535,7 +1549,8 @@
       "automaticCategoryId": "{{ categoryId 'goingOutAndTravel' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-08T00:00:00Z' }}",
-      "label": "Sncf"
+      "label": "Sncf",
+      "_id": "isa_sncf_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1543,7 +1558,8 @@
       "automaticCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
-      "label": "Free Mobile"
+      "label": "Free Mobile",
+      "_id": "isa_free_mobile_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1551,7 +1567,8 @@
       "automaticCategoryId": "400180",
       "currency": "€",
       "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
-      "label": "FNAC TERNES"
+      "label": "FNAC TERNES",
+      "_id": "gene_fnac_ternes_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1559,7 +1576,8 @@
       "automaticCategoryId": "400420",
       "currency": "€",
       "date": "{{ freshDate '2018-11-11T00:00:00Z' }}",
-      "label": "FRANPRIX"
+      "label": "FRANPRIX",
+      "_id": "isa_franprix_nov_2018"
     },
     {
       "account": "comptelou1",
@@ -1567,7 +1585,8 @@
       "automaticCategoryId": "400740",
       "currency": "€",
       "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
-      "label": "GAUMONTPARNASSE"
+      "label": "GAUMONTPARNASSE",
+      "_id": "lou_gaumontparnasse_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1575,7 +1594,8 @@
       "automaticCategoryId": "400110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
-      "label": "CARREFOUR MARKET"
+      "label": "CARREFOUR MARKET",
+      "_id": "isa_carrefour_market_nov_2018"
     },
     {
       "account": "comptelou1",
@@ -1583,7 +1603,8 @@
       "automaticCategoryId": "400810",
       "currency": "€",
       "date": "{{ freshDate '2018-11-12T00:00:00Z' }}",
-      "label": "MC DONALDS"
+      "label": "MC DONALDS",
+      "_id": "lou_mc_donalds_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1591,7 +1612,8 @@
       "automaticCategoryId": "400130",
       "currency": "€",
       "date": "{{ freshDate '2018-11-13T00:00:00Z' }}",
-      "label": "LA REDOUTE"
+      "label": "LA REDOUTE",
+      "_id": "gene_la_redoute_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1599,7 +1621,8 @@
       "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-13T00:00:00Z' }}",
-      "label": "Leclerc Drive"
+      "label": "Leclerc Drive",
+      "_id": "isa_leclerc_drive_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1607,7 +1630,8 @@
       "automaticCategoryId": "400290",
       "currency": "€",
       "date": "{{ freshDate '2018-11-14T00:00:00Z' }}",
-      "label": "UBER"
+      "label": "UBER",
+      "_id": "isa_uber2_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1615,7 +1639,8 @@
       "automaticCategoryId": "400110",
       "currency": "€",
       "date": "{{ freshDate '2018-11-14T00:00:00Z' }}",
-      "label": "CARREFOUR CITY"
+      "label": "CARREFOUR CITY",
+      "_id": "gene_carrefour_city_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1623,7 +1648,8 @@
       "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-15T00:00:00Z' }}",
-      "label": "Just Eat"
+      "label": "Just Eat",
+      "_id": "isa_just_eat_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1631,7 +1657,8 @@
       "automaticCategoryId": "400130",
       "currency": "€",
       "date": "{{ freshDate '2018-11-17T00:00:00Z' }}",
-      "label": "FRANCK PROVOST MONCEAU"
+      "label": "FRANCK PROVOST MONCEAU",
+      "_id": "isa_franck_provost_monceau_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1639,7 +1666,8 @@
       "automaticCategoryId": "400750",
       "currency": "€",
       "date": "{{ freshDate '2018-11-17T00:00:00Z' }}",
-      "label": "REMBOURSEMENT PRET LCL"
+      "label": "REMBOURSEMENT PRET LCL",
+      "_id": "isa_remboursement_pret_lcl_nov_2018"
     },
     {
       "account": "comptelou1",
@@ -1647,7 +1675,8 @@
       "automaticCategoryId": "300",
       "currency": "€",
       "date": "{{ freshDate '2018-11-19T00:00:00Z' }}",
-      "label": "RETRAIT BNPPARIBAS 2018-10-19"
+      "label": "RETRAIT BNPPARIBAS 2018-10-19",
+      "_id": "lou_retrait_bnpparibas_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1655,7 +1684,8 @@
       "automaticCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-20T00:00:00Z' }}",
-      "label": "Netflix"
+      "label": "Netflix",
+      "_id": "isa_netflix_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1663,7 +1693,8 @@
       "automaticCategoryId": "400330",
       "currency": "€",
       "date": "{{ freshDate '2018-11-20T00:00:00Z' }}",
-      "label": "FRANCE MENAGE MONTLY SUBSCRIPTION"
+      "label": "FRANCE MENAGE MONTLY SUBSCRIPTION",
+      "_id": "gene_france_menage_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1671,7 +1702,8 @@
       "automaticCategoryId": "400130",
       "currency": "€",
       "date": "{{ freshDate '2018-11-21T00:00:00Z' }}",
-      "label": "H&M"
+      "label": "H&M",
+      "_id": "isa_hm_nov_2018"
     },
     {
       "account": "comptegene1",
@@ -1679,7 +1711,8 @@
       "automaticCategoryId": "400420",
       "currency": "€",
       "date": "{{ freshDate '2018-11-21T00:00:00Z' }}",
-      "label": "FRANPRIX ST LAZARE PR"
+      "label": "FRANPRIX ST LAZARE PR",
+      "_id": "gene_franprix_st_lazare_pr_nov_2018"
     },
     {
       "account": "compteisa1",
@@ -1687,7 +1720,8 @@
       "automaticCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
       "date": "{{ freshDate '2018-11-23T00:00:00Z' }}",
-      "label": "Sosh"
+      "label": "Sosh",
+      "_id": "isa_sosh_nov_2018"
     }
   ],
   "io.cozy.bills": [


### PR DESCRIPTION
- [x] Create branch and the PR with the following content
- [x] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode` and `ios-CFBundleVersion`.
- [ ] Write changelogs
  - [ ] Android: `src/targets/mobile/fastlane/metadata/android/{lang}/changelogs/ANDROID_VERSION.txt` (⚠️ ANDROID_VERSION should match `android-versionCode` in `config.xml`)
  - [ ] iOS : `src/targets/mobile/fastlane/metadata/ios/{lang}/release_notes.txt`
- [ ] Update metadata and screenshots
- [x] Commit and tag with a beta tag (X.Y.Z-beta.M)
- [x] Push the tag and wait for the CI to push the beta version to the registry
- [x] Push and check with a cozy from production (which has to be on the beta track for Banks)
- [ ] Release the app on Testflight for iOS. `yarn ios:publish`
- [x] Release the app on Play Store on `beta` track. `yarn android:publish`
- [x] Upload the APK (`src/targets/mobile/build/android/cozy-banks.apk`) on [the APK card in Trello](https://trello.com/c/wtToK7IN/1192-apks)
- [ ] Test well on the 3 platforms
- [ ] Tag the branch as prod (X.Y.Z)
- [ ] Push the tag, wait for the CI to push the build to the registry
- [ ] Update cozies with the latest web version via Rundeck
- [ ] [Promote Android app][playstore] to the production track
- [ ] [Promote iOS app][itunesconnect] to the production track.

<details>
<summary>How to check CI</summary>
In Travis <a href="https://travis-ci.org/cozy/cozy-banks/builds/">logs</a>, you should see

```
Attempting to publish banks (version 0.7.6-beta.0) from https://downcloud.cozycloud.cc/upload/cozy-banks/0.7.6-8f932d80f510e1942fa09865ce3526c166b00b0e/cozy-banks.tar.gz (sha256 dd42d7b55ff3992893cc2432f23a813ded6b6766a880bdf24184d35060150fe7) to https://apps-registry.cozycloud.cc (space: banks)
Application published!
```
To check that the registry has the right version:

```curl "https://apps-registry.cozycloud.cc/banks/registry/banks" | jq '.'```
</details>

<details>
<summary>How to update a Cozy on the beta version of the registry</summary>

```
cozy-stack apps update banks registry://banks/beta --domain drazik2.mycozy.cloud
```

</details>

<details>
<summary>How to deploy on Testflight</summary>

```
yarn ios:publish
```

</details>

<details>
<summary>Managing versions</summary>

#### How to bump versions

At the **start** of the release process

1. Bump the `version` number in `package.json` and `config.xml` according to semver.
2. Copy this version to the `ios-CFBundleVersion` attribute and add a fourth number `.1` (then `.2` for the next beta version etc..)
3. For `android-versionCode`, follow this formula `beta + patch*100 + minor * 10000 + major * 1000000`.
4. Update the version number for the `AppendUserAgent` preference in `config.xml`.

At the **end** of the release process

For iOS you can simply remove the suffix and rebuild/reupload.
For Android, you have nothing to do, and can simply promote the build to the production track.

#### Why not let Cordova manage this automatically ?

The difficulty is that for stores (both PlayStore and iTunesConnect), you cannot have build with the same versionCode (for
Android) or ios-CFBundleVersion (for iOS). Normally those two numbers are managed by Cordova automatically (computed from the `version` attribute) but this
does not work well if during the release process (after having pushed a beta build in Testflight/PlayStore), you want to put a new version (because you have detected bug). If you let Cordova manage this, you would have to change the `version` from your config.xml and your `package.json`, and your production users would see a jump of version.

#### Android versionCode

The android-versionCode has to be a integer. But it has to be related to the `versionName` for debugging/understand purposes. Cordova does patch + minor *100 + major * 10000 but it does not leave space for beta versions (that have the same `versionName`). This is why we go one step further : `beta + patch *100 + minor * 10000 * major * 1000000). 0.7.6-beta1 is then `700601`. This number is not visible to the users, it's `android-versionName` that is visible and it's copied from `version` automatically Cordova.

#### ios-CFBundleVersion

For iOS, this is a little bit better since `ios-CFBundleVersion` can be a string with a fourth number at the end. Add a fourth number `.1` (and then `.2`, `.3` etc..) to your version number while developing, until you are sure that the build is completely ready. Then you can remove the suffix and `ios-CFBundleVersion` will be the same as `version`.

Cordova doc : https://cordova.apache.org/docs/fr/latest/config_ref/
iOS doc : https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364
Android doc : https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes
</details>

[playstore]: https://play.google.com/apps/publish/?pli=1&account=7424624102327137158#ManageReleasesPlace:p=io.cozy.banks.mobile&appid=4975496102553953948
[itunesconnect]: https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/1349814380