### PR TITLE
feat: Add CAF connector in brands dictionnary

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -52,6 +52,11 @@
     "konnectorSlug": "bouyguestelecom"
   },
   {
+    "name": "CAF",
+    "regexp": "\\bcaf\\b",
+    "konnectorSlug": "caf"
+  },
+  {
     "name": "Cdiscount",
     "regexp": "\\bcdiscount\\b",
     "konnectorSlug": "cdiscount"


### PR DESCRIPTION
Connector will be publish now.
Merge and publish this new brand when it's possible.