### PR TITLE
test(categorization): Fix manual categorized transactions fetch mock

### DIFF
--- a/src/ducks/categorization/services-fixtures.spec.js
+++ b/src/ducks/categorization/services-fixtures.spec.js
@@ -1,12 +1,16 @@
-import { BankTransaction } from 'cozy-doctypes'
 import { cozyClient } from 'cozy-konnector-libs'
 import { localModel } from 'cozy-konnector-libs/dist/libs/categorization/localModel'
 import { globalModel } from 'cozy-konnector-libs/dist/libs/categorization/globalModel'
 import { tokenizer } from 'cozy-konnector-libs/dist/libs/categorization/helpers'
+import fetchTransactionsWithManualCat from 'cozy-konnector-libs/dist/libs/categorization/fetchTransactionsWithManualCat'
 import path from 'path'
 import fs from 'fs'
 import cat2name from '../categories/tree.json'
 import allowedFallbackCategories from './allowed_wrong_categories.json'
+
+jest.mock(
+  'cozy-konnector-libs/dist/libs/categorization/fetchTransactionsWithManualCat'
+)
 
 const fixturePath = path.join(__dirname, 'fixtures')
 
@@ -362,9 +366,9 @@ xOrDescribe('Chain of predictions', () => {
   // prepare mock
   let manualCategorizations = []
   beforeEach(() => {
-    jest
-      .spyOn(BankTransaction, 'queryAll')
-      .mockImplementation(() => Promise.resolve(manualCategorizations))
+    fetchTransactionsWithManualCat.mockImplementation(() =>
+      Promise.resolve(manualCategorizations)
+    )
 
     // Mock global model
     jest


### PR DESCRIPTION
We had a hard time trying to mock `BankTransaction.queryAll` used in cozy-konnector-libs, but failed. Following that, we decided to extract the `BankTransaction.queryAll` call to its own function and file in cozy-konnector-libs, so it's easier to mock outside of it. See https://github.com/konnectors/libs/pull/436

Tests are failing because https://github.com/konnectors/libs/pull/436 needs to be merged and published for it to work.