### PR TITLE
Refactor actions context

### DIFF
--- a/src/ducks/transactions/TransactionActionsContext.jsx
+++ b/src/ducks/transactions/TransactionActionsContext.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { flowRight as compose } from 'lodash'
+import { flowRight as compose, omit } from 'lodash'
 import withAppsUrls from 'ducks/apps/withAppsUrls'
 import withBrands from 'ducks/brandDictionary/withBrands'
 
@@ -7,9 +7,7 @@ export const TransactionActionsContext = React.createContext()
 
 class DumbTransactionActionsProvider extends React.Component {
   render() {
-    const { brands, urls } = this.props
-
-    const value = { brands, urls }
+    const value = omit(this.props, 'children')
 
     return (
       <TransactionActionsContext.Provider value={value}>

--- a/src/ducks/transactions/TransactionActionsContext.jsx
+++ b/src/ducks/transactions/TransactionActionsContext.jsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { flowRight as compose, omit } from 'lodash'
-import withAppsUrls from 'ducks/apps/withAppsUrls'
-import withBrands from 'ducks/brandDictionary/withBrands'
+import { omit } from 'lodash'
 
 export const TransactionActionsContext = React.createContext()
 
-class DumbTransactionActionsProvider extends React.Component {
+export class DumbTransactionActionsProvider extends React.Component {
   render() {
     const value = omit(this.props, 'children')
 
@@ -16,8 +14,3 @@ class DumbTransactionActionsProvider extends React.Component {
     )
   }
 }
-
-export const TransactionActionsProvider = compose(
-  withAppsUrls,
-  withBrands
-)(DumbTransactionActionsProvider)

--- a/src/ducks/transactions/TransactionActionsProvider.jsx
+++ b/src/ducks/transactions/TransactionActionsProvider.jsx
@@ -1,0 +1,11 @@
+import { flowRight as compose } from 'lodash'
+import withAppsUrls from 'ducks/apps/withAppsUrls'
+import withBrands from 'ducks/brandDictionary/withBrands'
+import { DumbTransactionActionsProvider } from 'ducks/transactions/TransactionActionsContext'
+
+const TransactionActionsProvider = compose(
+  withAppsUrls,
+  withBrands
+)(DumbTransactionActionsProvider)
+
+export default TransactionActionsProvider

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -45,7 +45,7 @@ import {
 } from 'ducks/balance/helpers'
 import BarTheme from 'ducks/mobile/BarTheme'
 import flag from 'cozy-flags'
-import { TransactionActionsProvider } from 'ducks/transactions/TransactionActionsContext'
+import TransactionActionsProvider from 'ducks/transactions/TransactionActionsProvider'
 
 const { BarRight } = cozy.bar
 

--- a/src/ducks/transactions/actions/KonnectorAction/helpers.js
+++ b/src/ducks/transactions/actions/KonnectorAction/helpers.js
@@ -1,3 +1,26 @@
+import { findMatchingBrand } from 'ducks/brandDictionary'
+
 export function getBrandsWithoutTrigger(brands) {
   return brands.filter(brand => !brand.hasTrigger)
 }
+
+export const findMatchingBrandWithoutTrigger = (transaction, brands) => {
+  const brandsWithoutTrigger = getBrandsWithoutTrigger(brands)
+
+  if (!brandsWithoutTrigger) {
+    return null
+  }
+
+  const matchingBrand = findMatchingBrand(
+    brandsWithoutTrigger,
+    transaction.label
+  )
+
+  if (!matchingBrand || matchingBrand.maintenance) {
+    return null
+  }
+
+  return matchingBrand
+}
+
+export const hasUrls = urls => urls['COLLECT'] || urls['HOME']

--- a/src/ducks/transactions/actions/KonnectorAction/match.js
+++ b/src/ducks/transactions/actions/KonnectorAction/match.js
@@ -1,23 +1,16 @@
-import { findMatchingBrand } from 'ducks/brandDictionary'
-import { getBrandsWithoutTrigger } from 'ducks/transactions/actions/KonnectorAction/helpers'
+import {
+  hasUrls,
+  findMatchingBrandWithoutTrigger
+} from 'ducks/transactions/actions/KonnectorAction/helpers'
 
 const match = (transaction, { brands, urls }) => {
-  const brandsWithoutTrigger = getBrandsWithoutTrigger(brands)
-
-  if (!brandsWithoutTrigger) {
+  if (!hasUrls(urls)) {
     return false
   }
 
-  const matchingBrand = findMatchingBrand(
-    brandsWithoutTrigger,
-    transaction.label
-  )
+  const matchingBrand = findMatchingBrandWithoutTrigger(transaction, brands)
 
-  return (
-    matchingBrand &&
-    !matchingBrand.maintenance &&
-    (urls['COLLECT'] || urls['HOME'])
-  )
+  return matchingBrand
 }
 
 export default match


### PR DESCRIPTION
The goal of this PR is to be able to override the actions context and matching functions with the less effort as possible.

* Pass all props except children to the context value
* Split `TransactionActionsProvider` from `TransactionActionsContext` to make it overridable without touching `TransactionActionsContext` which is now more generic
* Extract helpers to make `KonnectorAction/match` more generic