### PR TITLE
refactor(mobile): Use an intermediary variable for status bar color

### DIFF
--- a/src/ducks/mobile/statusBar.js
+++ b/src/ducks/mobile/statusBar.js
@@ -5,7 +5,7 @@ export const setColor = color => {
 }
 
 const THEME_TO_COLORS = {
-  primary: 'primaryColorDark',
+  primary: 'statusBarPrimaryColor',
   default: 'coolGrey'
 }
 

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -17,3 +17,4 @@ body
     --tableHeadSeparatorPrimaryColor var(--primaryColor)
     --categoriesHeaderTogglePrimaryContrastTextColor var(--primaryContrastTextColor)
     --categoriesHeaderTogglePrimaryBackgroundColor var(--primaryColorLight)
+    --statusBarPrimaryColor var(--primaryColorDark)


### PR DESCRIPTION
So it's not always `primaryColorDark` in customizations.