### PR TITLE
fix: Matomo config

### DIFF
--- a/config/webpack.config.piwik.js
+++ b/config/webpack.config.piwik.js
@@ -1,12 +1,12 @@
- const webpack = require('webpack')
+const webpack = require('webpack')
 
- module.exports = {
-   plugins: [
-     new webpack.DefinePlugin({
-       __PIWIK_SITEID__: 255, // TODO change for real value
-       __PIWIK_SITEID_MOBILE__: 255,
-       __PIWIK_DIMENSION_ID_APP__: 1,
-       __PIWIK_TRACKER_URL__: JSON.stringify('https://matomo.cozycloud.cc')
-     })
-   ]
- }
+module.exports = {
+  plugins: [
+    new webpack.DefinePlugin({
+      __PIWIK_SITEID__: 8,
+      __PIWIK_TRACKER_URL__: JSON.stringify(
+        'https://matomo.cozycloud.cc/piwik.php'
+      )
+    })
+  ]
+}

--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -80,11 +80,7 @@ module.exports = merge.strategy({
     ),
 
     new webpack.DefinePlugin({
-      __TARGET__: JSON.stringify('services'),
-      __PIWIK_SITEID__: 8,
-      __PIWIK_TRACKER_URL__: JSON.stringify(
-        'https://matomo.cozycloud.cc/piwik.php'
-      )
+      __TARGET__: JSON.stringify('services')
     }),
 
     /* Does not work in a bundle, we do not use it */


### PR DESCRIPTION
We had the Matomo config in 2 places, and in one of them the site ID was
a fake one, causing errors in logs.