### PR TITLE
Pin settings

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -52,7 +52,10 @@ const App = props => {
 }
 
 export default compose(
-  flag('pin') ? pinGuarded({ timeout: 30 * 1000 }) : x => x,
+  // When removing the pin flag, do not forget to replace the exports (uncomment)
+  // in ducks/pin/index.browser.jsx so that pin functionality is not included
+  // in browsers
+  flag('pin') ? pinGuarded({ showTimeout: true, timeout: 5 * 1000 }) : x => x,
   queryConnect({ settingsCollection: settingsConn }),
   withRouter
 )(App)

--- a/src/components/ErrorBoundary/Error.jsx
+++ b/src/components/ErrorBoundary/Error.jsx
@@ -57,7 +57,7 @@ class Error extends React.Component {
           icon={brokenIcon}
           title={t('Error.title')}
           text={
-            <div
+            <span
               dangerouslySetInnerHTML={{ __html: `${update}</br>${contact}` }}
             />
           }

--- a/src/ducks/pin/PinAuth.jsx
+++ b/src/ducks/pin/PinAuth.jsx
@@ -8,6 +8,7 @@ import compose from 'lodash/flowRight'
 
 import PinKeyboard from 'ducks/pin/PinKeyboard'
 import FingerprintButton from 'ducks/pin/FingerprintButton'
+import { pinSetting } from 'ducks/pin/queries'
 
 /**
  * Show pin keyboard and fingerprint button.
@@ -36,6 +37,21 @@ class PinAuth extends React.Component {
     // this.props.onCancel()
   }
 
+  handleConfirmKeyboard(val) {
+    const { pinSetting, t } = this.props
+    const pinDoc = pinSetting.data
+    if (!pinDoc) {
+      Alerter.info(t('Pin.no-pin-configured'))
+      this.props.onSuccess()
+    } else {
+      if (val === pinDoc.pin) {
+        this.props.onSuccess()
+      } else {
+        Alerter.info(t('Pin.bad-pin'))
+      }
+    }
+  }
+
   render() {
     return (
       <div>
@@ -44,7 +60,7 @@ class PinAuth extends React.Component {
           onError={this.handleFingerprintError}
           onCancel={this.handleFingerprintCancel}
         />
-        <PinKeyboard />
+        <PinKeyboard onConfirm={this.handleConfirmKeyboard} />
       </div>
     )
   }
@@ -58,4 +74,7 @@ class PinAuth extends React.Component {
 
 export default compose(
   translate(),
+  queryConnect({
+    pinSetting
+  })
 )(PinAuth)

--- a/src/ducks/pin/PinAuth.jsx
+++ b/src/ducks/pin/PinAuth.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { queryConnect } from 'cozy-client'
+import Alerter from 'cozy-ui/react/Alerter'
+import { translate } from 'cozy-ui/react/I18n'
+import compose from 'lodash/flowRight'
+
+import PinKeyboard from 'ducks/pin/PinKeyboard'
+import FingerprintButton from 'ducks/pin/FingerprintButton'
+
+/**
+ * Show pin keyboard and fingerprint button.
+ * When user confirms, checks if it is the right pin and
+ * calls onSuccess.
+ */
+class PinAuth extends React.Component {
+  constructor(props) {
+    super(props)
+    this.handleFingerprintSuccess = this.handleFingerprintSuccess.bind(this)
+    this.handleFingerprintError = this.handleFingerprintError.bind(this)
+    this.handleFingerprintCancel = this.handleFingerprintCancel.bind(this)
+    this.handleConfirmKeyboard = this.handleConfirmKeyboard.bind(this)
+  }
+
+  handleFingerprintSuccess() {
+    this.props.onSuccess()
+  }
+
+  handleFingerprintError() {
+    const { t } = this.props.t
+    Alerter.info(t('Pin.bad-pin'))
+  }
+
+  handleFingerprintCancel() {
+    // this.props.onCancel()
+  }
+
+  render() {
+    return (
+      <div>
+        <FingerprintButton
+          onSuccess={this.handleFingerprintSuccess}
+          onError={this.handleFingerprintError}
+          onCancel={this.handleFingerprintCancel}
+        />
+        <PinKeyboard />
+      </div>
+    )
+  }
+
+  static propTypes = {
+    onSuccess: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onError: PropTypes.func.isRequired
+  }
+}
+
+export default compose(
+  translate(),
+)(PinAuth)

--- a/src/ducks/pin/PinEditView.jsx
+++ b/src/ducks/pin/PinEditView.jsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import compose from 'lodash/flowRight'
+
+import { translate } from 'cozy-ui/react'
+import Alerter from 'cozy-ui/react/Alerter'
+import Button from 'cozy-ui/react/Button'
+import Spinner from 'cozy-ui/react/Spinner'
+import { queryConnect, withMutations } from 'cozy-client'
+
+import PinKeyboard from 'ducks/pin/PinKeyboard'
+import PinWrapper from 'ducks/pin/PinWrapper'
+import { pinSetting } from 'ducks/pin/queries'
+import { SETTINGS_DOCTYPE } from 'doctypes'
+import styles from 'ducks/pin/styles.styl'
+
+/**
+ * Handles pin edit
+ *  - user has to repeat
+ *  - show error if both pin are not the same
+ *  - show spinner while pin in saving
+ **/
+class PinEditView extends React.Component {
+  state = {
+    pin1: null,
+    error: null,
+    value: '',
+    saving: false
+  }
+
+  constructor(props) {
+    super(props)
+    this.handleConfirm = this.handleConfirm.bind(this)
+    this.handleKeyboardChange = this.handleKeyboardChange.bind(this)
+  }
+
+  async savePin(pinValue) {
+    const doc = this.props.pinSetting.data
+    await this.props.saveDocument({
+      _type: SETTINGS_DOCTYPE,
+      _id: 'pin',
+      ...doc,
+      pin: pinValue
+    })
+  }
+
+  async handleConfirm(pin) {
+    const t = this.props.t
+    if (this.state.pin1) {
+      if (this.state.pin1 === pin) {
+        this.setState({ saving: true })
+        try {
+          await this.savePin(pin)
+        } catch (e) {
+          Alerter.error(t('Pin.error-save'))
+          throw e
+        } finally {
+          this.setState({ saving: false })
+        }
+        Alerter.success(t('Pin.successfully-changed'))
+        this.props.onSaved()
+      } else {
+        this.setState({ error: 'different-pins', pin1: null, value: '' })
+      }
+    } else {
+      this.setState({ error: null, pin1: pin, value: '' })
+    }
+  }
+
+  handleKeyboardChange(value) {
+    this.setState({ value })
+  }
+
+  render() {
+    const { t } = this.props
+    if (this.state.saving) {
+      return (
+        <PinWrapper>
+          <Spinner />
+        </PinWrapper>
+      )
+    }
+    return (
+      <PinWrapper>
+        <div className={styles['Pin__text']}>
+          {!this.state.pin1
+            ? t('Pin.please-enter-pin')
+            : t('Pin.please-repeat-pin')}
+          <br />
+          {this.state.error ? (
+            <div className={styles['Pin__error']}>
+              {t(`Pin.errors.${this.state.error}`)}
+            </div>
+          ) : null}
+        </div>
+        <PinKeyboard
+          value={this.state.value}
+          onChange={this.handleKeyboardChange}
+          onConfirm={this.handleConfirm}
+        />
+        <Button onClick={this.props.onExit} theme="secondary">
+          Back
+        </Button>
+      </PinWrapper>
+    )
+  }
+}
+
+PinEditView.propTypes = {
+  onSaved: PropTypes.func.isRequired
+}
+
+export const DumbPinEditView = PinEditView
+export default compose(
+  translate(),
+  withMutations(),
+  queryConnect({
+    pinSetting
+  })
+)(PinEditView)

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -18,6 +18,7 @@ class PinGuard extends React.Component {
 
   componentDidMount() {
     document.addEventListener('touchstart', this.handleInteraction)
+    document.addEventListener('click', this.handleInteraction)
     document.addEventListener('resume', this.handleResume)
     document.addEventListener('pause', this.handlePause)
     this.handleInteraction()
@@ -25,6 +26,7 @@ class PinGuard extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('touchstart', this.handleInteraction)
+    document.removeEventListener('click', this.handleInteraction)
     document.removeEventListener('resume', this.handleResume)
     document.removeEventListener('pause', this.handlePause)
   }

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 
 import PinTimeout from 'ducks/pin/PinTimeout.debug'
-import BarTheme from 'ducks/mobile/BarTheme'
 import PinWrapper from 'ducks/pin/PinWrapper'
 import PinAuth from 'ducks/pin/PinAuth'
 

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -1,11 +1,14 @@
 import React from 'react'
 
-import styles from 'ducks/pin/styles.styl'
-import PinKeyboard from 'ducks/pin/PinKeyboard'
 import PinTimeout from 'ducks/pin/PinTimeout.debug'
 import BarTheme from 'ducks/mobile/BarTheme'
 import PinWrapper from 'ducks/pin/PinWrapper'
+import PinAuth from 'ducks/pin/PinAuth'
 
+/**
+ * Wraps an App and display a Pin screen after a period
+ * of inactivity (touch events on document).
+ */
 class PinGuard extends React.Component {
   constructor(props) {
     super(props)
@@ -57,7 +60,7 @@ class PinGuard extends React.Component {
         {this.props.children}
         {this.state.showPin ? (
           <PinWrapper>
-            <PinKeyboard onSuccess={this.handlePinSuccess} />
+            <PinAuth onSuccess={this.handlePinSuccess} />
           </PinWrapper>
         ) : null}
         {this.props.showTimeout ? (

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 
 import styles from 'ducks/pin/styles.styl'
 import PinKeyboard from 'ducks/pin/PinKeyboard'
-import LockedBody from 'ducks/pin/LockedBody'
 import PinTimeout from 'ducks/pin/PinTimeout.debug'
 import BarTheme from 'ducks/mobile/BarTheme'
+import PinWrapper from 'ducks/pin/PinWrapper'
 
 class PinGuard extends React.Component {
   constructor(props) {
@@ -54,12 +54,9 @@ class PinGuard extends React.Component {
       <React.Fragment>
         {this.props.children}
         {this.state.showPin ? (
-          <LockedBody>
-            <div className={styles.PinWrapper}>
-              <BarTheme theme="primary" />
-              <PinKeyboard onSuccess={this.handlePinSuccess} />
-            </div>
-          </LockedBody>
+          <PinWrapper>
+            <PinKeyboard onSuccess={this.handlePinSuccess} />
+          </PinWrapper>
         ) : null}
         {this.props.showTimeout ? (
           <PinTimeout start={this.state.last} duration={this.props.timeout} />

--- a/src/ducks/pin/PinKeyboard.jsx
+++ b/src/ducks/pin/PinKeyboard.jsx
@@ -5,27 +5,76 @@ import range from 'lodash/range'
 import styles from 'ducks/pin/styles'
 import Round from 'ducks/pin/Round'
 
+
+/**
+ * Allows to type a value with an onScreen keyboard.
+ * If `onChange` is defined, it acts as a controlled component,
+ * otherwise, it keeps an internal state.
+ */
 class PinKeyboard extends React.PureComponent {
   constructor(props) {
     super(props)
+    this.handleConfirm = this.handleConfirm.bind(this)
+    this.handleClickNumber = this.handleClickNumber.bind(this)
+    this.handleRemoveCharacter = this.handleRemoveCharacter.bind(this)
   }
 
+  state = {
+    value: ''
+  }
 
+  handleConfirm() {
+    this.props.onConfirm(this.getValue())
+  }
 
+  getValue() {
+    return this.props.value || this.state.value
+  }
+
+  handleClickNumber(n) {
+    const value = this.getValue()
+    const newVal = (value + n).substr(0, MAX_LENGTH)
+    this.handleNewValue(newVal)
+  }
+
+  handleRemoveCharacter() {
+    const newVal = this.state.value.substr(0, this.state.value.length - 1)
+    this.handleNewValue(newVal)
+  }
+
+  handleNewValue(newVal) {
+    if (this.props.onChange) {
+      this.props.onChange(newVal)
+    } else {
+      this.setState({ value: newVal })
+    }
   }
 
   render() {
+    const value = this.getValue()
     return (
-      <div className={styles.PinKeyboard}>
-        {range(1, 10).map(n => (
-          <Round key={n}>{n}</Round>
-        ))}
-        <Round>0</Round>
-        <Round className="u-hide" />
+      <div>
+        <div className={styles.PinKeyboard}>
+          {range(1, 10).map(n => (
+            <Round
+              onClick={this.handleClickNumber.bind(null, n.toString())}
+              key={n}
+            >
+              {n}
+            </Round>
+          ))}
+          <Round onClick={this.handleRemoveCharacter}>R</Round>
+          <Round>0</Round>
+          <Round onClick={this.handleConfirm}>OK</Round>
+        </div>
       </div>
     )
   }
+}
 
+PinKeyboard.propTypes = {
+  value: PropTypes.string,
+  onChange: PropTypes.func
 }
 
 export default PinKeyboard

--- a/src/ducks/pin/PinKeyboard.jsx
+++ b/src/ducks/pin/PinKeyboard.jsx
@@ -1,10 +1,29 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import range from 'lodash/range'
 
 import styles from 'ducks/pin/styles'
 import Round from 'ducks/pin/Round'
 
+const MAX_LENGTH = 6
+
+/**
+ * Shows a value as Dots
+ */
+const Dots = props => {
+  return (
+    <div className={cx(styles['Pin__dots'], styles['Pin__text'])}>
+      {range(1, props.max).map(i => (
+        <span key={i}>{i <= props.value.length ? '●' : '○'}</span>
+      ))}
+    </div>
+  )
+}
+
+Dots.propTypes = {
+  value: PropTypes.string.isRequired
+}
 
 /**
  * Allows to type a value with an onScreen keyboard.
@@ -54,6 +73,7 @@ class PinKeyboard extends React.PureComponent {
     const value = this.getValue()
     return (
       <div>
+        <Dots max={MAX_LENGTH} value={value} />
         <div className={styles.PinKeyboard}>
           {range(1, 10).map(n => (
             <Round

--- a/src/ducks/pin/PinKeyboard.jsx
+++ b/src/ducks/pin/PinKeyboard.jsx
@@ -4,26 +4,14 @@ import range from 'lodash/range'
 
 import styles from 'ducks/pin/styles'
 import Round from 'ducks/pin/Round'
-import FingerprintButton from 'ducks/pin/FingerprintButton'
 
 class PinKeyboard extends React.PureComponent {
   constructor(props) {
     super(props)
-    this.handleFingerprintSuccess = this.handleFingerprintSuccess.bind(this)
-    this.handleFingerprintError = this.handleFingerprintError.bind(this)
-    this.handleFingerprintCancel = this.handleFingerprintCancel.bind(this)
   }
 
-  handleFingerprintSuccess() {
-    this.props.onSuccess()
-  }
 
-  handleFingerprintError() {
-    this.props.onError()
-  }
 
-  handleFingerprintCancel() {
-    this.props.onCancel()
   }
 
   render() {
@@ -32,22 +20,12 @@ class PinKeyboard extends React.PureComponent {
         {range(1, 10).map(n => (
           <Round key={n}>{n}</Round>
         ))}
-        <FingerprintButton
-          onSuccess={this.handleFingerprintSuccess}
-          onError={this.handleFingerprintError}
-          onCancel={this.handleFingerprintCancel}
-        />
         <Round>0</Round>
         <Round className="u-hide" />
       </div>
     )
   }
 
-  static propTypes = {
-    onSuccess: PropTypes.func.isRequired,
-    onCancel: PropTypes.func.isRequired,
-    onError: PropTypes.func.isRequired
-  }
 }
 
 export default PinKeyboard

--- a/src/ducks/pin/PinWrapper.jsx
+++ b/src/ducks/pin/PinWrapper.jsx
@@ -2,11 +2,14 @@ import React from 'react'
 import LockedBody from 'ducks/pin/LockedBody'
 import styles from 'ducks/pin/styles.styl'
 import BarTheme from 'ducks/mobile/BarTheme'
+import Portal from 'cozy-ui/react/Portal'
 
 const PinWrapper = ({ children }) => (
   <LockedBody>
     <BarTheme theme="primary" />
-    <div className={styles.PinWrapper}>{children}</div>
+    <Portal into="body">
+      <div className={styles.PinWrapper}>{children}</div>
+    </Portal>
   </LockedBody>
 )
 

--- a/src/ducks/pin/PinWrapper.jsx
+++ b/src/ducks/pin/PinWrapper.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import LockedBody from 'ducks/pin/LockedBody'
+import styles from 'ducks/pin/styles.styl'
+import BarTheme from 'ducks/mobile/BarTheme'
+
+const PinWrapper = ({ children }) => (
+  <LockedBody>
+    <BarTheme theme="primary" />
+    <div className={styles.PinWrapper}>{children}</div>
+  </LockedBody>
+)
+
+export default PinWrapper

--- a/src/ducks/pin/index.browser.jsx
+++ b/src/ducks/pin/index.browser.jsx
@@ -1,3 +1,8 @@
-const pinGuarded = () => x => x
+// const pinGuarded = () => x => x
 
-export { pinGuarded }
+// export { pinGuarded }
+
+// Temporary export, pinGuarded should not be used on
+// browsers, this is mainly for testing. It is behind
+// a flag at the moment.
+export { default as pinGuarded } from './hoc'

--- a/src/ducks/pin/queries.js
+++ b/src/ducks/pin/queries.js
@@ -1,0 +1,11 @@
+import { SETTINGS_DOCTYPE } from 'doctypes'
+
+const getOne = (doctype, id) => client => {
+  const queryDef = client.all(doctype)
+  queryDef.id = id
+  return queryDef
+}
+
+export const pinSetting = {
+  query: getOne(SETTINGS_DOCTYPE, 'pin')
+}

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -20,9 +20,10 @@
     align-items center
     justify-content center
     display flex
-    width 100%
     flex-direction row
     flex-wrap wrap
+    max-width 300px
+    margin auto
 
 .PinWrapper
     background var(--primaryColor)

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -12,7 +12,7 @@
     border 0
 
 .Round:active, .Round:focus 
-    background rgba(0, 0, 0, 0.5)
+    background rgba(0, 0, 0, 0.15)
     transform scale(1.1)
     transition transform 0.1s ease
 

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -28,9 +28,12 @@
     background var(--primaryColor)
     width 100vw
     height 100vh
-    z-index 10000
-    position absolute
+    z-index 100
+    position fixed
     display flex
     justify-content center
     flex-direction column
     top 0
+    bottom 0
+    left 0
+    right 0

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -37,6 +37,10 @@
     bottom 0
     left 0
     right 0
+
+.Pin__dots
+    font-size 2rem
+
 .Pin__text
     color var(--primaryContrastTextColor)
     text-align center

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -37,3 +37,14 @@
     bottom 0
     left 0
     right 0
+.Pin__text
+    color var(--primaryContrastTextColor)
+    text-align center
+    
+.Pin__error
+    background var(--pomegranate)
+    color var(--primaryContrastTextColor)
+    margin .5rem
+    padding .5rem
+    border-radius .5rem
+    display inline-block

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -12,6 +12,8 @@ import { settingsConn } from 'doctypes'
 import { flowRight as compose, set } from 'lodash'
 import Loading from 'components/Loading'
 import { getDefaultedSettingsFromCollection } from './helpers'
+import PinSettings from 'ducks/settings/PinSettings'
+import flag from 'cozy-flags'
 
 class Configuration extends React.PureComponent {
   saveDocument = async doc => {
@@ -96,6 +98,7 @@ class Configuration extends React.PureComponent {
             name="localModelOverride"
           />
         </TogglePane>
+        {flag('pin') ? <PinSettings /> : null}
       </div>
     )
   }

--- a/src/ducks/settings/PinSettings.jsx
+++ b/src/ducks/settings/PinSettings.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import Button from 'cozy-ui/react/Button'
+
+import PinEditView from 'ducks/pin/PinEditView'
+
+class PinSettings extends React.Component {
+  state = {
+    configuring: false
+  }
+
+  constructor(props) {
+    super(props)
+    this.handleConfigure = this.handleConfigure.bind(this)
+    this.handleExit = this.handleExit.bind(this)
+    this.handlePinSaved = this.handlePinSaved.bind(this)
+  }
+
+  handleConfigure() {
+    this.setState({ configuring: true })
+  }
+
+  handleExit() {
+    this.setState({ configuring: false })
+  }
+
+  handlePinSaved() {
+    this.setState({ configuring: false })
+  }
+
+  render() {
+    return (
+      <div>
+        <Button onClick={this.handleConfigure}>
+          Configure PIN code for mobile
+        </Button>
+        {this.state.configuring ? (
+          <PinEditView onSaved={this.handlePinSaved} onExit={this.handleExit} />
+        ) : null}
+      </div>
+    )
+  }
+}
+
+export default PinSettings

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -526,5 +526,15 @@
     "title": "Update of your banking connections",
     "content": "A latest version of our banking connection has been released. You need to sign the new terms of service. <a href='https://support.cozy.io/article/302-budget' target='_blank'>Learn more</a>.",
     "cta": "Update my banks"
+  },
+
+  "Pin": {
+    "please-enter-pin": "Please enter a pin (max: 6 characters).",
+    "please-repeat-pin": "Please repeat the code.",
+    "errors": {
+      "different-pins": "The two codes are different, please retry."
+    },
+    "successfully-changed": "Pin succesfully changed",
+    "error-save": "Could not save pin, are you connected to internet ?"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -479,5 +479,15 @@
     "title": "Nouveaux connecteurs bancaires",
     "content": "De nouvelles versions des connecteurs sont disponibles et nécessitent une mise à jour de leurs CGUs. <a href='https://support.cozy.io/article/302-budget' target='_blank'>En savoir plus</a>.",
     "cta": "Mettre à jour mes banques"
+  },
+
+  "Pin": {
+    "please-enter-pin": "Merci d'entrer un code (max: 6 caractères).",
+    "please-repeat-pin": "Merci de répeter ce code.",
+    "errors": {
+      "different-pins": "Les deux codes sont différents, merci de recommencer."
+    },
+    "successfully-changed": "Code changé avec succès",
+    "error-save": "Erreur de la sauvegarde du pin, êtes vous connecté à internet ?"
   }
 }


### PR DESCRIPTION
- Add Pin configuration in Settings
- Pin functionality is now basicly functional

Caveats

- Alert for bad pin is behind the Pin screen, need to fix this
- When no pin is configured, you cannot re-enter the app if the pin screen is displayed. As a workaround, you can set a pin-duration for 100s, configure the pin, and then set a lower duration

Visible on https://testbankspinsettings-banks.cozy.works/#/balances

```
flag('pin', true)
flag('pin-timeout', true) // show how much time left
flag('pin-duration', 100) // set the number of seconds before the pin is shown after the last click 
// configure the pin code via settings page
flag('pin-duration', 10) // 5/10 seconds seems reasonable when testing
```