### PR TITLE
fix(Figure): Use CSS variables

### DIFF
--- a/src/components/Figure/Figure.styl
+++ b/src/components/Figure/Figure.styl
@@ -2,28 +2,28 @@
 
 .default
     &.Figure-currency
-        color       coolGrey
+        color       var(--coolGrey)
 
     &.Figure-content--positive
-        color   emerald
+        color   var(--emerald)
 
         .Figure-currency
-            color   emerald
+            color   var(--emerald)
 
     &.Figure-content--negative
-        color   pomegranate
+        color   var(--pomegranate)
 
         .Figure-currency
-            color   pomegranate
+            color   var(--pomegranate)
 
     &.Figure-content--warning
-        color   texasRose
+        color   var(--texasRose)
 
         .Figure-currency
-            color   texasRose
+            color   var(--texasRose)
 
 .primary
-    color white
+    color var(--white)
 
 .Figure-total
     font-weight    900


### PR DESCRIPTION
The stylus variables doesn't exist anymore. So their names was read as a
value by the browser.