### PR TITLE
Updates on global categorization model

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -18,7 +18,7 @@ const makeSubcategory = catId => ({
 })
 
 export const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
-export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.9
+export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.25
 
 /**
  * Return the category id of the transaction

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -288,7 +288,7 @@ export const pctOfTokensInVoc = (tokens, vocabularyArray) => {
 export const localModel = async (classifierOptions, transactions) => {
   const classifier = await createLocalModel(classifierOptions)
 
-  if (classifier !== undefined) {
+  if (classifier) {
     localModelLog(
       'info',
       'Reweighting model to lower the impact of amount in the prediction'

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -1,7 +1,7 @@
 /* global __TARGET__ */
 
 import logger from 'cozy-logger'
-import { maxBy, pick, uniq } from 'lodash'
+import { maxBy, uniq } from 'lodash'
 import { tokenizer, createClassifier } from '.'
 import bayes from 'classificator'
 import { getLabel } from 'ducks/transactions/helpers'
@@ -369,38 +369,4 @@ export const categorizes = async transactions => {
   })
 
   return transactions
-}
-
-export class AutoCategorization extends Document {
-  static async sendTransactions(transactions) {
-    const log = logger.namespace('categorization-send-transactions')
-
-    const transactionsToSend = transactions.map(transaction =>
-      pick(transaction, [
-        'amount',
-        'date',
-        'label',
-        'automaticCategoryId',
-        'metadata.version',
-        'manualCategoryId',
-        'cozyCategoryId',
-        'cozyCategoryProba',
-        'localCategoryId',
-        'localCategoryProba'
-      ])
-    )
-
-    try {
-      await this.cozyClient.fetchJSON(
-        'POST',
-        '/remote/cc.cozycloud.autocategorization',
-        {
-          data: JSON.stringify(transactionsToSend)
-        }
-      )
-    } catch (e) {
-      log('info', 'Error while sending transactions')
-      log('info', e)
-    }
-  }
 }

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -95,14 +95,6 @@ class Configuration extends React.PureComponent {
             enabled={settings.community.localModelOverride.enabled}
             name="localModelOverride"
           />
-          <ToggleRow
-            description={t(
-              'AdvancedFeaturesSettings.automatic_categorization.auto_categorization.description'
-            )}
-            onToggle={this.onToggle('community.autoCategorization')}
-            enabled={settings.community.autoCategorization.enabled}
-            name="autoCategorization"
-          />
         </TogglePane>
       </div>
     )

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -11,9 +11,6 @@ Object {
     "lastSeq": 0,
   },
   "community": Object {
-    "autoCategorization": Object {
-      "enabled": false,
-    },
     "localModelOverride": Object {
       "enabled": false,
     },

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -31,9 +31,6 @@ export const DEFAULTS_SETTINGS = {
     transactionsLastSeq: '0'
   },
   community: {
-    autoCategorization: {
-      enabled: false
-    },
     localModelOverride: {
       enabled: false
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -527,9 +527,6 @@
       "title" :"Automatic categorization",
       "local_model_override": {
         "description": "Learn from my manual categorizations"
-      },
-      "auto_categorization": {
-        "description": "Help us improve the model by anonymously sharing your categorized transactions. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>More</a>"
       }
     },
     "balance_history": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -480,9 +480,6 @@
       "title" :"Catégorisation automatique",
       "local_model_override": {
         "description": "Apprendre de mes catégorisations manuelles"
-      },
-      "auto_categorization": {
-        "description": "Participer à l'amélioration du modèle par le partage anonymisé de vos écritures catégorisées. <a href='https://support.cozy.io/article/181-collaboration-a-la-categorisation-bancaire' target='_blank'>En savoir plus</a>"
       }
     },
     "balance_history": {

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -136,7 +136,7 @@ const doCategorization = async setting => {
     if (e.message === PARAMETERS_NOT_FOUND) {
       log('info', PARAMETERS_NOT_FOUND)
     } else {
-      log('warn', e)
+      log('warn', 'Error in categorization ' + e)
     }
   }
 }

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -3,8 +3,7 @@ import logger from 'cozy-logger'
 import flag from 'cozy-flags'
 import {
   categorizes,
-  PARAMETERS_NOT_FOUND,
-  AutoCategorization
+  PARAMETERS_NOT_FOUND
 } from 'ducks/categorization/services'
 import { sendNotifications } from 'ducks/notifications/services'
 import { Document } from 'cozy-doctypes'
@@ -127,20 +126,6 @@ const doCategorization = async setting => {
         Transaction,
         catChanges.newLastSeq
       )
-
-      if (setting.community.autoCategorization.enabled) {
-        log(
-          'info',
-          'Auto categorization setting is enabled, sending transactions to API'
-        )
-        await AutoCategorization.sendTransactions(transactionsCategorized)
-        log(
-          'info',
-          `Sent ${transactionsCategorized.length} transactions to API`
-        )
-      } else {
-        log('info', 'Auto categorization setting is disabled, skipping')
-      }
 
       setting.categorization.lastSeq = newChanges.newLastSeq
     } else {


### PR DESCRIPTION
* Set the usage threshold to 0.25
* Remove the setting to allow users to send their manually categorized transactions to feed the model
* Fix a bug due to a bad condition in the categorization service

See https://testbanksglobalmodelupdate-banks.cozy.works