### PR TITLE
Use webpack resolver and relative requires in stylus files

### DIFF
--- a/config/webpack.config.styles.js
+++ b/config/webpack.config.styles.js
@@ -24,8 +24,8 @@ module.exports = {
           }, {
             loader: 'stylus-loader',
             options: {
-              sourceMap: true
-
+              sourceMap: true,
+              preferPathResolver: 'webpack'
             }
           }
         ]

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,10 +1,10 @@
 @require 'generic/normalize.styl'
 @require 'elements/defaults.styl'
-@require './utilities.styl'
-@require './text.styl'
+@require 'utilities.styl'
+@require 'text.styl'
 @require 'settings/breakpoints'
 @require '~styles/variables.styl'
-@require './palette.styl'
+@require 'palette.styl'
 
 html
     -webkit-touch-callout none

--- a/src/styles/mixins.styl
+++ b/src/styles/mixins.styl
@@ -1,4 +1,4 @@
-@require './variables.styl'
+@require 'variables.styl'
 @require 'settings/breakpoints'
 
 /**

--- a/src/styles/utilities.styl
+++ b/src/styles/utilities.styl
@@ -1,4 +1,4 @@
-@require './spacers.styl'
+@require 'spacers.styl'
 @require 'settings/palette'
 @require 'generic/animations'
 


### PR DESCRIPTION
With the stylus resolver and `./something.styl` we were not able to customize stylus files that are not imported in JS files easily.

For example, since `src/styles/palette.styl` was imported with `@require './palette.styl'`, even if we created an override for this file in a customization repository, it would never be used because stylus-loader resolved the file by its path.

To fix this, I did two things:

* Use the webpack resolver in stylus-loader using [the preferPathResolver option](https://github.com/shama/stylus-loader#prefer-webpack-resolving)
* Use relative imports without `./` when we `@require` stylus files

Now since stylus `@require` uses the webpack resolver and we use the good paths style, we can create overrides files in the customizations repositories for these files.