### PR TITLE
chore: Remove rundeck step in PR template

### DIFF
--- a/scripts/release-pr-template.txt
+++ b/scripts/release-pr-template.txt
@@ -15,7 +15,6 @@ Release $VERSION
 - [ ] Test well on the 3 platforms
 - [ ] Tag the branch as prod (X.Y.Z)
 - [ ] Push the tag, wait for the CI to push the build to the registry
-- [ ] Update cozies with the latest web version via Rundeck
 - [ ] [Promote Android app][playstore] to the production track
 - [ ] [Promote iOS app][itunesconnect] to the production track.
 


### PR DESCRIPTION
The apps are automatically updated when they are used, so we don't force
the update via rundeck on all instances anymore when releasing a new
version of the app.