### PR TITLE
feat: Set global model usage threshold to 15%

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -20,7 +20,7 @@ const makeSubcategory = catId => ({
 })
 
 export const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
-export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.25
+export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.15
 
 /**
  * Return the category id of the transaction


### PR DESCRIPTION
We are confident that even with a `0.15` probability, the results of our
global model are relevant.