### PR TITLE
feat: Mention global cordova in doc to build mobile apps

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -85,6 +85,12 @@ More information : https://github.com/cozy/cozy-stack/blob/master/docs/registry-
 
 ### Pre-requisites
 
+- Install cordova globally (necessary for the fastlane cordova plugin)
+
+```
+yarn global add cordova@<same version as in package.json>
+```
+
 - Generate icons
 
 ```


### PR DESCRIPTION
It is necessary to have cordova installed globally for
fastlane cordova plugin to work correctly.