### PR TITLE
Allow config.xml transformations at build time

### DIFF
--- a/docs/override-cordova-config.md
+++ b/docs/override-cordova-config.md
@@ -1,0 +1,46 @@
+# Override Cordova project `config.xml`
+
+It is possible to override the Cordova project config file located at
+`src/targets/mobile/config.xml` before building the app.
+
+To achieve that, you have to declare a `MOBILE_CONFIG_TRANSFORM_FILE`
+environment variable containing the path (absolute or relative to
+`src/targets/mobile`) to an XSL file when building the app.
+
+```
+env MOBILE_CONFIG_TRANSFORM_FILE=override-config.xsl yarn android:run
+```
+
+Don't worry about this XSL thing, this is not that hard, just a little verbose.
+Still, this is a good way to customize an XML document. Here is an example XSL
+that customizes the app's name and identifiers on stores:
+
+```xml
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:widget="http://www.w3.org/ns/widgets">
+  <!-- Copy the original file -->
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Customize Android package name on store -->
+  <xsl:template match="widget:widget/@android-packageName">
+    <xsl:attribute name="android-packageName">
+      <xsl:value-of select="'io.cozy.my-custom-banks'"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- Customize iOS package name on store -->
+  <xsl:template match="widget:widget/@ios-CFBundleIdentifier">
+    <xsl:attribute name="ios-CFBundleIdentifier">
+      <xsl:value-of select="'io.cozy.my-custom-banks'"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <!-- Customize app name -->
+  <xsl:template match="widget:widget/widget:name">
+    <name>My App Name</name>
+  </xsl:template>
+</xsl:stylesheet>
+```

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "imports-loader": "0.8.0",
     "jest": "24.5.0",
     "json-loader": "0.5.7",
+    "libxslt": "0.7.0",
     "lint-staged": "8.1.5",
     "madge": "3.4.4",
     "mini-css-extract-plugin": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "watch:mobile:production": "NODE_ENV=mobile:production npm run commons:watch -- --env.target=mobile",
     "serve:mobile": "(cd src/targets/mobile/www && http-server -p 8005)",
     "mobile:icon": "(cd src/targets/mobile && splashicon-generator --imagespath='./res/model')",
-    "mobile:prepare": "(cd src/targets/mobile && cordova prepare && bundle install) && [[ $(uname) == 'Darwin' ]] && npm run ios:install_pods",
+    "mobile:prepare": "(cd src/targets/mobile && cordova prepare && bundle install) && if [ $(uname) == 'Darwin' ] ; then npm run ios:install_pods ; fi",
     "mobile:clean": "(cd src/targets/mobile && rm -rf package.json node_modules platforms plugins)",
     "mobile:build": "npm run build:mobile && npm run mobile:clean && npm run mobile:prepare",
     "android:run": "(cd src/targets/mobile && cordova run android --device)",

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -12,6 +12,7 @@
     <allow-intent href="mailto:*" />
     <allow-intent href="geo:*" />
     <preference name="AppendUserAgent" value="io.cozy.banks.mobile-1.0.3" />
+    <hook src="scripts/beforePrepare.js" type="before_prepare"/>
     <platform name="android">
         <allow-intent href="market:*" />
         <icon density="ldpi" src="res/icons/android/icon-36-ldpi.png" />

--- a/src/targets/mobile/scripts/beforePrepare.js
+++ b/src/targets/mobile/scripts/beforePrepare.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const path = require('path')
+const fs = require('fs-extra')
+const libxslt = require('libxslt')
+
+function handleError(error) {
+  console.log('Error in beforePrepare hook:')
+  console.error(error)
+  throw error
+}
+module.exports = function (context) {
+  if (!process.env.MOBILE_CONFIG_TRANSFORM_FILE) {
+    console.log('No transformation file provided, skipping transformation step')
+    return
+  }
+
+  const transformFilePath = path.resolve(
+    process.cwd(),
+    process.env.MOBILE_CONFIG_TRANSFORM_FILE
+  )
+
+  let transformFile
+
+  try {
+    transformFile = fs.readFileSync(transformFilePath, 'utf8')
+  } catch (err) {
+    handleError(err)
+  }
+
+  const configPath = path.resolve(__dirname, '../config.xml')
+  const config = fs.readFileSync(configPath, 'utf8')
+
+  libxslt.parse(transformFile, (err, stylesheet) => {
+    if (err) {
+      handleError(err)
+    }
+
+    stylesheet.apply(config, (err, output) => {
+      if (err) {
+        handleError(err)
+      }
+
+      fs.writeFileSync(configPath, output)
+      console.log(`config.xml successfully transformed using ${transformFilePath}`)
+    })
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2653,6 +2653,13 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.11.0.tgz#46aa1751fb6a2f93ee5e689bb1087d4b14c6c205"
   integrity sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=
 
+bindings@^1.2.1:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 bindings@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.2.1.tgz#14ad6113812d2d37d72e67b4cacb4bb726505f11"
@@ -7095,6 +7102,11 @@ file-loader@^0.8.1:
   dependencies:
     loader-utils "~0.2.5"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"
@@ -10567,6 +10579,23 @@ lexical-scope@^1.2.0:
   dependencies:
     astw "^2.0.0"
 
+libxmljs-mt@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/libxmljs-mt/-/libxmljs-mt-0.18.0.tgz#dc94eacc38b38c8e3d8a2412efb8e471b53886c1"
+  integrity sha1-3JTqzDizjI49iiQS77jkcbU4hsE=
+  dependencies:
+    bindings "^1.2.1"
+    nan "^2.3.2"
+
+libxslt@0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/libxslt/-/libxslt-0.7.0.tgz#dd6469bb89af35dd6820d997b1e019e2e302d2ee"
+  integrity sha512-lVzTGnCWVdSnLkMp7DIWt1dLsNp7XACvG4K/7XC65hrflm96aFKtc3vVN0JJxjToDRphnVwGHrFWLmIT3GKqGA==
+  dependencies:
+    bindings "~1.2.1"
+    libxmljs-mt "0.18.0"
+    nan "^2.1.0"
+
 lie@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.0.4.tgz#bc7ae1ebe7f1c8de39afdcd4f789076b47b0f634"
@@ -12130,6 +12159,11 @@ nan-x@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nan-x/-/nan-x-1.0.2.tgz#5f34e9d3115242486219eee3c8bc49fd2425b19a"
   integrity sha512-dndRmy03JQEN+Nh6WjQl7/OstIozeEmrtWe4TE7mEqJ8W8oMD8m2tHjsLPWt//e3hLAeRSbs4pxMyc5pk/nCkQ==
+
+nan@^2.1.0, nan@^2.3.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
 nan@^2.3.0, nan@~2.10.0:
   version "2.10.0"
@@ -13998,13 +14032,6 @@ pouchdb-adapter-cordova-sqlite@2.0.5:
   integrity sha512-K7eIQzFYfuYOo4Nwn8r96Pq01t5mPOppO+n31U7IM/fPJTIGS/juJyNYYY9ePrlrz8icHEDl35cgHLMq40xFyA==
   dependencies:
     pouchdb-adapter-websql-core "^6.4.3"
-
-"pouchdb-adapter-cordova-sqlite@git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
-  version "2.0.2"
-  uid f3ee23009b70209c611435d57491aa77fb88802a
-  resolved "git+https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
-  dependencies:
-    pouchdb-adapter-websql-core "^6.1.1"
 
 "pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
   version "2.0.2"


### PR DESCRIPTION
This allows to specify the path to a XSL file in an environment variable. This XSL is applied to `config.xml` in a `before_prepare` hook, so the built app uses the transformed configuration.

« XSL » can be scary to read, as it sounds like an old technology, but it's made for what we want to do : transform XML documents. Otherwise we would have to use a lot of regex and placeholders. Here, we use something that is verbose, but is standard and exists for what we want to achieve.