### PR TITLE
fix: Increase priority of CSS selector since we are overriding a Button

### DIFF
--- a/src/ducks/balance/components/NoAccount.styl
+++ b/src/ducks/balance/components/NoAccount.styl
@@ -10,7 +10,7 @@
     +small-screen()
         height calc(50vh - 48px) // 48 is cozy-bar + bottom nav size / 2
 
-.NoAccount_addButton
+.NoAccount_addButton.NoAccount_addButton
     position absolute
     bottom -24px
     left 0


### PR DESCRIPTION
NoAccountButton class overrides styles from the Button. Since the order
of CSS between Button and NoAccountButton is not guaranteed, we have
to increase the priority of the selector.

This fixes a margin bug, the button being aligned to the left and not
centrally, on mobile.