### PR TITLE
fix: Onboarding

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -27,11 +27,19 @@ class KonnectorUpdateInfo extends React.PureComponent {
         pendingUpdate: true
       })
 
+      if (this.unmounted) {
+        return
+      }
+
       this.setState({ url })
     } catch (err) {
       // eslint-disable-next-line no-console
       console.warn('Error while retrieving redirection URL', err)
     }
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true
   }
 
   render() {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -231,12 +231,12 @@ class Balance extends PureComponent {
     try {
       this._ensureRealtimeProperlyConfigured()
     } catch (e) {
-      // eslint-disable no-console
+      /* eslint-disable no-console */
       console.error(e)
       console.warn(
         'Balance: Could not correctly configure realtime, see error above.'
       )
-      // eslint-enable no-console
+      /* eslint-enable no-console */
     }
   }
 

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -37,6 +37,15 @@ import BarTheme from 'ducks/mobile/BarTheme'
 import { filterByAccounts } from 'ducks/filters'
 import { CozyRealtime } from 'cozy-realtime'
 
+// TODO should be removed when realtime can be initialized directly
+// with cozyClient
+const getCredentialsFromClient = cozyClient => {
+  const url = cozyClient.stackClient.uri
+  const token =
+    cozyClient.stackClient.token.accessToken || cozyClient.stackClient.token
+  return { url, token }
+}
+
 class Balance extends PureComponent {
   constructor(props) {
     super(props)
@@ -161,8 +170,9 @@ class Balance extends PureComponent {
       const cozyClient = this.props.client
       // TODO: Update cozy-realtime to do only:
       //   this.realtime = new CozyRealtime({ cozyClient })
-      const url = cozyClient.stackClient.uri
-      const token = cozyClient.stackClient.token.token
+      const creds = getCredentialsFromClient(cozyClient)
+      const url = creds.url
+      const token = creds.token
       this.realtime = new CozyRealtime({ url, token })
     }
   }

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -161,8 +161,8 @@ class Balance extends PureComponent {
       const cozyClient = this.props.client
       // TODO: Update cozy-realtime to do only:
       //   this.realtime = new CozyRealtime({ cozyClient })
-      const url = cozyClient.client.uri
-      const token = cozyClient.client.token.token
+      const url = cozyClient.stackClient.uri
+      const token = cozyClient.stackClient.token.token
       this.realtime = new CozyRealtime({ url, token })
     }
   }

--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -68,7 +68,7 @@ const withAuth = Wrapped => {
         await onLogout(
           this.context.store,
           this.props.client,
-          this.props.history.replace
+          this.props.history
         )
         this.setState({ isLoggingOut: false })
       })

--- a/src/ducks/mobile/utils.js
+++ b/src/ducks/mobile/utils.js
@@ -52,7 +52,7 @@ export const setBarTheme = theme => {
 }
 
 export const AUTH_PATH = 'authentication'
-export const onLogout = async (store, cozyClient, router) => {
+export const onLogout = async (store, cozyClient, routerOrHistoryOrReplace) => {
   await stopPushNotifications()
   store.dispatch(unlink())
   store.dispatch(resetFilterByDoc())
@@ -70,5 +70,17 @@ export const onLogout = async (store, cozyClient, router) => {
       console.warn('Error while resetting client', e)
     }
   }
-  router.push(`/${AUTH_PATH}`)
+
+  try {
+    // TODO Some caller pass history, other the router
+    if (routerOrHistoryOrReplace.push) {
+      routerOrHistoryOrReplace.push(`/${AUTH_PATH}`)
+    } else if (routerOrHistoryOrReplace.replace) {
+      routerOrHistoryOrReplace.replace(`/${AUTH_PATH}`)
+    } else {
+      routerOrHistoryOrReplace(`/${AUTH_PATH}`)
+    }
+  } catch (e) {
+    window.location.reload()
+  }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,7 +16,7 @@
     "more-information": "More information",
     "less-information": "Less information",
     "title": "L'affichage de vos données bancaires a échoué",
-    "update": "Vous pouvez essayer à nouveau #{LINK}en rafraichissant la page#{/LINK}.",
+    "update": "Vous pouvez essayer à nouveau #{LINK}en rafraîchissant la page#{/LINK}.",
     "contact": "#{LINK}Contactez-nous#{/LINK} si le problème persiste."
   },
 


### PR DESCRIPTION
When realtime is not correctly configured on the cozy-bar, we should not explode.

- Extracted start/stop of realtime into one method and added try/catch
- The token was not the right one, I think we have two ways of accessing the token with cozyClient, sometimes it is in cozyClient.stackClient.token and sometimes (I think with the OAuthClient, it is in cozyClient.stackClient.token.accessToken)

Removed warnings

- stackClient is accessible with client.stackClient, not with client.client anymore. For clarity
- if setState is called after an await, it can be called when the component is unmounted, and it triggers a warning