### PR TITLE
fix: Use NODE_ENV==test to deactivate icons in jest

### DIFF
--- a/src/ducks/categories/icons.js
+++ b/src/ducks/categories/icons.js
@@ -1,7 +1,7 @@
 import fromPairs from 'lodash/fromPairs'
 
 let iconsByCatName
-if (require.context) {
+if (process.env.NODE_ENV !== 'test') {
   // Require all icons automatically
   const context = require.context('assets/icons/categories', false, /\.svg$/)
 


### PR DESCRIPTION
`require.context` does not exist in runtime so icons where not displayed. `require.context` was used to detect if we were in tests, so NODE_ENV==test can be used also.