### PR TITLE
Make balance's HeaderTitle reusable

### DIFF
--- a/src/ducks/balance/components/HeaderTitle.jsx
+++ b/src/ducks/balance/components/HeaderTitle.jsx
@@ -10,7 +10,6 @@ const HeaderTitle = ({ balance, subtitle, onClickBalance, className }) => (
       <Figure
         onClick={onClickBalance}
         className={styles.HeaderTitle_balance}
-        currencyClassName={styles.BalanceHeader__currentBalanceCurrency}
         total={balance}
         symbol="€"
       />

--- a/src/ducks/balance/components/HeaderTitle.jsx
+++ b/src/ducks/balance/components/HeaderTitle.jsx
@@ -1,10 +1,11 @@
-import React, { Fragment, memo } from 'react'
+import React, { memo } from 'react'
 import PropTypes from 'prop-types'
+import cx from 'classnames'
 import styles from 'ducks/balance/components/HeaderTitle.styl'
 import { Figure } from 'components/Figure'
 
-const HeaderTitle = ({ balance, subtitle, onClickBalance }) => (
-  <Fragment>
+const HeaderTitle = ({ balance, subtitle, onClickBalance, className }) => (
+  <div className={cx(styles.HeaderTitle, className)}>
     {balance !== undefined && (
       <Figure
         onClick={onClickBalance}
@@ -15,7 +16,7 @@ const HeaderTitle = ({ balance, subtitle, onClickBalance }) => (
       />
     )}
     <div className={styles.HeaderTitle_subtitle}>{subtitle}</div>
-  </Fragment>
+  </div>
 )
 
 HeaderTitle.propTypes = {

--- a/src/ducks/balance/components/HeaderTitle.styl
+++ b/src/ducks/balance/components/HeaderTitle.styl
@@ -1,7 +1,9 @@
 @require 'settings/breakpoints'
 
-.HeaderTitle_balance
+.HeaderTitle
     text-align center
+
+.HeaderTitle_balance
     font-size 2rem
     line-height 2.5rem
 

--- a/src/ducks/balance/components/HeaderTitle.styl
+++ b/src/ducks/balance/components/HeaderTitle.styl
@@ -11,9 +11,6 @@
         font-size 1.5rem
         line-height 2rem
 
-.HeaderTitle_balanceCurrency
-    color inherit
-
 .HeaderTitle_subtitle
     margin-bottom .5rem
     text-transform uppercase


### PR DESCRIPTION
Add the possibility to give it a className and make it manage its own text alignment. The subtitle is well aligned on the balances page because the parent have a `text-align: center`, but if we reuse it elsewhere, it was not well aligned.