### PR TITLE
fix: Show category icons on CategoriesPage

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -6,6 +6,7 @@ import { getCurrencySymbol } from 'utils/currencySymbol'
 const getParent = parentCategory.get.bind(parentCategory)
 
 const makeCategory = parent => ({
+  id: parent.id,
   name: parent.name,
   color: parent.color,
   transactions: [],
@@ -13,6 +14,7 @@ const makeCategory = parent => ({
 })
 
 const makeSubcategory = catId => ({
+  id: catId,
   name: categoryNames[catId],
   transactions: []
 })
@@ -90,8 +92,11 @@ export const transactionsByCategory = transactions => {
   return categories
 }
 
-// Very specific to this component: takes the transactions by category as returned by the `transactionsByCategory` function, and turns it into a flat array, while computing derived data such as totals and curencies.
-// The result is used pretty much as is down the chain by other components, so changing property names here should be done with care.
+// Very specific to this component: takes the transactions by category as returned by the
+// `transactionsByCategory` function, and turns it into a flat array, while computing derived
+// data such as totals and currencies.
+// The result is used pretty much as is down the chain by other components, so changing property
+// names here should be done with care.
 export const computeCategorieData = transactionsByCategory => {
   return Object.values(transactionsByCategory).map(category => {
     let subcategories = Object.values(category.subcategories).map(
@@ -106,6 +111,7 @@ export const computeCategorieData = transactionsByCategory => {
         )
 
         return {
+          id: subcategory.id,
           name: subcategory.name,
           amount: credit + debit,
           debit: debit,
@@ -130,6 +136,7 @@ export const computeCategorieData = transactionsByCategory => {
     )
 
     return {
+      id: category.id,
       name: category.name,
       color: category.color,
       amount: credit + debit,

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -3,9 +3,28 @@ jest.mock('cozy-flags')
 import flag from 'cozy-flags'
 import {
   getCategoryId,
+  transactionsByCategory,
   LOCAL_MODEL_USAGE_THRESHOLD,
   GLOBAL_MODEL_USAGE_THRESHOLD
 } from './helpers'
+
+describe('transactionsByCategory', () => {
+  const byCategory = transactionsByCategory([
+    {
+      manualCategoryId: '200110',
+      automaticCategoryId: '200120',
+      localCategoryId: '200130'
+    }
+  ])
+  expect(Object.keys(byCategory).length).toBe(13)
+  expect(byCategory.activities.id).toBe('400700')
+  expect(byCategory.incomeCat.id).toBe('200100')
+  expect(byCategory.incomeCat.transactions.length).toBe(1)
+  expect(byCategory.incomeCat.subcategories['200110'].id).toBe('200110')
+  expect(byCategory.incomeCat.subcategories['200110'].name).toBe(
+    'activityIncome'
+  )
+})
 
 describe('getCategoryId', () => {
   beforeEach(() => {


### PR DESCRIPTION
When building the aggregate of transactions by category, we did not
put categories' `id`, so it was not working with `CategoryIcon`.