### PR TITLE
Add maintenance property in brand dictionnary and KonnectorAction

### DIFF
--- a/src/ducks/brandDictionary/index.js
+++ b/src/ducks/brandDictionary/index.js
@@ -8,12 +8,14 @@ const getRegexp = brand => {
 export const getBrands = filterFct =>
   filterFct ? brands.filter(filterFct) : brands
 
+export const isMatchingBrand = (brand, label) => getRegexp(brand).test(label)
+
 export const findMatchingBrand = (brands, label) => {
-  return find(brands, brand => getRegexp(brand).test(label))
+  return find(brands, brand => isMatchingBrand(brand, label))
 }
 
 export const matchBrands = (brands, label) => {
-  return some(brands, brand => getRegexp(brand).test(label))
+  return some(brands, brand => isMatchingBrand(brand, label))
 }
 
 export default findMatchingBrand

--- a/src/ducks/brandDictionary/index.spec.js
+++ b/src/ducks/brandDictionary/index.spec.js
@@ -1,4 +1,4 @@
-import { getBrands, matchBrands, findMatchingBrand } from '.'
+import { getBrands, matchBrands, findMatchingBrand, isMatchingBrand } from '.'
 import brands from './brands'
 
 const getFilteredBrands = () => getBrands(brand => brand.name === 'Filtered')
@@ -10,6 +10,18 @@ describe('brandDictionary', () => {
     })
     it('Should return brands filtered', () => {
       expect(getFilteredBrands()).toEqual([])
+    })
+  })
+
+  describe('isMatchingBrand', () => {
+    const [cpam] = brands.filter(brand => brand.name === 'Ameli')
+
+    it('should return true if the brand and the label match', () => {
+      expect(isMatchingBrand(cpam, 'Remboursement CPAM')).toBe(true)
+    })
+
+    it("should return false if the brand and the label don't match", () => {
+      expect(isMatchingBrand(cpam, 'Pouet pouet')).toBe(false)
     })
   })
 

--- a/src/ducks/transactions/TransactionActions.spec.jsx
+++ b/src/ducks/transactions/TransactionActions.spec.jsx
@@ -13,6 +13,15 @@ import data from 'test/fixtures'
 import store, { normalizeData } from 'test/store'
 import getClient from 'test/client'
 
+const brandInMaintenance = {
+  name: 'Maintenance',
+  regexp: '\\bmaintenance\\b',
+  konnectorSlug: 'maintenance',
+  maintenance: true
+}
+
+brands.push(brandInMaintenance)
+
 jest.mock('cozy-ui/react/Icon', () => {
   const OriginalIcon = jest.requireActual('cozy-ui/react/Icon')
   const mockIcon = props => {
@@ -49,7 +58,8 @@ const tests = [
   ['remboursementcomplementaire', null, '1 invoice', null, 'bill', {
     brands: brands.filter(x => x.name == 'Malakoff Mederic').map(b => ({ ...b, hasTrigger: true }))
   }, 'remboursementcomplementaire konnector installed'],
-  ['normalshopping', null, 'toto', null]
+  ['normalshopping', null, 'toto', null],
+  ['maintenance', null, null, null, null]
 ]
 /* eslint-enable */
 

--- a/src/ducks/transactions/__snapshots__/TransactionActions.spec.jsx.snap
+++ b/src/ducks/transactions/__snapshots__/TransactionActions.spec.jsx.snap
@@ -14,6 +14,8 @@ exports[`transaction action menu should render correctly facturebouygues  1`] = 
 
 exports[`transaction action menu should render correctly fnac  1`] = `Array []`;
 
+exports[`transaction action menu should render correctly maintenance  1`] = `Array []`;
+
 exports[`transaction action menu should render correctly normalshopping  1`] = `Array []`;
 
 exports[`transaction action menu should render correctly paiementdocteur  1`] = `Array []`;

--- a/src/ducks/transactions/actions/KonnectorAction.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
 import { withClient } from 'cozy-client'
-import { matchBrands, findMatchingBrand } from 'ducks/brandDictionary'
+import { findMatchingBrand } from 'ducks/brandDictionary'
 import { translate } from 'cozy-ui/react'
 import IntentModal from 'cozy-ui/react/IntentModal'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
@@ -221,9 +221,18 @@ const action = {
   match: (transaction, { brands, urls }) => {
     const brandsWithoutTrigger = getBrandsWithoutTrigger(brands)
 
+    if (!brandsWithoutTrigger) {
+      return false
+    }
+
+    const matchingBrand = findMatchingBrand(
+      brandsWithoutTrigger,
+      transaction.label
+    )
+
     return (
-      brandsWithoutTrigger &&
-      matchBrands(brandsWithoutTrigger, transaction.label) &&
+      matchingBrand &&
+      !matchingBrand.maintenance &&
       (urls['COLLECT'] || urls['HOME'])
     )
   },

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1369,6 +1369,15 @@
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
       "label": "FRANPRIX ST LAZARE PR"
+    },
+    {
+      "_id": "maintenance",
+      "account": "comptegene1",
+      "amount": -44.9,
+      "automaticCategoryId": "400140",
+      "currency": "€",
+      "date": "2018-06-21T00:00:00Z",
+      "label": "maintenance"
     }
   ],
   "io.cozy.bills": [


### PR DESCRIPTION
The KonnectorAction (« My invoices » CTA) now checks if the brand is in maintenance mode or not. This state can be specified in the brand dictionnary by adding the `maintenance: true` property to a brand.