### PR TITLE
WIP: feat(store): Combine app store and cozy client store

### DIFF
--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -1,5 +1,5 @@
 /* global __DEV__ */
-import { compose, createStore, applyMiddleware } from 'redux'
+import { compose, createStore, applyMiddleware, combineReducers } from 'redux'
 import thunkMiddleware from 'redux-thunk'
 import { createLogger } from 'redux-logger'
 import flag from 'cozy-flags'
@@ -10,15 +10,17 @@ import {
 } from 'cozy-ui/react/helpers/tracker'
 import { isReporterEnabled, getReporterMiddleware } from 'lib/sentry'
 
-import appReducers from 'reducers'
+import { reducers as appReducers } from 'reducers'
 
 const configureStore = (cozyClient, persistedState) => {
   // Enable Redux dev tools
   const composeEnhancers =
     (__DEV__ && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose
-
   // reducers
-  const reducers = [appReducers, persistedState]
+  const reducers = [
+    combineReducers({ ...appReducers, cozy: cozyClient.reducer() }),
+    persistedState
+  ]
 
   // middlewares
   const middlewares = [thunkMiddleware]


### PR DESCRIPTION
The goal is to be able to get documents from the redux store instead of cozy-client queries. This way the store acts like a local cache.

It's not fully working because the `cozy` property of the state contains empty `documents` and `queries` properties.