### PR TITLE
fix(deps): Update cozy-flags to v1.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "cozy-client-js": "0.15.0",
     "cozy-device-helper": "1.6.10",
     "cozy-doctypes": "1.44.0",
-    "cozy-flags": "1.6.0",
+    "cozy-flags": "1.6.1",
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.14.13",
     "cozy-pouch-link": "6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4711,6 +4711,14 @@ cozy-flags@1.6.0:
     detect-node "2.0.4"
     microee "^0.0.6"
 
+cozy-flags@1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/cozy-flags/-/cozy-flags-1.6.1.tgz#27e8bed076f0676e512beda0f4532548862df0f4"
+  integrity sha512-L0Nh8DdgqRBAu4UkSWTbfJZAlcVYQPX2G09nSiOgsgBzr002txXRz1899r9jHoLJPFFR+Ep9zkSmnOnPzMHUwA==
+  dependencies:
+    detect-node "2.0.4"
+    microee "^0.0.6"
+
 cozy-harvest-lib@0.38.3:
   version "0.38.3"
   resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-0.38.3.tgz#ecf2a188ea6f647332fd3a7d2478a3cba7d91c09"


### PR DESCRIPTION
This cozy-flags version fixes a bug in Node environment. See
https://github.com/cozy/cozy-libs/blob/master/packages/cozy-flags/CHANGELOG.md#161-2019-05-03
for more informations. In banks, it fixes the service, which crashed
due to this bug.