### PR TITLE
fix(AppLinkAction): Filter cozy home

### DIFF
--- a/src/ducks/transactions/actions/AppLinkAction.jsx
+++ b/src/ducks/transactions/actions/AppLinkAction.jsx
@@ -10,7 +10,7 @@ import palette from 'cozy-ui/react/palette'
 const name = 'app'
 
 const getAppName = (urls, transaction) => {
-  const filteredUrls = omit(urls, ['COLLECT'])
+  const filteredUrls = omit(urls, ['COLLECT', 'HOME'])
 
   const label = transaction.label.toLowerCase()
   return findKey(


### PR DESCRIPTION
We wrongly showed an action to redirect the user to his Home when we
found "home" in the transaction label