### PR TITLE
chore: Put libxslt in optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "imports-loader": "0.8.0",
     "jest": "24.5.0",
     "json-loader": "0.5.7",
-    "libxslt": "0.7.0",
     "lint-staged": "8.1.5",
     "madge": "3.4.4",
     "mini-css-extract-plugin": "0.5.0",
@@ -254,5 +253,8 @@
     "extends": [
       "cozy"
     ]
+  },
+  "optionalDependencies": {
+    "libxslt": "0.7.0"
   }
 }

--- a/src/targets/mobile/scripts/beforePrepare.js
+++ b/src/targets/mobile/scripts/beforePrepare.js
@@ -2,7 +2,6 @@
 
 const path = require('path')
 const fs = require('fs-extra')
-const libxslt = require('libxslt')
 
 function handleError(error) {
   console.log('Error in beforePrepare hook:')
@@ -12,6 +11,17 @@ function handleError(error) {
 module.exports = function (context) {
   if (!process.env.MOBILE_CONFIG_TRANSFORM_FILE) {
     console.log('No transformation file provided, skipping transformation step')
+    return
+  }
+
+
+  let libxslt
+
+  try {
+    libxslt = require('libxslt')
+  } catch (err) {
+    console.error('Transformation file provided, but impossible to load `libxslt`. See the error below to know more:')
+    console.error(err)
     return
   }
 


### PR DESCRIPTION
The whole banks dependencies install should not fail if libxslt install
fails, since it's used only in special cases (when we want to override
the config.xml before building the mobile app)