### PR TITLE
refactor(GroupPanel): Import ExpansionPanel from cozy-ui

### DIFF
--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { withRouter } from 'react-router'
 
-import ExpansionPanel from '@material-ui/core/ExpansionPanel'
+import ExpansionPanel from 'cozy-ui/react/MuiCozyTheme/ExpansionPanel'
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
 import { withStyles } from '@material-ui/core/styles'


### PR DESCRIPTION
It makes it easier to override it in customization. For example, if we
want to override the default props so `square` is true by default.