### PR TITLE
fix(Cordova): Upgrade ios and android engine

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -75,8 +75,7 @@
         <resource-file src="keys/ios/GoogleService-Info.plist" />
     </platform>
     <preference name="StatusBarBackgroundColor" value="#95999D" />
-    <engine name="android" spec="7.1.0" />
-    <engine name="ios" spec="4.5.4" />
+    <engine name="android" spec="7.1.4" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <plugin name="cordova-plugin-statusbar" spec="2.4.2" />
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.1" />
@@ -99,4 +98,5 @@
         <variable name="FACEID_USAGE_DESCRIPTION" value=" " />
     </plugin>
     <plugin name="cordova-blur-app-privacy-screen" spec="https://github.com/lifeofcoding/cordova-blur-app-privacy-screen.git" />
+    <engine name="ios" spec="4.5.5" />
 </widget>


### PR DESCRIPTION
- Upgrade android since there is a big issue with maven / jcenter recently (see this issue https://issues.apache.org/jira/browse/CB-14127). We can't build the native part of banks on android without this fix (from scratch, you don't see the problem if you have already built once). 

- Upgraded ios, but nothing special to say about it (https://cordova.apache.org/announcements/2018/07/26/cordova-ios-4.5.5.html) 