### PR TITLE
fix(deps): Remove cozy-stack-client from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "cozy-interapp": "0.2.20",
     "cozy-konnector-libs": "4.14.9",
     "cozy-pouch-link": "5.7.7",
-    "cozy-stack-client": "5.6.1",
     "cozy-ui": "19.5.0",
     "d3": "5.9.1",
     "date-fns": "1.30.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4958,7 +4958,7 @@ cozy-realtime@2.0.3:
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-2.0.3.tgz#7c02e19833f8061d32f8f72529a94d2277a8aee1"
   integrity sha512-Ad/l2wWYyvaKvLSOrSVALBdk+utqm6MJIIDDcpPLcT092ynmbSROC4JtG6dEfbzirVqKAM5H44oTtPgGT/e2mg==
 
-cozy-stack-client@5.6.1, cozy-stack-client@^5.6.1:
+cozy-stack-client@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-5.6.1.tgz#f7ea391d5a635605a16b7bdaea0a36b2d9cd1023"
   integrity sha512-8Z1fMepAm5bu4eup4DviUux8j/bwbvuFNPVaVuk4We+k3/ly07nvp2q3sUh9YMSXGKZOsb3O9ybIZ5XzCOKnWA==


### PR DESCRIPTION
It is not a direct dependency anymore. But it is still imported by
cozy-client