### PR TITLE
fix(Panel): Save always settings configuration

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -130,11 +130,8 @@ class Balance extends PureComponent {
 
   savePanelState() {
     const { panels } = this.state
-    const settings = this.props.settings.data[0]
-
-    if (!settings) {
-      return
-    }
+    const { settings: settingsCollection } = this.props
+    const settings = getDefaultedSettingsFromCollection(settingsCollection)
 
     const newSettings = {
       ...settings,


### PR DESCRIPTION
When we did not have settings we did not save the state of the panels