### PR TITLE
fix: Bad transition fix when reducing d3 size

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -380,26 +380,30 @@ class LineChart extends Component {
       this.mask.attr('opacity', 0)
     }
 
-    d3.transition(this.line)
+    this.line
       .attr('stroke-dasharray', lineTotalLength)
       .attr('stroke-dashoffset', lineTotalLength)
+      .transition()
       .duration(this.props.enterAnimationDuration)
       .ease(d3.easeExpInOut)
       .attr('stroke-dashoffset', 0)
       .on('end', () => {
         if (this.mask) {
-          d3.transition(this.mask)
+          this.mask
+            .transition()
             .duration(250)
             .ease(d3.easeLinear)
             .attr('opacity', 1)
 
-          d3.transition(this.point)
+          this.point
+            .transition()
             .duration(200)
             .ease(d3.easeLinear)
             .attr('r', this.props.pointRadius)
             .attr('stroke-width', this.props.pointStrokeWidth)
 
-          d3.transition(this.pointLine)
+          this.pointLine
+            .transition()
             .duration(400)
             .ease(d3.easeExpIn)
             .attr('opacity', 1)


### PR DESCRIPTION
When changing the code not to bring the whole d3 but only some methods, I had an error transition() is not a function. I made a mistake when fixing it, I thought I needed to wrap the d3-selection into a transition. This was unnecessary since merely importing d3-transition adds the `transition` method to `d3-selection`s. `d3-transition` is imported in `utils/d3`.