### PR TITLE
feat: Supports iPhone X screen

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -208,6 +208,16 @@ yarn global add cordova@<same version as in package.json>
 yarn mobile:icon
 ```
 
+On iOS, if the given splashscreens are not to the resoution of the device, iOS
+falls back to compatibility mode and adds blacks bars to the top/bottom of the
+screen. This is particularly disgraceful on the iPhoneX which has an unusual screen
+shape.
+
+To fix this, we use a single splashscreen file and set XCode for it to use
+Cordova's launch screen functionality.
+
+`CozyBanks > Resources > Images.xcassets > LaunchStoryBoard > App icons and Launch images > LaunchScreenFile "CDVLaunchScreen"`
+
 - Install Ruby, Bundler and project dependencies
 
 See [Ruby installation page](https://www.ruby-lang.org/fr/documentation/installation/) to get the installation method for your system.

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "watch:mobile": "npm run util:check-dev-server && NODE_ENV=mobile:development npm run commons:watch:hot",
     "watch:mobile:production": "NODE_ENV=mobile:production npm run commons:watch -- --env.target=mobile",
     "serve:mobile": "(cd src/targets/mobile/www && http-server -p 8005)",
-    "mobile:icon": "(cd src/targets/mobile && splashicon-generator --imagespath='./res/model')",
+    "mobile:icon": "(cd src/targets/mobile && splashicon-generator --imagespath='./res/model' && cp ./res/model/splash.png ./res/screens/ios/Default@2x~universal~anyany.png)",
     "mobile:prepare": "(cd src/targets/mobile && cordova prepare && bundle install) && if [[ $(uname) == 'Darwin' ]] ; then npm run ios:install_pods ; fi",
     "mobile:clean": "(cd src/targets/mobile && rm -rf package.json node_modules platforms plugins)",
     "mobile:build": "npm run build:mobile && npm run mobile:clean && npm run mobile:prepare",

--- a/src/ducks/bar/statusBar.js
+++ b/src/ducks/bar/statusBar.js
@@ -1,18 +1,49 @@
+/* global cordova */
+
+// TODO Move this module to cozy-ui
+
 import { getCssVariableValue } from 'cozy-ui/react/utils/color'
 
-export const setColor = color => {
+export const luminosity = hex => {
+  if (hex.length == 4) {
+    const r = hex.slice(1, 2)
+    const g = hex.slice(2, 3)
+    const b = hex.slice(3, 4)
+    hex = `#${r}${r}${g}${g}${b}${b}`
+  }
+  const R = parseInt(hex.slice(1, 3), 16)
+  const G = parseInt(hex.slice(3, 5), 16)
+  const B = parseInt(hex.slice(5, 7), 16)
+  return 0.21 * R + 0.72 * G + 0.07 * B
+}
+
+// Luminosity goes from 0 to 255. At the middle point, we switch
+// the bar theme
+const lumThresold = 127
+
+export const setColor = colorHex => {
   if (!window.StatusBar) {
     return
   }
-  window.StatusBar.backgroundColorByHexString(color)
+  const StatusBar = window.StatusBar
+  const lum = luminosity(colorHex)
+  if (lum > lumThresold) {
+    StatusBar.styleDefault()
+  } else {
+    StatusBar.styleBlackTranslucent()
+  }
+  StatusBar.backgroundColorByHexString(colorHex)
 }
 
 const THEME_TO_COLORS = {
   primary: 'statusBarPrimaryColor',
-  default: 'coolGrey'
+  default: 'statusBarDefault'
 }
 
 export const setTheme = theme => {
-  const color = THEME_TO_COLORS[theme] || THEME_TO_COLORS.default
-  setColor(getCssVariableValue(color))
+  const colorName = THEME_TO_COLORS[theme] || THEME_TO_COLORS.default
+  const platform = cordova.platformId == 'ios' ? 'IOS' : 'Android'
+  const varName = colorName + platform
+  const colorValue = getCssVariableValue(varName)
+  setColor(colorValue)
 }

--- a/src/ducks/bar/statusBar.spec.js
+++ b/src/ducks/bar/statusBar.spec.js
@@ -1,0 +1,42 @@
+const { setTheme } = require('./statusBar')
+
+jest.mock('cozy-ui/react/utils/color', () => ({
+  getCssVariableValue: varName => {
+    if (varName == 'statusBarDefaultAndroid') {
+      return '#eee'
+    } else if (varName == 'statusBarDefaultIOS') {
+      return '#fff'
+    } else if (varName == 'statusBarPrimaryColorAndroid') {
+      return '#0d60d1'
+    } else if (varName == 'statusBarPrimaryColorIOS') {
+      return '#297ef2'
+    } else {
+      throw new Error('Inexisting color')
+    }
+  }
+}))
+
+const setup = ({ platformId, theme }) => {
+  global.cordova = { platformId }
+  window.StatusBar = {
+    styleBlackTranslucent: jest.fn(),
+    styleDefault: jest.fn(),
+    backgroundColorByHexString: jest.fn()
+  }
+  setTheme(theme)
+}
+
+for (let [platformId, theme, expectedStyle, expectedColor] of [
+  ['android', 'primary', 'styleBlackTranslucent', '#0d60d1'],
+  ['android', 'default', 'styleDefault', '#eee'],
+  ['ios', 'primary', 'styleBlackTranslucent', '#297ef2'],
+  ['ios', 'default', 'styleDefault', '#fff']
+]) {
+  it(`should work ${platformId} ${theme}`, () => {
+    setup({ platformId, theme })
+    expect(window.StatusBar[expectedStyle]).toHaveBeenCalled()
+    expect(window.StatusBar.backgroundColorByHexString).toHaveBeenCalledWith(
+      expectedColor
+    )
+  })
+}

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -1,28 +1,34 @@
 // @stylint off
 body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)
-    
+
     --headerDefaultBackgroundColor var(--white)
     --headerPrimaryBackgroundColor var(--primaryColor)
 
     --historyTooltipBackgroundColor var(--white)
     --historyTooltipTextColor var(--primaryColor)
     --historyGradientColor var(--primaryColor)
-    
+
     --selectDatesSeparatorPrimaryColor var(--primaryColor)
     --selectDatesChipPrimaryBackgroundColor var(--primaryColorLight)
     --selectDatesButtonDisabledPrimaryBackgroundColor var(--primaryColorLighter)
     --selectDatesButtonDisabledPrimaryColor var(--primaryColorLightest)
     --selectDatesIconPrimaryColor var(--white)
     --selectDatesButtonPrimaryColor var(--white)
-    
+
     --tableHeadPrimaryBackgroundColor var(--primaryColorLight)
     --tableHeadPrimaryContrastTextColor var(--primaryContrastTextColor)
     --tableHeadSeparatorPrimaryColor var(--primaryColor)
-    
+
     --categoriesHeaderTogglePrimaryContrastTextColor var(--primaryContrastTextColor)
     --categoriesHeaderTogglePrimaryBackgroundColor var(--primaryColorLight)
-    --statusBarPrimaryColor var(--primaryColorDark)
+
+    // Status bar is of a different color on Android but on iOS the norm is to
+    // have the same color
+    --statusBarDefaultAndroid var(--coolGrey)
+    --statusBarDefaultIOS var(--white)
+    --statusBarPrimaryColorAndroid var(--primaryColorDark)
+    --statusBarPrimaryColorIOS var(--primaryColor)
 
     --pinPrimaryBackgroundColor var(--primaryColor)
     --pinPrimaryContrastTextColor var(--primaryContrastTextColor)

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -77,18 +77,7 @@
         <icon height="76" src="res/icons/ios/icon-76.png" width="76" />
         <icon height="152" src="res/icons/ios/icon-76-2x.png" width="152" />
         <icon height="167" src="res/icons/ios/icon-83.5-2x.png" width="167" />
-        <splash height="1136" src="res/screens/ios/screen-iphone-568h-2x.png" width="640" />
-        <splash height="480" src="res/screens/ios/screen-iphone-portrait.png" width="320" />
-        <splash height="960" src="res/screens/ios/screen-iphone-portrait-2x.png" width="640" />
-        <splash height="1334" src="res/screens/ios/screen-iphone-portrait-667h.png" width="750" />
-        <splash height="2208" src="res/screens/ios/screen-iphone-portrait-736h.png" width="1242" />
-        <splash height="1242" src="res/screens/ios/screen-iphone-landscape-736h.png" width="2208" />
-        <splash height="1024" src="res/screens/ios/screen-ipad-portrait.png" width="768" />
-        <splash height="2048" src="res/screens/ios/screen-ipad-portrait-2x.png" width="1536" />
-        <splash height="768" src="res/screens/ios/screen-ipad-landscape.png" width="1024" />
-        <splash height="1536" src="res/screens/ios/screen-ipad-landscape-2x.png" width="2048" />
-        <splash height="2048" src="res/screens/ios/screen-ipad-landscape-ipadpro.png" width="2732" />
-        <splash height="2732" src="res/screens/ios/screen-ipad-portrait-ipadpro.png" width="2048" />
+        <splash src="res/screens/ios/Default@2x~universal~anyany.png" />
         <resource-file src="keys/ios/GoogleService-Info.plist" />
     </platform>
     <preference name="StatusBarBackgroundColor" value="#95999D" />


### PR DESCRIPTION
Il faut savoir que sur iOS, si on ne fournit pas les splashscreen dans la résolution du device, alors iOS se met en mode "compatibilité" et ajoute les barres noires en haut et en bas. 

L'idée est donc de ne plus utiliser chaque splashscreen pour chaque résolution. Donc on met un splashscreen générique (celui qu'on copie à la fin), en faisant ça, on change le projet XCode pour passer de "AppImage" à "Launch Screen file". Ainsi, cordova génère un `LaunchStoryboard` qui devrait fonctionner partout. 

<img width="1512" alt="Capture d’écran 2019-03-31 à 17 36 35" src="https://user-images.githubusercontent.com/1107936/55291145-95579900-53db-11e9-9671-bfc917233d23.png">
<img width="791" alt="Capture d’écran 2019-03-31 à 17 36 41" src="https://user-images.githubusercontent.com/1107936/55291146-95f02f80-53db-11e9-9574-e9cb87d4e943.png">



![Simulator Screen Shot - iPhone XR - 2019-03-31 at 17 32 07](https://user-images.githubusercontent.com/1107936/55291153-9be61080-53db-11e9-85f7-bdac3f5397e5.png)
![Simulator Screen Shot - iPhone XR - 2019-03-31 at 17 32 14](https://user-images.githubusercontent.com/1107936/55291154-9be61080-53db-11e9-8f8f-a66b87fc7620.png)
