### PR TITLE
feat(bar): Handle bar theme overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "classnames": "2.2.6",
     "cordova": "7.1.0",
     "cozy-authentication": "1.4.0-beta1",
-    "cozy-bar": "6.14.0",
+    "cozy-bar": "6.15.0",
     "cozy-client": "6.4.2",
     "cozy-client-js": "0.14.2",
     "cozy-device-helper": "1.6.3",

--- a/src/ducks/bar/overrides.js
+++ b/src/ducks/bar/overrides.js
@@ -1,0 +1,13 @@
+/**
+ * This object connects theme names to overrides to apply to the bar when the
+ * theme is applied to it. It should have the following shape:
+ * ```
+ * {
+ *   themeName: {
+ *     primaryColor: 'someColor',
+ *     primaryContrastTextColor: 'someOtherColor'
+ *   }
+ * }
+ * ```
+ */
+export default {}

--- a/src/ducks/mobile/utils.js
+++ b/src/ducks/mobile/utils.js
@@ -1,5 +1,6 @@
 /* global cozy, __TARGET__ */
 import { setTheme as setStatusBarTheme } from './statusBar'
+import barOverrides from 'ducks/bar/overrides'
 
 const getLang = () =>
   navigator && navigator.language ? navigator.language.slice(0, 2) : 'en'
@@ -41,6 +42,7 @@ export const setBarTheme = theme => {
   }
 
   if (cozy.bar && cozy.bar.setTheme) {
-    cozy.bar.setTheme(theme)
+    const overrides = barOverrides[theme]
+    cozy.bar.setTheme(theme, overrides)
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4729,10 +4729,10 @@ cozy-authentication@1.4.0-beta1:
   dependencies:
     url-polyfill "1.1.0"
 
-cozy-bar@6.14.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-6.14.0.tgz#282424cc3ff874ba47104c2da42d7f1965e4caa8"
-  integrity sha512-K09CUjTXzW3gscNlFE/1KbK2BVLWsj0JyNNhluvs7g9QzaWkTVIS4nHiHJhgx1BgWbZDnoGvxpFn1cYu3FqMwQ==
+cozy-bar@6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-6.15.0.tgz#216773a2c02277caef4b011d61bdad1a0dc1234a"
+  integrity sha512-2kG2I5ep2FT5bW5bLiWU6Pe2DjsCFZV+gcW3WXrKwobVQOW1iS/8YQFyQ+owU6MrXUYcMj1CJluPvr/XCGby+Q==
   dependencies:
     "@babel/core" "7.2.2"
     babel-core "7.0.0-bridge.0"


### PR DESCRIPTION
For customization needs, we need to be able to pass overrides to
`cozy.bar.setTheme`. Do be able to override it easily, I added a map in
its own file. This way, we can override this single file in every
customization. In the original Banks we don't want any overrides, so it
is an empty object.

See cozy/cozy-bar#473 for the implementation of
the overrides in the cozy-bar side.