### PR TITLE
feat(LineChart): Use lineColor prop for point line color

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -290,7 +290,7 @@ class LineChart extends Component {
     this.pointLine = this.svg
       .append('line')
       .attr('stroke-width', 1)
-      .attr('stroke', 'white')
+      .attr('stroke', this.props.lineColor)
       .attr('stroke-dasharray', '3,2')
   }
 


### PR DESCRIPTION
The point line color was hardcoded `white`