### PR TITLE
feat(AccountsSettings): Update add account link label

### DIFF
--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -104,7 +104,7 @@ class AccountsSettings extends Component {
           <Button
             className={cx(btnStyles['btn--no-outline'], 'u-pb-1')}
             icon={<Icon icon={plus} className="u-mr-half" />}
-            label={t('Accounts.add-account')}
+            label={t('Accounts.add_bank')}
           />
         </AddAccountLink>
         {myAccounts ? (


### PR DESCRIPTION
We want the label to be « Add a bank » / « Ajouter une banque » instead of « Add an account » / « Ajouter un compte »