### PR TITLE
fix(MobileRouter): Default route is always /balances

### DIFF
--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -5,7 +5,6 @@ import PropTypes from 'prop-types'
 import { Router, Route } from 'react-router'
 import { withClient } from 'cozy-client'
 import { Authentication, Revoked } from 'cozy-authentication'
-import { defaultRoute } from 'components/AppRoute'
 import { setURLContext, logException } from 'lib/sentry'
 import {
   storeCredentials,
@@ -77,7 +76,7 @@ const withAuth = Wrapped =>
         const { url, clientInfo, router, token } = res
         setURLContext(url)
         this.context.store.dispatch(storeCredentials(url, clientInfo, token))
-        router.replace(defaultRoute())
+        router.replace('/balances')
       } else {
         // when user is already authenticated
         clientInfos = this.context.store.getState().mobile.client


### PR DESCRIPTION
I forgot this in 6f4d9bc69deca154cb71ec3c6db2578ceaf1deb0 and it's
breaking the mobile app.