### PR TITLE
fix: Better perf for toggling expansion panels

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent, Fragment } from 'react'
-import { flowRight as compose, get, sumBy, set } from 'lodash'
+import { flowRight as compose, get, sumBy, set, debounce } from 'lodash'
+
 import { queryConnect, withMutations } from 'cozy-client'
 import flag from 'cozy-flags'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
@@ -29,6 +30,11 @@ class Balance extends PureComponent {
     }
 
     setBarTheme('primary')
+    this.handlePanelChange = this.handlePanelChange.bind(this)
+    this.debouncedHandlePanelChange = debounce(this.handlePanelChange, 3000, {
+      leading: false,
+      trailing: true
+    }).bind(this)
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -64,7 +70,7 @@ class Balance extends PureComponent {
     }, this.savePanelState)
   }
 
-  handlePanelChange = (panelId, event, expanded) => {
+  handlePanelChange(panelId, event, expanded) {
     const path = panelId + '.expanded'
 
     this.setState(prevState => {
@@ -173,7 +179,7 @@ class Balance extends PureComponent {
               warningLimit={balanceLower}
               panelsState={this.state.panels}
               onSwitchChange={this.handleSwitchChange}
-              onPanelChange={this.handlePanelChange}
+              onPanelChange={this.debouncedHandlePanelChange}
             />
           ) : (
             <BalanceTables
@@ -187,6 +193,8 @@ class Balance extends PureComponent {
     )
   }
 }
+
+export const DumbBalance = Balance
 
 export default compose(
   queryConnect({

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -61,7 +61,7 @@ class Balance extends PureComponent {
       set(nextState.panels, path, checked)
 
       return nextState
-    }, this.onPanelsStateChange)
+    }, this.savePanelState)
   }
 
   handlePanelChange = (panelId, event, expanded) => {
@@ -72,10 +72,10 @@ class Balance extends PureComponent {
       set(nextState.panels, path, expanded)
 
       return nextState
-    }, this.onPanelsStateChange)
+    }, this.savePanelState)
   }
 
-  onPanelsStateChange() {
+  savePanelState() {
     const { panels } = this.state
     const settings = this.props.settings.data[0]
 

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -1,0 +1,54 @@
+/* global shallow */
+
+const React = require('react')
+const { DumbBalance } = require('./Balance')
+const debounce = require('lodash/debounce')
+
+jest.mock('lodash/debounce', () => jest.fn(fn => fn))
+
+jest.useFakeTimers()
+
+const fakeCollection = (doctype, data) => ({
+  data: data || []
+})
+
+describe('Balance page', () => {
+  let root, instance, saveDocumentMock
+
+  beforeEach(() => {
+    saveDocumentMock = jest.fn()
+    const settingDoc = {}
+    root = shallow(
+      <DumbBalance
+        accounts={fakeCollection('io.cozy.bank.accounts')}
+        groups={fakeCollection('io.cozy.bank.groups')}
+        settings={fakeCollection('io.cozy.bank.settings', [settingDoc])}
+        saveDocument={saveDocumentMock}
+      />
+    )
+    instance = root.instance()
+  })
+
+  describe('panel toggling', () => {
+    it('should debounce handlePanelChange', () => {
+      expect(debounce).toHaveBeenCalledWith(instance.handlePanelChange, 3000, {
+        leading: false,
+        trailing: true
+      })
+    })
+
+    it('should call savePanelState when handling panel change', () => {
+      instance.setState = (fn, callback) => callback.apply(instance)
+      jest.spyOn(instance, 'savePanelState')
+      instance.handlePanelChange()
+      instance.handlePanelChange()
+      instance.handlePanelChange()
+      expect(instance.savePanelState).toHaveBeenCalledTimes(3)
+    })
+
+    it('should call saveDocument when saving panel state', () => {
+      instance.savePanelState()
+      expect(saveDocumentMock).toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Debounce has been introduced not to re-render the whole
BalancePage when toggling expansion panels.

https://testbanksdebouncedpanels-banks.cozy.works