### PR TITLE
feat: Add tagandpass (Tag&Pass) brand in dictionnary

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -242,6 +242,11 @@
     "konnectorSlug": "stickersdiscount"
   },
   {
+    "name": "Tag&Pass",
+    "regexp": "\\bsemitag\\b",
+    "konnectorSlug": "tagandpass"
+  },
+  {
     "name": "The Old Reader",
     "regexp": "\\btheoldreader\\b",
     "konnectorSlug": "theoldreader"


### PR DESCRIPTION
Please merge it and publish in next release.
Connector will be out today or tomorrow