### PR TITLE
feat(TransactionActions): Get apps urls and brands from context

### DIFF
--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -11,6 +11,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import palette from 'cozy-ui/react/palette'
 import { findMatchingActions } from 'ducks/transactions/actions'
+import { TransactionActionsContext } from 'ducks/transactions/TransactionActionsContext'
 
 // TODO delete or rename this variable (see https://gitlab.cozycloud.cc/labs/cozy-bank/merge_requests/237)
 const PRIMARY_ACTION_COLOR = palette.dodgerBlue
@@ -81,6 +82,8 @@ export const SyncTransactionActions = ({
 )
 
 class TransactionActions extends Component {
+  static contextType = TransactionActionsContext
+
   state = {
     actions: false,
     actionProps: false
@@ -89,11 +92,10 @@ class TransactionActions extends Component {
   async findMatchingActions() {
     const { transaction } = this.props
     if (transaction) {
-      const { urls, brands, bill } = this.props
+      const { bill } = this.props
       const actionProps = {
-        urls,
-        brands,
-        bill
+        bill,
+        ...this.context
       }
       const actions = await findMatchingActions(transaction, actionProps)
       if (!this.unmounted) {
@@ -143,9 +145,7 @@ class TransactionActions extends Component {
 }
 
 TransactionActions.propTypes = {
-  transaction: PropTypes.object.isRequired,
-  urls: PropTypes.object.isRequired,
-  brands: PropTypes.array.isRequired
+  transaction: PropTypes.object.isRequired
 }
 
 export default TransactionActions

--- a/src/ducks/transactions/TransactionActionsContext.jsx
+++ b/src/ducks/transactions/TransactionActionsContext.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { flowRight as compose } from 'lodash'
+import withAppsUrls from 'ducks/apps/withAppsUrls'
+import withBrands from 'ducks/brandDictionary/withBrands'
+
+export const TransactionActionsContext = React.createContext()
+
+class DumbTransactionActionsProvider extends React.Component {
+  render() {
+    const { brands, urls } = this.props
+
+    const value = { brands, urls }
+
+    return (
+      <TransactionActionsContext.Provider value={value}>
+        {this.props.children}
+      </TransactionActionsContext.Provider>
+    )
+  }
+}
+
+export const TransactionActionsProvider = compose(
+  withAppsUrls,
+  withBrands
+)(DumbTransactionActionsProvider)

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -65,9 +65,7 @@ class _RowDesktop extends React.PureComponent {
       isExtraLarge,
       showCategoryChoice,
       filteringOnAccount,
-      onRef,
-      urls,
-      brands
+      onRef
     } = this.props
 
     const categoryId = getCategoryId(transaction)
@@ -122,12 +120,7 @@ class _RowDesktop extends React.PureComponent {
           />
         </TdSecondary>
         <TdSecondary className={styles.ColumnSizeAction}>
-          <TransactionActions
-            transaction={transaction}
-            urls={urls}
-            brands={brands}
-            onlyDefault
-          />
+          <TransactionActions transaction={transaction} onlyDefault />
         </TdSecondary>
       </tr>
     )

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -161,9 +161,7 @@ export class TransactionsDumb extends React.Component {
       limitMax,
       breakpoints: { isDesktop, isExtraLarge },
       manualLoadMore,
-      filteringOnAccount,
-      brands,
-      urls
+      filteringOnAccount
     } = this.props
     const transactionsGrouped = groupByDate(
       this.transactions.slice(limitMin, limitMax)
@@ -191,8 +189,6 @@ export class TransactionsDumb extends React.Component {
                     key={transaction._id}
                     onRef={this.handleRefRow.bind(null, transaction._id)}
                     transaction={transaction}
-                    brands={brands}
-                    urls={urls}
                     isExtraLarge={isExtraLarge}
                     filteringOnAccount={filteringOnAccount}
                     selectTransaction={selectTransaction}

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -1,6 +1,6 @@
 /* global cozy */
 
-import React, { Component, Fragment } from 'react'
+import React, { Component } from 'react'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import { subMonths } from 'date-fns'
@@ -45,8 +45,7 @@ import {
 } from 'ducks/balance/helpers'
 import BarTheme from 'ducks/mobile/BarTheme'
 import flag from 'cozy-flags'
-import withAppsUrls from 'ducks/apps/withAppsUrls'
-import withBrands from 'ducks/brandDictionary/withBrands'
+import { TransactionActionsProvider } from 'ducks/transactions/TransactionActionsContext'
 
 const { BarRight } = cozy.bar
 
@@ -213,7 +212,7 @@ class TransactionsPage extends Component {
 
   displayTransactions() {
     const { limitMin, limitMax, infiniteScrollTop } = this.state
-    const { t, urls, brands } = this.props
+    const { t } = this.props
     const transactions = this.getTransactions()
 
     if (transactions.length === 0) {
@@ -234,8 +233,6 @@ class TransactionsPage extends Component {
         onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
         onScroll={this.checkToActivateTopInfiniteScroll}
         transactions={transactions}
-        urls={urls}
-        brands={brands}
         filteringOnAccount={this.getFilteringOnAccount()}
         manualLoadMore={isMobileApp()}
       />
@@ -291,7 +288,7 @@ class TransactionsPage extends Component {
     const isOnSubcategory = onSubcategory(this.props)
     const theme = flag('transaction-history') ? 'primary' : 'default'
     return (
-      <Fragment>
+      <TransactionActionsProvider>
         <BarTheme theme={theme} />
         <TransactionHeader
           transactions={filteredTransactions}
@@ -308,7 +305,7 @@ class TransactionsPage extends Component {
         ) : (
           this.displayTransactions()
         )}
-      </Fragment>
+      </TransactionActionsProvider>
     )
   }
 }
@@ -360,9 +357,7 @@ const ConnectedTransactionsPage = compose(
     triggers: triggersConn,
     transactions: transactionsConn
   }),
-  connect(mapStateToProps),
-  withAppsUrls,
-  withBrands
+  connect(mapStateToProps)
 )(UnpluggedTransactionsPage)
 
 export const TransactionsPageWithBackButton = props => (


### PR DESCRIPTION
With this, it's easier to override what's needed by the actions to match
and render because we only have to override the context to add things (konnectors, whatever...)