### PR TITLE
Color select dates

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "cozy-interapp": "0.2.20",
     "cozy-konnector-libs": "4.14.9",
     "cozy-pouch-link": "5.7.7",
-    "cozy-ui": "19.8.0",
+    "cozy-ui": "19.11.0",
     "d3": "5.9.1",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -59,8 +59,10 @@ select-date-height-small = 2.75rem
 
         &.SelectDatesButtonDisabled
             background-color var(--selectDatesButtonDisabledPrimaryBackgroundColor)
-            opacity 0.5
 
+            svg
+                color var(--selectDatesButtonDisabledPrimaryColor)
+        
         .SelectDatesButtonColor
             color var(--selectDatesButtonPrimaryColor)
 

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -3,17 +3,23 @@
 // @stylint off
 body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)
+    
     --headerDefaultBackgroundColor var(--white)
     --headerPrimaryBackgroundColor var(--primaryColor)
+    
     --historyTooltipTextColor var(--primaryColor)
     --historyGradientColor var(--primaryColor)
+    
     --selectDatesSeparatorPrimaryColor var(--primaryColor)
     --selectDatesChipPrimaryBackgroundColor var(--primaryColorLight)
-    --selectDatesButtonDisabledPrimaryBackgroundColor var(--primaryColorLight)
+    --selectDatesButtonDisabledPrimaryBackgroundColor var(--primaryColorLighter)
+    --selectDatesButtonDisabledPrimaryColor var(--primaryColorLightest)
     --selectDatesIconPrimaryColor var(--white)
     --selectDatesButtonPrimaryColor var(--white)
+    
     --tableHeadPrimaryBackgroundColor var(--primaryColorLight)
     --tableHeadPrimaryContrastTextColor var(--primaryContrastTextColor)
     --tableHeadSeparatorPrimaryColor var(--primaryColor)
+    
     --categoriesHeaderTogglePrimaryContrastTextColor var(--primaryContrastTextColor)
     --categoriesHeaderTogglePrimaryBackgroundColor var(--primaryColorLight)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5020,10 +5020,10 @@ cozy-stack-client@^6.5.0:
     detect-node "2.0.4"
     mime-types "2.1.20"
 
-cozy-ui@19.8.0:
-  version "19.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.8.0.tgz#2568fc1ccfc03c6490266c2fc8855db117cb5aca"
-  integrity sha512-o8mQ6fniXXOyyU67yE+nvLxjwR0Ww6AQMbV3H+zoUHrqXtWU1yXiiXDf77qz/GqvYof8imqYvDX7tnZQnQvFTg==
+cozy-ui@19.11.0:
+  version "19.11.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-19.11.0.tgz#788b9dc9d744901fdc5d5e64099d16c93499c9c5"
+  integrity sha512-BRIy/jDa4w/zMdGgrSyTPh39GjCsoZXghPPPdt4IRI+3PSTjoHS+6dgTk4KJF1NzQhPusNzncu0SbBddGs23dw==
   dependencies:
     body-scroll-lock "^2.5.8"
     classnames "^2.2.5"


### PR DESCRIPTION
The disabled version of the select dates buttons were semi-transparent. This was a problem as we could see the chart balance line behind. It is solved by using non transparent colors.