### PR TITLE
feat(AddAccountLink): Open a web browser on mobile

### DIFF
--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -1,5 +1,3 @@
-/* global __TARGET__ */
-
 import React, { Component } from 'react'
 import { withClient } from 'cozy-client'
 
@@ -26,11 +24,14 @@ class SameWindowLink extends Component {
       }
     )
 
-    if (__TARGET__ === 'browser') {
-      window.location = redirectionURL
-    } else if (__TARGET__ === 'mobile') {
-      open(redirectionURL)
-    }
+    // We use `window.location` because on desktop we want to stay in the same tab/window
+    // and on mobile we want to open the user's browser instead of an inapp browser
+    // because in the onboarding flow, the user clicks on email links, which open
+    // the "native" browser (external Firefox for example) instead of the in-app one.
+    // This means login cookies are stored in the external browser.
+    // To prevent asking the user to login again, we have to use an external browser
+    // instead of the in app browser.
+    window.location = redirectionURL
   }
 
   render() {


### PR DESCRIPTION
The enrollment flow is better if we open the user's web browser instead
of an inapp browser: the user is already logged in in his browser.