### PR TITLE
feat(account): Show the good account update date

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "cozy-client": "6.24.0",
     "cozy-client-js": "0.15.0",
     "cozy-device-helper": "1.6.10",
-    "cozy-doctypes": "1.39.0",
+    "cozy-doctypes": "1.44.0",
     "cozy-flags": "1.6.0",
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.14.13",

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -3,6 +3,7 @@ import { getDate, getReimbursedAmount } from 'ducks/transactions/helpers'
 import { isHealthExpense } from 'ducks/categories/helpers'
 import { differenceInCalendarDays, isThisYear } from 'date-fns'
 import flag from 'cozy-flags'
+import { BankAccount } from 'cozy-doctypes'
 
 const PARTS_TO_DELETE = ['(sans Secure Key)']
 
@@ -21,11 +22,8 @@ export const getAccountInstitutionLabel = account => {
 export const getAccountLabel = account =>
   account ? account.shortLabel || account.label : ''
 
-export const getAccountUpdateDate = account =>
-  get(account, 'cozyMetadata.updatedAt')
-
 export const getAccountUpdateDateDistance = (account, from) => {
-  const updateDate = getAccountUpdateDate(account)
+  const updateDate = BankAccount.getUpdatedAt(account)
 
   if (!updateDate || !from) {
     return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -4651,15 +4651,16 @@ cozy-doctypes@1.38.6:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-doctypes@1.39.0:
-  version "1.39.0"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
-  integrity sha512-k/GgUs1K120hAtCdBRSE50L+wDHWn/HDErGNvzqXCSpQKicMrjVvFpD6EHie4thc5oNPzHn0RqWuT4gBFcfY9Q==
+cozy-doctypes@1.44.0:
+  version "1.44.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.44.0.tgz#7ad05afb8f4ab807a6fe53ed97b1fd13aac9ee61"
+  integrity sha512-VA6GwGi5TG4R5ZNmPOozaEHyylNoEZ7+nARr96zBo/Gv53RPJ9vjSsr0i4r8IvRKHsLfyYHBo0zmTUFbVSFbcg==
   dependencies:
     "@babel/runtime" "7.3.1"
     cozy-logger "1.3.1"
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
+    prop-types "^15.7.2"
 
 cozy-flags@1.6.0, cozy-flags@^1.6.0:
   version "1.6.0"


### PR DESCRIPTION
Use `BankAccount.getUpdatedAt` from cozy-doctypes to get the best update
date possible. See cozy/cozy-libs#423 for more
infos.