### PR TITLE
fix(TransactionsPage): Update current month when changing filtering doc

### DIFF
--- a/src/ducks/filters/index.js
+++ b/src/ducks/filters/index.js
@@ -14,8 +14,9 @@ const FILTER_BY_DOC = 'FILTER_BY_DOC'
 const RESET_FILTER_BY_DOC = 'RESET_FILTER_BY_DOC'
 
 // selectors
-export const getPeriod = state => state.filters.period
-export const getFilteringDoc = state => state.filters.filteringDoc
+export const getPeriod = state => state.filters && state.filters.period
+export const getFilteringDoc = state =>
+  state.filters && state.filters.filteringDoc
 
 export const getFilteredAccountIds = state => {
   const availableAccountIds = getAccounts(state).map(x => x._id)

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -113,6 +113,9 @@ class TransactionsPage extends Component {
     ) {
       this.setCurrentMonthFollowingMostRecentTransaction()
     }
+    if (prevProps.filteringDoc !== this.props.filteringDoc) {
+      this.handleChangeMonth(this.state.currentMonth)
+    }
   }
 
   getInstalledKonnectorsSlugs() {

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -17,7 +17,7 @@ import {
   uniq,
   maxBy
 } from 'lodash'
-import { getFilteredAccounts } from 'ducks/filters'
+import { getFilteredAccounts, getFilteringDoc } from 'ducks/filters'
 import BarBalance from 'components/BarBalance'
 import { Padded } from 'components/Spacing'
 
@@ -383,7 +383,7 @@ const mapStateToProps = (state, ownProps) => {
       HOME: getAppUrlById(enhancedState, 'io.cozy.apps/home')
     },
     accountIds: getFilteredAccountIds(enhancedState),
-    filteringDoc: state.filters.filteringDoc,
+    filteringDoc: getFilteringDoc(state),
     filteredAccounts: getFilteredAccounts(enhancedState),
     filteredTransactions: filteredTransactions
   }

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -35,6 +35,8 @@ describe('TransactionsPage', () => {
     jest.restoreAllMocks()
   })
 
+  // Necessary wrapper to be able to use setProps since `setProps` is
+  // only callable on the Enzyme root
   const Wrapper = ({ filteringDoc }) => (
     <AppLike>
       <UnpluggedTransactionsPage

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -7,7 +7,8 @@ import {
   TransactionsPageBar
 } from './TransactionsPage'
 import data from '../../../test/fixtures'
-
+import PropTypes from 'prop-types'
+import AppLike from 'test/AppLike'
 const allAccounts = data['io.cozy.bank.accounts']
 const allTransactions = data['io.cozy.bank.operations']
 
@@ -34,18 +35,28 @@ describe('TransactionsPage', () => {
     jest.restoreAllMocks()
   })
 
-  const setup = () => {
-    root = mount(
+  const Wrapper = ({ filteringDoc }) => (
+    <AppLike>
       <UnpluggedTransactionsPage
         filteredTransactions={allTransactions}
         filteredAccounts={allAccounts}
-        router={{
-          params: {
-            subcategoryName
-          }
-        }}
+        filteringDoc={filteringDoc}
       />
-    )
+    </AppLike>
+  )
+
+  const setup = () => {
+    const context = {
+      router: {
+        params: {
+          subcategoryName
+        }
+      }
+    }
+    const childContextTypes = {
+      router: PropTypes.object
+    }
+    root = mount(<Wrapper />, { context, childContextTypes })
   }
 
   it('should not show the top balance on movements page on non mobile', () => {
@@ -101,5 +112,14 @@ describe('TransactionsPage', () => {
     expect(instance.setState).toHaveBeenCalledWith({
       currentMonth: '2019-02'
     })
+  })
+
+  it('should call handleChangeMonth if filteringDoc changed', () => {
+    setup()
+    const tp = root.find(DumbTransactionsPage)
+    const instance = tp.instance()
+    jest.spyOn(instance, 'handleChangeMonth')
+    root.setProps({ filteringDoc: { _id: 'new-doc' } })
+    expect(instance.handleChangeMonth).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
When changing the filtering doc while on a specific month, we didn't
update `limitMin` and `limitMax`. But it could be wrong since the number
of transactions changed. Now, on update we trigger `handleChangeMonth`,
which recomputes the limits and the current month.

https://testbanksfixtransactions-banks.cozy.works

Do the following to test:

* Go to an account details
* Select "all accounts"
* Go back one month
* Select "awaiting reimbursements"
* You see the transactions (before the fix, you couldn't see it)