### PR TITLE
fix(HistoryChart): Scroll to end of chart only if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,6 +173,7 @@
     "d3": "5.9.1",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",
+    "element-scroll-polyfill": "1.0.1",
     "expose-loader": "0.7.5",
     "fastclick": "1.0.6",
     "geco": "0.11.1",

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -37,7 +37,10 @@ class HistoryChart extends Component {
 
   componentDidMount() {
     const container = this.container.current
-    container.scrollTo(container.scrollWidth, 0)
+
+    if (container && container.scrollTo) {
+      container.scrollTo(container.scrollWidth, 0)
+    }
   }
 
   render() {

--- a/src/ducks/balance/HistoryChart.jsx
+++ b/src/ducks/balance/HistoryChart.jsx
@@ -7,6 +7,7 @@ import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
 import { getCssVariableValue } from 'cozy-ui/react/utils/color'
 import { lighten } from '@material-ui/core/styles/colorManipulator'
+import 'element-scroll-polyfill'
 
 // on iOS white transparency on SVG failed so we should calculate hexa color
 const gradientColor = getCssVariableValue('historyGradientColor')

--- a/yarn.lock
+++ b/yarn.lock
@@ -6313,6 +6313,11 @@ element-resize-detector@^1.1.12:
   dependencies:
     batch-processor "1.0.0"
 
+element-scroll-polyfill@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/element-scroll-polyfill/-/element-scroll-polyfill-1.0.1.tgz#adee88656a3e514f20be53d54965ed91b9269122"
+  integrity sha512-7DHhK7AjqipVYyFbZ0UePaU23Go5+hpgCvg4beqWHcAyCwH+NfzkKKUth+91dXuwS4QbOjIljqaUsfe5GTUPMg==
+
 elementtree@0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/elementtree/-/elementtree-0.1.6.tgz#2ac4c46ea30516c8c4cbdb5e3ac7418e592de20c"


### PR DESCRIPTION
On some old browsers, `Element.scrollTo` is not supported. See
https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo for
more informations.