### PR TITLE
fix: Clear timeout in PinGuard

### DIFF
--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -29,6 +29,7 @@ class PinGuard extends React.Component {
     document.removeEventListener('touchstart', this.handleInteraction)
     document.removeEventListener('click', this.handleInteraction)
     document.removeEventListener('resume', this.handleResume)
+    clearTimeout(this.timeout)
   }
 
   componentDidUpdate(prevProps) {


### PR DESCRIPTION
We have to clear timeouts when a component is unmounted.