### PR TITLE
fix: Webpack config for services

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -28,7 +28,7 @@ const config = env => merge.strategy({
   plugins: 'replace',
   output: 'replace',
   entry: 'replace'
-})(base, ui, {
+})(base(env), ui, {
   entry: entries,
   mode: env.production ? 'production' : 'development',
   target: 'node',
@@ -93,4 +93,4 @@ const config = env => merge.strategy({
   ]
 })
 
-module.exports = merge(config, piwik)
+module.exports = env => merge(config(env), piwik)


### PR DESCRIPTION
Since webpack config have become functions (to support
--env), we need to call this functions before merging
them in the config for services.