### PR TITLE
feat: Set bar theme for Pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,7 @@
     "react-markdown": "2.5.1",
     "react-redux": "5.1.1",
     "react-router": "3.2.1",
+    "react-side-effect": "1.1.5",
     "react-sizeme": "2.5.2",
     "redux": "3.7.2",
     "redux-logger": "3.0.6",

--- a/src/components/ErrorBoundary/Error.jsx
+++ b/src/components/ErrorBoundary/Error.jsx
@@ -4,7 +4,6 @@ import styles from './Error.styl'
 import { translate } from 'cozy-ui/react'
 import Empty from 'cozy-ui/react/Empty'
 import brokenIcon from 'assets/icons/icon-broken.svg'
-import { setBarTheme } from 'ducks/mobile/utils'
 
 const refreshLinkID = 'error-refresh-link'
 
@@ -14,12 +13,6 @@ class Error extends React.Component {
   }
 
   rootRef = React.createRef()
-
-  constructor(props) {
-    super(props)
-
-    setBarTheme('default')
-  }
 
   componentDidMount() {
     this.listenRefreshLinkClick()

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -30,7 +30,7 @@ import styles from 'ducks/balance/Balance.styl'
 import BalanceTables from './BalanceTables'
 import BalancePanels from './BalancePanels'
 import { getPanelsState } from './helpers'
-import { setBarTheme } from 'ducks/mobile/utils'
+import BarTheme from 'ducks/mobile/BarTheme'
 import { filterByAccounts } from 'ducks/filters'
 
 class Balance extends PureComponent {
@@ -41,7 +41,6 @@ class Balance extends PureComponent {
       panels: null
     }
 
-    setBarTheme('primary')
     this.handleClickBalance = this.handleClickBalance.bind(this)
     this.handlePanelChange = this.handlePanelChange.bind(this)
     this.debouncedHandlePanelChange = debounce(this.handlePanelChange, 3000, {
@@ -158,6 +157,7 @@ class Balance extends PureComponent {
     if (collections.some(isCollectionLoading)) {
       return (
         <Fragment>
+          <BarTheme theme="primary" />
           <BalanceHeader />
           <Loading />
         </Fragment>
@@ -201,6 +201,7 @@ class Balance extends PureComponent {
 
     return (
       <Fragment>
+        <BarTheme theme="primary" />
         <BalanceHeader
           onClickBalance={this.handleClickBalance}
           accountsBalance={accountsBalance}

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -19,17 +19,12 @@ import {
   groupsConn
 } from 'doctypes'
 import { isCollectionLoading } from 'ducks/client/utils'
-import { setBarTheme } from 'ducks/mobile/utils'
+import BarTheme from 'ducks/mobile/BarTheme'
 import flag from 'cozy-flags'
 
+const barTheme = flag('categories-header-primary') ? 'primary' : 'default'
+
 class CategoriesPage extends Component {
-  constructor(props) {
-    super(props)
-
-    const theme = flag('categories-header-primary') ? 'primary' : 'default'
-    setBarTheme(theme)
-  }
-
   selectCategory = (selectedCategory, subcategory) => {
     if (subcategory) {
       this.props.router.push(`/categories/${selectedCategory}/${subcategory}`)
@@ -91,6 +86,7 @@ class CategoriesPage extends Component {
 
     return (
       <Fragment>
+        <BarTheme theme={barTheme} />
         <CategoriesHeader
           breadcrumbItems={breadcrumbItems}
           selectedCategory={selectedCategory}

--- a/src/ducks/mobile/BarTheme.jsx
+++ b/src/ducks/mobile/BarTheme.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withSideEffect from 'react-side-effect'
+import { setBarTheme } from 'ducks/mobile/utils'
+
+class BarTheme extends React.Component {
+  render() {
+    return null
+  }
+}
+
+BarTheme.propTypes = {
+  theme: PropTypes.string.isRequired
+}
+
+function reducePropsToState(propsList) {
+  const last = propsList[propsList.length - 1]
+  return last ? last.theme : 'default'
+}
+
+function handleStateChangeOnClient(theme) {
+  setBarTheme(theme)
+}
+
+export default withSideEffect(reducePropsToState, handleStateChangeOnClient)(
+  BarTheme
+)

--- a/src/ducks/mobile/BarTheme.spec.jsx
+++ b/src/ducks/mobile/BarTheme.spec.jsx
@@ -1,0 +1,56 @@
+/* global mount */
+
+import React from 'react'
+import BarTheme from './BarTheme'
+import { setBarTheme } from 'ducks/mobile/utils'
+
+jest.mock('ducks/mobile/utils')
+
+class Testing extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { themes: [] }
+  }
+  addTheme(theme) {
+    const themes = this.state.themes
+    themes.push(theme)
+    this.setState({ themes })
+  }
+
+  removeTheme() {
+    const themes = this.state.themes
+    themes.splice(themes.length - 1, 1)
+    this.setState({ themes })
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.themes.map(theme => (
+          <BarTheme key={theme} theme={theme} />
+        ))}
+      </div>
+    )
+  }
+}
+
+describe('BarTheme', () => {
+  beforeEach(() => {
+    setBarTheme.mockReset()
+  })
+
+  it('should set the theme of the last', () => {
+    const root = mount(<Testing />)
+    const inst = root.instance()
+    inst.addTheme('A')
+    inst.addTheme('B')
+    inst.addTheme('C')
+    expect(setBarTheme).toHaveBeenLastCalledWith('C')
+    inst.removeTheme()
+    expect(setBarTheme).toHaveBeenLastCalledWith('B')
+    inst.removeTheme()
+    expect(setBarTheme).toHaveBeenLastCalledWith('A')
+    inst.removeTheme()
+    expect(setBarTheme).toHaveBeenLastCalledWith('default')
+  })
+})

--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -18,7 +18,7 @@ import {
   registerPushNotifications,
   stopPushNotifications
 } from 'ducks/mobile/push'
-import { initBar, resetClient, setBarTheme } from 'ducks/mobile/utils'
+import { initBar, resetClient } from 'ducks/mobile/utils'
 import LogoutModal from 'components/LogoutModal'
 import { resetFilterByDoc } from 'ducks/filters'
 import { connect } from 'react-redux'
@@ -27,7 +27,6 @@ import appIcon from 'targets/favicons/icon-banks.jpg'
 export const AUTH_PATH = 'authentication'
 
 export const onLogout = async (store, cozyClient) => {
-  setBarTheme('default')
   try {
     await stopPushNotifications()
 
@@ -161,9 +160,6 @@ const withAuth = Wrapped => {
 }
 
 const PotentiallyRevoked_ = props => {
-  if (props.revoked) {
-    setBarTheme('default')
-  }
   return props.revoked ? <Revoked {...props} /> : props.children
 }
 

--- a/src/ducks/pin/FingerprintButton.jsx
+++ b/src/ducks/pin/FingerprintButton.jsx
@@ -15,6 +15,9 @@ class FingerprintButton extends React.PureComponent {
   }
 
   checkForFingerprintSystem() {
+    if (typeof Fingerprint === 'undefined') {
+      return
+    }
     Fingerprint.isAvailable(
       method => {
         this.setState({ method })

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -4,6 +4,7 @@ import styles from 'ducks/pin/styles.styl'
 import PinKeyboard from 'ducks/pin/PinKeyboard'
 import LockedBody from 'ducks/pin/LockedBody'
 import PinTimeout from 'ducks/pin/PinTimeout.debug'
+import BarTheme from 'ducks/mobile/BarTheme'
 
 class PinGuard extends React.Component {
   constructor(props) {
@@ -51,14 +52,15 @@ class PinGuard extends React.Component {
   render() {
     return (
       <React.Fragment>
+        {this.props.children}
         {this.state.showPin ? (
           <LockedBody>
             <div className={styles.PinWrapper}>
+              <BarTheme theme="primary" />
               <PinKeyboard onSuccess={this.handlePinSuccess} />
             </div>
           </LockedBody>
         ) : null}
-        {this.props.children}
         {this.props.showTimeout ? (
           <PinTimeout start={this.state.last} duration={this.props.timeout} />
         ) : null}

--- a/src/ducks/settings/Settings.jsx
+++ b/src/ducks/settings/Settings.jsx
@@ -10,11 +10,8 @@ import { PageTitle } from 'components/Title'
 import { Padded } from 'components/Spacing'
 import cx from 'classnames'
 import flag from 'cozy-flags'
-import { setBarTheme } from 'ducks/mobile/utils'
 
 const Settings = ({ t, children, router, breakpoints: { isMobile } }) => {
-  setBarTheme('default')
-
   const tabNames = ['configuration', 'accounts', 'groups']
   let defaultTab = router.location.pathname.replace('/settings/', '')
   if (tabNames.indexOf(defaultTab) === -1) defaultTab = 'configuration'

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -54,7 +54,7 @@ import {
   sumBalanceHistories,
   balanceHistoryToChartData
 } from 'ducks/balance/helpers'
-import { setBarTheme } from 'ducks/mobile/utils'
+import BarTheme from 'ducks/mobile/BarTheme'
 import flag from 'cozy-flags'
 
 const { BarRight } = cozy.bar
@@ -84,9 +84,6 @@ class TransactionsPage extends Component {
       limitMax: STEP_INFINITE_SCROLL,
       infiniteScrollTop: false
     }
-
-    const theme = flag('transaction-history') ? 'primary' : 'default'
-    setBarTheme(theme)
   }
 
   setCurrentMonthFollowingMostRecentTransaction() {
@@ -327,6 +324,7 @@ class TransactionsPage extends Component {
     const theme = flag('transaction-history') ? 'primary' : 'default'
     return (
       <Fragment>
+        <BarTheme theme={theme} />
         <TransactionHeader
           transactions={filteredTransactions}
           handleChangeMonth={this.handleChangeMonth}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6670,6 +6670,11 @@ execspawn@^1.0.1:
   dependencies:
     util-extend "^1.0.1"
 
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
+  integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -15169,6 +15174,14 @@ react-select@2.2.0:
     react-input-autosize "^2.2.1"
     react-transition-group "^2.2.1"
 
+react-side-effect@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.5.tgz#f26059e50ed9c626d91d661b9f3c8bb38cd0ff2d"
+  integrity sha512-Z2ZJE4p/jIfvUpiUMRydEVpQRf2f8GMHczT6qLcARmX7QRb28JDBTpnM2g/i5y/p7ZDEXYGHWg0RbhikE+hJRw==
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
+
 react-sizeme@2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-sizeme/-/react-sizeme-2.5.2.tgz#e7041390cfb895ed15d896aa91d76e147e3b70b5"
@@ -16636,7 +16649,7 @@ shallow-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
   integrity sha1-UI0YOLPeWQq4dXsBGyXkMJAJRfc=
 
-shallowequal@^1.0.2:
+shallowequal@^1.0.1, shallowequal@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==


### PR DESCRIPTION
Pin needs to set bar theme in blue but the theme must go
back to its previous value when Pin is unmounted.

`react-side-effect` allows to build components that generate
a side effect (here changing the color of the bar), and you
can process all the props of side-effects components before
executing your side effect. In our case, processing means
only taking the last, so the innermost/latest React component will
set the bar color. When unmounted, automatically, the color
is set back to the previous color (or default).