### PR TITLE
feat(Balance): Fetch triggers or accounts when is necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.14.13",
     "cozy-pouch-link": "6.18.0",
+    "cozy-realtime": "3.0.0-beta.1",
     "cozy-ui": "19.17.0",
     "d3": "5.9.2",
     "date-fns": "1.30.1",

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -3,12 +3,7 @@ import { flowRight as compose, get, sumBy, set, debounce } from 'lodash'
 
 import { queryConnect, withMutations } from 'cozy-client'
 import flag from 'cozy-flags'
-import {
-  ACCOUNT_DOCTYPE,
-  GROUP_DOCTYPE,
-  SETTINGS_DOCTYPE,
-  TRIGGER_DOCTYPE
-} from 'doctypes'
+import { groupsConn, settingsConn, triggersConn, accountsConn } from 'doctypes'
 import cx from 'classnames'
 
 import { connect } from 'react-redux'
@@ -257,10 +252,10 @@ export default compose(
     actionCreators
   ),
   queryConnect({
-    accounts: { query: client => client.all(ACCOUNT_DOCTYPE), as: 'accounts' },
-    groups: { query: client => client.all(GROUP_DOCTYPE), as: 'groups' },
-    settings: { query: client => client.all(SETTINGS_DOCTYPE), as: 'settings' },
-    triggers: { query: client => client.all(TRIGGER_DOCTYPE), as: 'triggers' }
+    accounts: accountsConn,
+    groups: groupsConn,
+    settings: settingsConn,
+    triggers: triggersConn
   }),
   withMutations()
 )(Balance)

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -165,11 +165,11 @@ class Balance extends PureComponent {
     client.query(triggersConn.query(client))
   }
 
-  startFetchTriggersInterval() {
+  startFetchTriggers() {
     this.startRealtime(TRIGGER_DOCTYPE, this.fetchTriggers)
   }
 
-  stopFetchTriggersInterval() {
+  stopFetchTriggers() {
     this.stopRealtime(TRIGGER_DOCTYPE, this.fetchTriggers)
   }
 
@@ -178,17 +178,17 @@ class Balance extends PureComponent {
     client.query(accountsConn.query(client))
   }
 
-  startFetchAccountsInterval() {
+  startFetchAccounts() {
     this.startRealtime(ACCOUNT_DOCTYPE, this.fetchAccounts)
   }
 
-  stopFetchAccountsInterval() {
+  stopFetchAccounts() {
     this.stopRealtime(ACCOUNT_DOCTYPE, this.fetchAccounts)
   }
 
   componentWillUnmount() {
-    this.stopFetchTriggersInterval()
-    this.stopFetchAccountsInterval()
+    this.stopFetchTriggers()
+    this.stopFetchAccounts()
   }
 
   render() {
@@ -241,17 +241,17 @@ class Balance extends PureComponent {
       }
 
       if (konnectorSlugs.length > 0) {
-        this.stopFetchTriggersInterval()
-        this.startFetchAccountsInterval()
+        this.stopFetchTriggers()
+        this.startFetchAccounts()
         return <AccountsImporting konnectorSlugs={konnectorSlugs} />
       }
 
-      this.stopFetchAccountsInterval()
-      this.startFetchTriggersInterval()
+      this.stopFetchAccounts()
+      this.startFetchTriggers()
       return <NoAccount />
     }
-    this.stopFetchAccountsInterval()
-    this.stopFetchTriggersInterval()
+    this.stopFetchAccounts()
+    this.stopFetchTriggers()
 
     const groups = [...groupsCollection.data, ...buildVirtualGroups(accounts)]
 

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -1,5 +1,6 @@
 /* global shallow */
 
+import getClient from 'test/client'
 const React = require('react')
 const { DumbBalance } = require('./Balance')
 const debounce = require('lodash/debounce')
@@ -31,6 +32,7 @@ describe('Balance page', () => {
         saveDocument={saveDocumentMock}
         filterByAccounts={filterByAccounts}
         router={router}
+        client={getClient()}
       />
     )
     instance = root.instance()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4715,6 +4715,11 @@ cozy-realtime@2.0.7:
   resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-2.0.7.tgz#1ca40806e4a3e752bf1d6ea4f8a761a8eaa123d2"
   integrity sha512-rGJ4lLqbhcw6CKYIKir3lpuck1GbJCy2hUiEKeQXjeLU0j4TIPB1OBk01oz46RyTcAr2tzW8EesRGd4eqy/8Hw==
 
+cozy-realtime@3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.0.0-beta.1.tgz#669b046ac4d8eb934e4ef6614a54970b8b1a417f"
+  integrity sha512-Y6HE2d+i52t2bXtSQ9CariCB/XEBcVMUYmQWOZnp3jV7ciu8HtbekWKmOt2M5nf+Q3zSqaiqiX/VFKruHFrz9Q==
+
 cozy-stack-client@^6.12.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.17.0.tgz#02d200ebba371d27332de246583e5cb49f1a968f"


### PR DESCRIPTION
Nous utilisons actuellement la lib cozy-realtime directement dans le dépot. Lorsque la nouvelle API sera sorti on pourra utiliser cozy-realtime directement depuis npm.

Relevant PR for realtime new API : https://github.com/cozy/cozy-libs/pull/355
