### PR TITLE
Use CSS variables for header

### DIFF
--- a/src/components/Chart/Tooltip.styl
+++ b/src/components/Chart/Tooltip.styl
@@ -1,7 +1,7 @@
 .Tooltip
     position absolute
     background-color white
-    color dodgerBlue
+    color var(--historyTooltipTextColor)
     border-radius 2px
     font-size 0.6875rem
     padding-left 2px

--- a/src/components/Header/Header.styl
+++ b/src/components/Header/Header.styl
@@ -10,10 +10,10 @@
         top 3rem
 
 .HeaderColor_default
-    background-color var(--white)
+    background-color var(--headerDefaultBackgroundColor)
 
 .HeaderColor_primary
-    background-color var(--primaryColor)
+    background-color var(--headerPrimaryBackgroundColor)
 
 .HeaderColor_primary.HeaderFixed
     box-shadow 0 2px 4px 0 rgba(0, 0, 0, 0.24), 0 0 4px 0 rgba(0, 0, 0, 0.16)

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -10,7 +10,7 @@
         left 0
         right 0
         height 44px
-        background-color var(--primaryColor)
+        background-color var(--headerPrimaryBackgroundColor)
 
     +small-screen()
         padding-left 0.5rem

--- a/src/ducks/balance/History.styl
+++ b/src/ducks/balance/History.styl
@@ -1,6 +1,5 @@
 .HistoryChart
     overflow-y auto
-    background-color dodgerBlue
     margin 0
 
 .History .HistoryChart
@@ -11,6 +10,6 @@
 
 .HistoryChart__tooltipBalance
     font-weight bold
-    border-left 1px solid dodgerBlue
+    border-left 1px solid var(--historyTooltipTextColor)
     padding-left 4px
     margin-left 4px

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -9,10 +9,10 @@ import { getCssVariableValue } from 'cozy-ui/react/utils/color'
 import { lighten } from '@material-ui/core/styles/colorManipulator'
 
 // on iOS white transparency on SVG failed so we should calculate hexa color
-const primaryColor = getCssVariableValue('primaryColor')
+const gradientColor = getCssVariableValue('historyGradientColor')
 const gradientStyle = {
-  '0%': lighten(primaryColor, 0.48),
-  '100%': getCssVariableValue('primaryColor')
+  '0%': lighten(gradientColor, 0.48),
+  '100%': gradientColor
 }
 
 class HistoryChart extends Component {

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -1,10 +1,10 @@
 @require 'generic/normalize.styl'
 @require 'elements/defaults.styl'
-@require 'utilities.styl'
-@require 'text.styl'
+@require '~styles/utilities.styl'
+@require '~styles/text.styl'
 @require 'settings/breakpoints'
 @require '~styles/variables.styl'
-@require 'palette.styl'
+@require '~styles/palette.styl'
 
 html
     -webkit-touch-callout none

--- a/src/styles/mixins.styl
+++ b/src/styles/mixins.styl
@@ -1,4 +1,4 @@
-@require 'variables.styl'
+@require '~styles/variables.styl'
 @require 'settings/breakpoints'
 
 /**

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -1,5 +1,7 @@
 @require 'settings/palette.styl'
 
 // @stylint off
-:root
+body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)
+    --headerDefaultBackgroundColor var(--white)
+    --headerPrimaryBackgroundColor var(--primaryColor)

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -5,3 +5,4 @@ body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)
     --headerDefaultBackgroundColor var(--white)
     --headerPrimaryBackgroundColor var(--primaryColor)
+    --historyTooltipTextColor var(--primaryColor)

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -6,3 +6,4 @@ body
     --headerDefaultBackgroundColor var(--white)
     --headerPrimaryBackgroundColor var(--primaryColor)
     --historyTooltipTextColor var(--primaryColor)
+    --historyGradientColor var(--primaryColor)

--- a/src/styles/utilities.styl
+++ b/src/styles/utilities.styl
@@ -1,4 +1,4 @@
-@require 'spacers.styl'
+@require '~styles/spacers.styl'
 @require 'settings/palette'
 @require 'generic/animations'
 


### PR DESCRIPTION
By introducing CSS variables for each part of the header, this is much easier to apply another theme to it by creating an override of the `src/styles/palette.styl` file.