### PR TITLE
refactor: Do not auto import palette

### DIFF
--- a/config/webpack.config.cozy-ui.js
+++ b/config/webpack.config.cozy-ui.js
@@ -22,7 +22,7 @@ module.exports = {
       options: {
         stylus: {
           use: [require('cozy-ui/stylus')()],
-          import: ['settings/palette.styl']
+          import: []
         }
       }
     })

--- a/src/components/AccountSharingStatus/AccountSharingStatus.styl
+++ b/src/components/AccountSharingStatus/AccountSharingStatus.styl
@@ -1,15 +1,13 @@
-@require 'settings/palette'
-
 .account-sharing-tooltip
     :global
         .react-hint__content
-            background charcoalGrey
+            background var(--charcoalGrey)
 
     &:global(.react-hint--top)::after
-        border-top-color charcoalGrey
+        border-top-color var(--charcoalGrey)
     &:global(.react-hint--bottom)::after
-        border-bottom-color charcoalGrey
+        border-bottom-color var(--charcoalGrey)
     &:global(.react-hint--left)::after
-        border-left-color charcoalGrey
+        border-left-color var(--charcoalGrey)
     &:global(.react-hint--right)::after
-        border-right-color charcoalGrey
+        border-right-color var(--charcoalGrey)

--- a/src/components/List/List.styl
+++ b/src/components/List/List.styl
@@ -1,4 +1,4 @@
-@require '../../stylus/components/list'
+@require 'components/list'
 
 .c-list-row
     min-height 3rem

--- a/src/components/PopupSelect/styles.styl
+++ b/src/components/PopupSelect/styles.styl
@@ -1,17 +1,15 @@
-@require 'settings/palette'
-
 .PopupSelect__content
     margin-left -1.5em
     width calc(100% + 3em)
 
 .PopupSelect__title
-    border-bottom 1px solid silver
+    border-bottom 1px solid var(--silver)
 
 .PopupSelect__row
-    border-bottom 1px solid silver
+    border-bottom 1px solid var(--silver)
 
     &:hover
-        background-color paleGrey
+        background-color var(--paleGrey)
         cursor pointer
 
     &:last-child

--- a/src/components/Select/styles.styl
+++ b/src/components/Select/styles.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'settings/breakpoints'
 
 select-date-height-small=2.75rem
@@ -21,7 +20,7 @@ select-date-height-small=2.75rem
     // Let click go through to the select
     pointer-events none
     cursor pointer
-    color coolGrey
+    color var(--coolGrey)
 
 /* target Internet Explorer 9 to undo the custom arrow */
 @media screen and (min-width:0\0)

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -1,5 +1,4 @@
 @require 'settings/breakpoints'
-@require 'settings/palette'
 @require '~styles/variables.styl'
 
 // Due to discrepancies between Chrome and Firefox in
@@ -36,7 +35,7 @@ select-date-height-small = 2.75rem
         background var(--white)
         width auto
         height select-date-height-small
-        color slateGrey
+        color var(--slateGrey)
 
         .SelectDates__chip
             height select-date-height-small
@@ -77,7 +76,7 @@ select-date-height-small = 2.75rem
                 padding 0
 
 .SelectDates__Select
-    color slateGrey
+    color var(--slateGrey)
 
 .SelectDates__month
     width 9rem
@@ -119,12 +118,12 @@ select-date-height-small = 2.75rem
 
     .SelectDates__Button.SelectDates__Button
         width auto
-        color coolGrey
+        color var(--coolGrey)
         padding-left 0.875rem
         padding-right 0.875rem
 
     .SelectDates__Button--disabled svg
-        color silver
+        color var(--silver)
 
     .SelectDates__Select
         color inherit
@@ -132,8 +131,8 @@ select-date-height-small = 2.75rem
 .SelectDates__Button
     cursor pointer
     transition transform 0.3s ease
-    color coolGrey
+    color var(--coolGrey)
 
 .SelectDates__Button--disabled
-    color silver
+    color var(--silver)
     cursor not-allowed

--- a/src/components/SharingIcon/SharingIcon.styl
+++ b/src/components/SharingIcon/SharingIcon.styl
@@ -1,5 +1,3 @@
-@require 'settings/palette'
-
 .sharing-icon
     background-image embedurl('../assets/icons/ui/share.svg')
     display inline-block
@@ -14,7 +12,7 @@
     margin-left .5rem
 
 .sharing-icon--to
-    background-color emerald
+    background-color var(--emerald)
 
 .sharing-icon--from
-    background-color portage
+    background-color var(--portage)

--- a/src/ducks/balance/components/BalanceRow.styl
+++ b/src/ducks/balance/components/BalanceRow.styl
@@ -1,11 +1,10 @@
 @require 'settings/breakpoints'
 @require '~styles/mixins.styl'
-@require 'settings/palette.styl'
 
 .BalanceRow
     &:active
     &:focus
-        background zircon
+        background var(--zircon)
 
     cursor pointer
     composes mobile-row from '../../../components/Table/styles.styl'
@@ -21,7 +20,7 @@
 
         &.warning
             font-weight bold
-            color texasRose
+            color var(--texasRose)
 
             span
                 margin-left 5px
@@ -31,12 +30,12 @@
                     vertical-align middle
                     margin-bottom 3px
         &.alert
-            color pomegranate
+            color var(--pomegranate)
 
 .BalanceRow--selected
-    border-left 0.25rem dodgerBlue solid
-    background zircon
+    border-left 0.25rem var(--dodgerBlue) solid
+    background var(--zircon)
 
 .BalanceRow--selected-account-from-group
     border-left 0.25rem silver solid
-    background paleGrey
+    background var(--paleGrey)

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette.styl'
 @require 'settings/breakpoints'
 @require '~styles/mixins.styl'
 
@@ -21,11 +20,11 @@
 
     &__number
         maxed-flex-basis 15%
-        color coolGrey
+        color var(--coolGrey)
 
     &__type
         maxed-flex-basis 15%
-        color coolGrey
+        color var(--coolGrey)
 
         +small-screen()
             td& // increase selectivity with td
@@ -68,5 +67,5 @@
                 background transparent
 
             td:first-child
-                color coolGrey
+                color var(--coolGrey)
                 font-size .85rem

--- a/src/ducks/settings/GroupsSettings.styl
+++ b/src/ducks/settings/GroupsSettings.styl
@@ -1,4 +1,3 @@
-@require 'settings/palette'
 @require 'components/forms.styl'
 @require 'settings/breakpoints'
 @require '~styles/mixins.styl'

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -1,5 +1,3 @@
-@require 'settings/palette.styl'
-
 // @stylint off
 body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)

--- a/src/styles/utilities.styl
+++ b/src/styles/utilities.styl
@@ -1,5 +1,4 @@
 @require '~styles/spacers.styl'
-@require 'settings/palette'
 @require 'generic/animations'
 
 :global
@@ -17,7 +16,7 @@
         font-weight bold
 
     .u-hover:hover
-        background paleGrey
+        background var(--paleGrey)
         cursor pointer
 
     .u-clickable


### PR DESCRIPTION
Palette.styl emits code so we should not import it.

There are still duplicates in the code, it has not removed
all declarations of CSS color variables.