### PR TITLE
feat: Add Ensap to brand dictionnary

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -126,6 +126,12 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "ensap",
+    "name": "Ensap",
+    "regexp": "\\\\b(ddfip|drfip)\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "eovimcdparticuliers",
     "name": "Eovi MCD Particuliers",
     "regexp": "\\\\beovi mcd mutuelle\\\\b",
@@ -542,6 +548,12 @@ Array [
     "konnectorSlug": "engie",
     "name": "Engie",
     "regexp": "\\\\bengie\\\\b",
+  },
+  Object {
+    "isInstalled": false,
+    "konnectorSlug": "ensap",
+    "name": "Ensap",
+    "regexp": "\\\\b(ddfip|drfip)\\\\b",
   },
   Object {
     "isInstalled": false,

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -102,6 +102,11 @@
     "konnectorSlug": "engie"
   },
   {
+    "name": "Ensap",
+    "regexp": "\\b(ddfip|drfip)\\b",
+    "konnectorSlug": "ensap"
+  },
+  {
     "name": "Eovi MCD Particuliers",
     "regexp": "\\beovi mcd mutuelle\\b",
     "konnectorSlug": "eovimcdparticuliers"


### PR DESCRIPTION
This PR add the new ensap connector in brand dictionnary.
Tests snaphots has been updated.

Connector is already published, merge it as soon as you can.

Thank's