### PR TITLE
Rename accounts schema

### DIFF
--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -116,7 +116,7 @@ export const schema = {
     attributes: {},
     relationships: {}
   },
-  accounts: {
+  bankAccounts: {
     doctype: ACCOUNT_DOCTYPE,
     attributes: {},
     relationships: {}


### PR DESCRIPTION
The goal of this PR is to avoid conflicts with other schema named `accounts`.