### PR TITLE
Categorization service

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -15,7 +15,8 @@ const entries = {
   onOperationOrBillCreate: path.resolve(
     SRC_DIR,
     './targets/services/onOperationOrBillCreate'
-  )
+  ),
+  categorization: path.resolve(SRC_DIR, './targets/services/categorization.js')
 }
 
 if (process.env.TEST_TEMPLATES) {

--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -46,6 +46,10 @@ module.exports = {
         test: /\.svg$/,
         include: SRC_DIR,
         loader: 'null-loader'
+      },
+      {
+        test: /\.mjs$/,
+        type: 'javascript/auto'
       }
     ],
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,79 @@
+# Services
+
+Banks exposes the following services:
+
+* [categorization](#categorization)
+* [onOperationOrBillCreate](#onoperationorbillcreate)
+
+## Categorization
+
+This service role is to categorize transactions. It is bound to no event at
+all, so it's not automatically triggered and needs to be explicitly called by a
+konnector or another service.
+
+When this service is ran, it gets all `io.cozy.bank.operations` that has the
+`toCategorize` property with a `true` value. Then it slices it into chunks and
+categories the most chunks it can before the service is stopped by the stack.
+If there are some uncategorized transactions remaining, it restarts itself to
+finish the work. If all transactions have been categorized, it calls the
+`onOperationOrBillCreate` service to trigger all other features.
+
+## onOperationOrBillCreate
+
+This service has many roles. It does:
+
+* Bills matching
+* Notifications (push & email)
+* Apps suggestions
+
+It is bound to the `io.cozy.bills` creation only. The creation of
+`io.cozy.bank.operations` should be managed by calling the categorization
+service. See [the next
+section](#i-am-writing-a-banking-konnector-what-should-i-do) for more precise
+informations about that.
+
+## I am writing a banking konnector, what should I do?
+
+If you want to benefit from all the features of these services, the most
+straightforward is to add `toCategorize: true` to the `io.cozy.bank.operations`
+your konnector creates, save these documents and then call the `categorization`
+service.
+
+Here is an example:
+
+```js
+const { cozyClient, BaseKonnector } = require('cozy-konnector-libs')
+
+class MyKonnector extends BaseKonnector {
+  async saveTransactions() {
+    const transactions = await this.fetchTransactions()
+    transactions.forEach(t => (t.toCategorize = true))
+
+    // save `transactions`
+
+    await cozyClient.jobs.create('service', {
+      message: {
+        name: 'categorization',
+        slug: 'banks'
+      }
+    })
+  }
+}
+```
+
+Finally, you will need a permission to create `io.cozy.jobs` document. Add the
+following permission to your `manifest.konnector`:
+
+```json
+{
+  "permissions": {
+    "jobs": {
+      "description": "Required to run applications services",
+      "type": "io.cozy.jobs"
+    }
+  }
+}
+```
+
+With this, the transactions you created will be categorized, then the
+`onOperationOrBillCreate` service will be launched and do its work.

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -68,6 +68,11 @@
       "file": "onOperationOrBillCreate.js",
       "trigger": "@event io.cozy.bank.operations:CREATED io.cozy.bills:CREATED",
       "debounce": "75s"
+    },
+    "categorization": {
+      "type": "node",
+      "file": "categorization.js",
+      "trigger": "@at 2000-01-01T00:00:00.000Z"
     }
   },
   "notifications": {

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -166,6 +166,10 @@
       "description": "Used to suggest which apps / connectors might be useful for the user",
       "type": "io.cozy.apps.suggestions",
       "verbs": ["GET", "POST", "PUT"]
+    },
+    "jobs": {
+      "description": "Used in services to start other services",
+      "type": "io.cozy.jobs"
     }
   }
 }

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -66,7 +66,7 @@
     "onOperationOrBillCreate": {
       "type": "node",
       "file": "onOperationOrBillCreate.js",
-      "trigger": "@event io.cozy.bank.operations:CREATED io.cozy.bills:CREATED",
+      "trigger": "@event io.cozy.bills:CREATED",
       "debounce": "75s"
     },
     "categorization": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "cozy-doctypes": "1.44.0",
     "cozy-flags": "1.6.1",
     "cozy-interapp": "0.4.5",
-    "cozy-konnector-libs": "4.14.13",
+    "cozy-konnector-libs": "4.15.8",
     "cozy-pouch-link": "6.18.0",
     "cozy-realtime": "3.0.0",
     "cozy-stack-client": "6.25.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "copy-webpack-plugin": "5.0.2",
     "cozy-ach": "1.18.0",
     "cozy-app-publish": "0.15.0",
-    "cozy-jobs-cli": "1.8.1",
+    "cozy-jobs-cli": "1.8.9",
     "css-loader": "2.1.1",
     "css-mqpacker": "7.0.0",
     "csswring": "7.0.0",

--- a/src/components/PopupSelect/index.jsx
+++ b/src/components/PopupSelect/index.jsx
@@ -70,6 +70,8 @@ class PopupSelect extends Component {
     const { history } = this.state
     const current = history[0]
     const children = current.children || []
+    const selectedItem = children.find(this.props.isSelected)
+
     return (
       <Modal
         closeBtnClassName={this.props.closeBtnClassName}
@@ -91,7 +93,7 @@ class PopupSelect extends Component {
             {children.map(item => (
               <PopupRow
                 key={item.title}
-                isSelected={this.props.isSelected(item)}
+                isSelected={item === selectedItem}
                 icon={item.icon}
                 label={item.title}
                 onClick={() => this.handleSelect(item)}

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -97,12 +97,12 @@ describe('buildHealthReimbursementsVirtualAccount', () => {
 
   beforeEach(() => {
     transactions = [
-      { automaticCategoryId: '400610', amount: -10, date: '2019-01-02' },
       { manualCategoryId: '400610', amount: -10, date: '2019-01-02' },
-      { automaticCategoryId: '400610', amount: -10, date: '2019-01-02' },
       { manualCategoryId: '400610', amount: -10, date: '2019-01-02' },
-      { automaticCategoryId: '400610', amount: -10, date: '2018-01-02' },
-      { automaticCategoryId: '400470', amount: 10 }
+      { manualCategoryId: '400610', amount: -10, date: '2019-01-02' },
+      { manualCategoryId: '400610', amount: -10, date: '2019-01-02' },
+      { manualCategoryId: '400610', amount: -10, date: '2018-01-02' },
+      { manualCategoryId: '400470', amount: 10 }
     ]
   })
 

--- a/src/ducks/categories/CategoryIcon.jsx
+++ b/src/ducks/categories/CategoryIcon.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Icon from 'cozy-ui/react/Icon'
 import categoryIcons from 'ducks/categories/icons'
 import {
   getParentCategory,
   getCategoryName
 } from 'ducks/categories/categoriesMap'
+import PendingCategoryIcon from 'ducks/categories/PendingCategoryIcon'
 
 const getCategoryIcon = categoryId => {
   let categoryName = getCategoryName(categoryId)
@@ -21,11 +23,20 @@ const getCategoryIcon = categoryId => {
   return categoryIcons.uncategorized
 }
 
-const CategoryIcon = ({ categoryId, className }) => {
+const CategoryIcon = ({ categoryId, ...rest }) => {
+  if (!categoryId) {
+    return <PendingCategoryIcon size={32} {...rest} />
+  }
+
   const icon = getCategoryIcon(categoryId)
   if (!icon) {
     return null
   }
-  return <Icon icon={icon} width={32} height={32} className={className} />
+  return <Icon icon={icon} width={32} height={32} {...rest} />
 }
+
+CategoryIcon.propTypes = {
+  categoryId: PropTypes.string
+}
+
 export default CategoryIcon

--- a/src/ducks/categories/PendingCategoryIcon.jsx
+++ b/src/ducks/categories/PendingCategoryIcon.jsx
@@ -8,6 +8,8 @@ const PendingCategoryIcon = ({ size = 32 }) => {
     height: size
   }
 
+  // We don't externalize the SVG into its own file and use it in a cozy-ui
+  // Icon because it breaks the SVG animations
   return (
     <span className={styles.PendingCategoryIcon} style={style}>
       <svg

--- a/src/ducks/categories/PendingCategoryIcon.jsx
+++ b/src/ducks/categories/PendingCategoryIcon.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styles from 'ducks/categories/PendingCategoryIcon.styl'
+
+const PendingCategoryIcon = ({ size = 32 }) => {
+  const style = {
+    width: size,
+    height: size
+  }
+
+  return (
+    <span className={styles.PendingCategoryIcon} style={style}>
+      <svg
+        version="1.1"
+        xmlns="http://www.w3.org/2000/svg"
+        xmlnsXlink="http://www.w3.org/1999/xlink"
+        x="0px"
+        y="0px"
+        viewBox="0 0 100 100"
+        enableBackground="new 0 0 0 0"
+        xmlSpace="preserve"
+      >
+        <circle fill="#fff" stroke="none" cx="25" cy="50" r="6">
+          <animate
+            attributeName="opacity"
+            dur="1s"
+            values="0;1;0"
+            repeatCount="indefinite"
+            begin="0.1"
+          />
+        </circle>
+        <circle fill="#fff" stroke="none" cx="50" cy="50" r="6">
+          <animate
+            attributeName="opacity"
+            dur="1s"
+            values="0;1;0"
+            repeatCount="indefinite"
+            begin="0.2"
+          />
+        </circle>
+        <circle fill="#fff" stroke="none" cx="75" cy="50" r="6">
+          <animate
+            attributeName="opacity"
+            dur="1s"
+            values="0;1;0"
+            repeatCount="indefinite"
+            begin="0.3"
+          />
+        </circle>
+      </svg>
+    </span>
+  )
+}
+
+PendingCategoryIcon.propTypes = {
+  size: PropTypes.number
+}
+
+export default PendingCategoryIcon

--- a/src/ducks/categories/PendingCategoryIcon.styl
+++ b/src/ducks/categories/PendingCategoryIcon.styl
@@ -1,0 +1,10 @@
+.PendingCategoryIcon
+    display inline-flex
+    align-items center
+    justify-content center
+    background-color var(--silver)
+    border-radius 50%
+
+    svg
+        height 100%
+        width 100%

--- a/src/ducks/categories/categoriesMap.js
+++ b/src/ducks/categories/categoriesMap.js
@@ -109,7 +109,7 @@ export const categoryToParent = new Map(
 
 export const getParentCategory = catId => {
   const parent = categoryToParent.get(catId)
-  return parent && parent.name ? parent.name : 'uncategorized'
+  return parent && parent.name
 }
 
 Object.keys(tree).forEach(catId => {

--- a/src/ducks/categories/categoriesMap.js
+++ b/src/ducks/categories/categoriesMap.js
@@ -125,6 +125,4 @@ Object.keys(tree).forEach(catId => {
   }
 })
 
-export const isAwaitingCategory = categoryId => categoryId === '-1'
-
 export default categoryToParent

--- a/src/ducks/categories/categoriesMap.js
+++ b/src/ducks/categories/categoriesMap.js
@@ -71,6 +71,11 @@ export const getCategories = () => {
 
 export const getCategoryName = id => {
   const undefinedId = 0
+
+  if (id === null) {
+    return 'awaiting'
+  }
+
   if (id === undefined) {
     return tree[undefinedId]
   }

--- a/src/ducks/categories/categoriesMap.js
+++ b/src/ducks/categories/categoriesMap.js
@@ -120,4 +120,6 @@ Object.keys(tree).forEach(catId => {
   }
 })
 
+export const isAwaitingCategory = categoryId => categoryId === '-1'
+
 export default categoryToParent

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -75,6 +75,11 @@ export const transactionsByCategory = transactions => {
     // Creates a map of categories, where each entry contains a list of
     // related operations and a breakdown by sub-category
     const catId = getCategoryId(transaction)
+
+    if (!catId) {
+      continue
+    }
+
     const parent = getParent(catId) || getParent('0')
 
     // create a new parent category if necessary

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -62,6 +62,10 @@ export const getParentCategory = transaction => {
   return getParent(getCategoryId(transaction))
 }
 
+export const isAwaitingCategorization = transaction => {
+  return getCategoryId(transaction) === null
+}
+
 // This function builds a map of categories and sub-categories, each containing
 // a list of related transactions, a name and a color
 export const transactionsByCategory = transactions => {
@@ -72,14 +76,13 @@ export const transactionsByCategory = transactions => {
   }
 
   for (const transaction of transactions) {
+    // Ignore transactions that don't have a usable categorization yet
+    if (isAwaitingCategorization(transaction)) {
+      continue
+    }
     // Creates a map of categories, where each entry contains a list of
     // related operations and a breakdown by sub-category
     const catId = getCategoryId(transaction)
-
-    if (!catId) {
-      continue
-    }
-
     const parent = getParent(catId) || getParent('0')
 
     // create a new parent category if necessary

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -25,7 +25,7 @@ export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.15
 /**
  * Return the category id of the transaction
  * @param {Object} transaction
- * @return {String}
+ * @return {String|null} A category id or null if the transaction has not been categorized yet
  */
 export const getCategoryId = transaction => {
   if (transaction.manualCategoryId) {

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -51,6 +51,10 @@ export const getCategoryId = transaction => {
     return transaction.cozyCategoryId
   }
 
+  if (!transaction.localCategoryId && !transaction.cozyCategoryId) {
+    return null
+  }
+
   return transaction.automaticCategoryId
 }
 

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -51,6 +51,9 @@ export const getCategoryId = transaction => {
     return transaction.cozyCategoryId
   }
 
+  // If the cozy categorization models have not been applied, we return null
+  // so the transaction is considered as « categorization in progress ».
+  // Otherwize we just use the automatic categorization from the vendor
   if (!transaction.localCategoryId && !transaction.cozyCategoryId) {
     return null
   }

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -52,9 +52,13 @@ describe('getCategoryId', () => {
     expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
   })
 
-  it("Should return the automaticCategoryId if there's neither manualCategoryId nor automaticCategoryId", () => {
+  it("Should return the automaticCategoryId if there's no manualCategoryId, and localCategory/cozyCategory are not usable", () => {
     const transaction = {
-      automaticCategoryId: '200120'
+      automaticCategoryId: '200120',
+      localCategoryId: '200130',
+      localCategoryPrba: LOCAL_MODEL_USAGE_THRESHOLD - 0.01,
+      cozyCategoryId: '200140',
+      cozyCategoryProba: GLOBAL_MODEL_USAGE_THRESHOLD - 0.01
     }
 
     expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
@@ -81,5 +85,13 @@ describe('getCategoryId', () => {
     }
 
     expect(getCategoryId(transaction)).toBe(transaction.cozyCategoryId)
+  })
+
+  it('should return null if there is only automaticCategoryId', () => {
+    const transaction = {
+      automaticCategoryId: '200120'
+    }
+
+    expect(getCategoryId(transaction)).toBeNull()
   })
 })

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -3,6 +3,7 @@ jest.mock('cozy-flags')
 import flag from 'cozy-flags'
 import {
   getCategoryId,
+  isAwaitingCategorization,
   transactionsByCategory,
   LOCAL_MODEL_USAGE_THRESHOLD,
   GLOBAL_MODEL_USAGE_THRESHOLD
@@ -93,5 +94,17 @@ describe('getCategoryId', () => {
     }
 
     expect(getCategoryId(transaction)).toBeNull()
+  })
+})
+
+describe('isAwaitingCategorization', () => {
+  it('should return true if the transaction is awaiting cozy categorization', () => {
+    const transaction = { _id: 't1', automaticCategoryId: '400110' }
+    expect(isAwaitingCategorization(transaction)).toBe(true)
+  })
+
+  it('should return false if the transaction have a cozy categorization', () => {
+    const transaction = { _id: 't1', cozyCategoryId: '400110' }
+    expect(isAwaitingCategorization(transaction)).toBe(false)
   })
 })

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -73,10 +73,10 @@ export const canCategorizeNextChunk = () => {
   return nextExecutionTime < MAX_EXECUTION_TIME
 }
 
-export const restartService = () => {
+export const startService = name => {
   const args = {
     message: {
-      name: 'categorization',
+      name,
       slug: 'banks'
     }
   }

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -72,3 +72,14 @@ export const canCategorizeNextChunk = () => {
 
   return nextExecutionTime < MAX_EXECUTION_TIME
 }
+
+export const restartService = () => {
+  const args = {
+    message: {
+      name: 'categorization',
+      slug: 'banks'
+    }
+  }
+
+  return cozyClient.jobs.create('service', args)
+}

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -9,7 +9,9 @@ import { LOCAL_MODEL_USAGE_THRESHOLD } from 'ducks/categories/helpers'
 
 BankTransaction.registerClient(cozyClient)
 
+// Each chunk will contain 100 transactions
 export const CHUNK_SIZE = 100
+
 const MAX_EXECUTION_TIME = 200
 const timeStart = new Date()
 let highestTime = 0

--- a/src/ducks/notifications/TransactionGreater.js
+++ b/src/ducks/notifications/TransactionGreater.js
@@ -3,7 +3,6 @@ import htmlTemplate from './html/transaction-greater-html'
 import * as utils from './html/utils'
 import { subDays } from 'date-fns'
 import { isTransactionAmountGreaterThan } from './helpers'
-import isCreatedDoc from 'utils/isCreatedDoc'
 import Notification from './Notification'
 import { sortBy } from 'lodash'
 import log from 'cozy-logger'
@@ -13,6 +12,13 @@ import { getCurrencySymbol } from 'utils/currencySymbol'
 const ACCOUNT_SEL = '.js-account'
 const DATE_SEL = '.js-date'
 const TRANSACTION_SEL = '.js-transaction'
+
+// We don't use `isCreatedDoc` from utils here because
+// we want to get the transactions that have just been
+// categorized, so their _rev is <= 2
+const isFreshTransaction = transaction => {
+  return parseInt(transaction._rev.split('-').shift(), 10) <= 2
+}
 
 const toText = cozyHTMLEmail => {
   const getTextTransactionRow = $row =>
@@ -58,7 +64,7 @@ class TransactionGreater extends Notification {
     const fourDaysAgo = subDays(new Date(), 4)
 
     return transactions
-      .filter(isCreatedDoc)
+      .filter(isFreshTransaction)
       .filter(tr => new Date(getDate(tr)) > fourDaysAgo)
       .filter(isTransactionAmountGreaterThan(this.maxAmount))
   }

--- a/src/ducks/notifications/TransactionGreater.js
+++ b/src/ducks/notifications/TransactionGreater.js
@@ -6,19 +6,12 @@ import { isTransactionAmountGreaterThan } from './helpers'
 import Notification from './Notification'
 import { sortBy } from 'lodash'
 import log from 'cozy-logger'
-import { getDate } from 'ducks/transactions/helpers'
+import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 
 const ACCOUNT_SEL = '.js-account'
 const DATE_SEL = '.js-date'
 const TRANSACTION_SEL = '.js-transaction'
-
-// We don't use `isCreatedDoc` from utils here because
-// we want to get the transactions that have just been
-// categorized, so their _rev is <= 2
-const isFreshTransaction = transaction => {
-  return parseInt(transaction._rev.split('-').shift(), 10) <= 2
-}
 
 const toText = cozyHTMLEmail => {
   const getTextTransactionRow = $row =>
@@ -64,7 +57,7 @@ class TransactionGreater extends Notification {
     const fourDaysAgo = subDays(new Date(), 4)
 
     return transactions
-      .filter(isFreshTransaction)
+      .filter(isNewTransaction)
       .filter(tr => new Date(getDate(tr)) > fourDaysAgo)
       .filter(isTransactionAmountGreaterThan(this.maxAmount))
   }

--- a/src/ducks/notifications/html/data/health-bill-linked.json
+++ b/src/ducks/notifications/html/data/health-bill-linked.json
@@ -3,7 +3,7 @@
     {
       "account": "compteisa1",
       "amount": -60,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-06T00:00:00Z",
       "demo": true,
@@ -20,7 +20,7 @@
     {
       "account": "compteisa1",
       "amount": -60,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-06T00:00:00Z",
       "demo": true,
@@ -43,7 +43,7 @@
     {
       "account": "comptecla1",
       "amount": -60,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-06T00:00:00Z",
       "demo": true,

--- a/src/ducks/notifications/html/data/transactions-greater.json
+++ b/src/ducks/notifications/html/data/transactions-greater.json
@@ -62,7 +62,7 @@
     {
       "account": "compteisa1",
       "amount": -60,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-06T00:00:00Z",
       "demo": true,
@@ -78,7 +78,7 @@
     {
       "account": "compteisa1",
       "amount": -60,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-06T00:00:00Z",
       "demo": true,
@@ -95,7 +95,7 @@
       "account": "comptecla1",
       "amount": -120.7,
       "bill": "io.cozy.bills:avrilrembourcla3",
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-07-11T00:00:00Z",
       "demo": true,
@@ -104,7 +104,7 @@
     {
       "account": "compteisa3",
       "amount": 400,
-      "automaticCategoryId": "600110",
+      "manualCategoryId": "600110",
       "currency": "€",
       "date": "2017-07-03T00:00:00Z",
       "demo": true,
@@ -113,7 +113,7 @@
     {
       "account": "comptegene1",
       "amount": -42.3,
-      "automaticCategoryId": "400110",
+      "manualCategoryId": "400110",
       "currency": "€",
       "date": "2017-07-04T00:00:00Z",
       "demo": true,
@@ -123,7 +123,7 @@
       "account": "compteisa1",
       "amount": -90,
       "bill": "io.cozy.bills:rembourcomplisa1",
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2017-08-25T00:00:00Z",
       "demo": true,

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -107,3 +107,16 @@ export const isFullyReimbursed = expense => {
 
   return reimbursedAmount === -expense.amount
 }
+
+/*
+ * A transaction is considered as new if its revision is lesser than or equals
+ * to 2. This is because when a transaction is imported by a banking konnector
+ * it is saved, then categorized and re-saved (by the konnector or by the
+ * categorization service). It means that when a new transaction is handled by
+ * the onOperationOrBillCreate service, its revision is already `2`. So if we
+ * only consider transactions with revision `1`, we will miss the vast majority
+ * of them. For all other cases, please see `utils/isCreatedDoc`
+ */
+export const isNew = transaction => {
+  return parseInt(transaction._rev.split('-').shift(), 10) <= 2
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -240,7 +240,8 @@
       "tax": "Others : Taxes",
       "transportation": "Others : Transportation, vehicles",
       "goingOutAndTravel": "Others : Outings, trips",
-      "uncategorized": "Others : To be categorized"
+      "uncategorized": "Others : To be categorized",
+      "awaiting": "Categorization in progress"
     },
     "virtualAccounts": {
       "healthReimbursements": "Awaiting health reimb"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -310,7 +310,8 @@
       "tax": "Autres : Impôts",
       "transportation": "Autres : Transports, véhicules",
       "goingOutAndTravel": "Autres : Sorties, voyages",
-      "uncategorized": "Autres : A catégoriser"
+      "uncategorized": "Autres : A catégoriser",
+      "awaiting": "Catégorisation en cours"
     },
     "virtualAccounts": {
       "healthReimbursements": "Remb santé en attente"

--- a/src/targets/services/categorization.js
+++ b/src/targets/services/categorization.js
@@ -6,7 +6,7 @@ import {
   categorizeChunk,
   updateTimeTracking,
   CHUNK_SIZE,
-  restartService
+  startService
 } from 'ducks/categorization/services'
 
 const log = logger.namespace('service/categorization')
@@ -48,12 +48,15 @@ const categorization = async () => {
         'info',
         'Not enough time remaining to categorize next chunk, starting a new service run.'
       )
-      await restartService()
+      await startService('categorization')
       return
     }
   }
 
   log('info', 'All transactions have been successfuly categorized.')
+
+  log('info', 'Starting onOperationOrBillCreate service...')
+  await startService('onOperationOrBillCreate')
 }
 
 categorization()

--- a/src/targets/services/categorization.js
+++ b/src/targets/services/categorization.js
@@ -1,0 +1,55 @@
+import logger from 'cozy-logger'
+import { createCategorizer } from 'cozy-konnector-libs'
+import {
+  fetchChunksToCategorize,
+  canCategorizeNextChunk,
+  categorizeChunk,
+  updateTimeTracking,
+  CHUNK_SIZE
+} from 'ducks/categorization/services'
+
+const log = logger.namespace('service/categorization')
+
+const categorization = async () => {
+  log('info', 'Fetching chunks to categorize...')
+  let chunks
+
+  try {
+    chunks = await fetchChunksToCategorize()
+  } catch (err) {
+    log('error', 'Error while fetching chunks to categorize ' + err)
+    return
+  }
+
+  log(
+    'info',
+    `${chunks.length} chunks of ${CHUNK_SIZE} transactions to categorize`
+  )
+
+  log('info', 'Creating a new categorizer...')
+  const categorizer = await createCategorizer()
+
+  log('info', 'Categorizing chunks...')
+  for (const chunk of chunks) {
+    if (canCategorizeNextChunk()) {
+      log('info', 'Categorizing chunk...')
+
+      try {
+        const timeElapsed = await categorizeChunk(categorizer, chunk)
+        log('info', `Last chunk was categorized in ${timeElapsed}s`)
+
+        updateTimeTracking(timeElapsed)
+      } catch (e) {
+        log('error', 'Error while categorizing transactions ' + e)
+      }
+    } else {
+      log(
+        'info',
+        'Not enough time remaining to categorize next chunk, stopping.'
+      )
+      return
+    }
+  }
+}
+
+categorization()

--- a/src/targets/services/categorization.js
+++ b/src/targets/services/categorization.js
@@ -5,7 +5,8 @@ import {
   canCategorizeNextChunk,
   categorizeChunk,
   updateTimeTracking,
-  CHUNK_SIZE
+  CHUNK_SIZE,
+  restartService
 } from 'ducks/categorization/services'
 
 const log = logger.namespace('service/categorization')
@@ -45,8 +46,9 @@ const categorization = async () => {
     } else {
       log(
         'info',
-        'Not enough time remaining to categorize next chunk, stopping.'
+        'Not enough time remaining to categorize next chunk, starting a new service run.'
       )
+      await restartService()
       return
     }
   }

--- a/src/targets/services/categorization.js
+++ b/src/targets/services/categorization.js
@@ -52,6 +52,8 @@ const categorization = async () => {
       return
     }
   }
+
+  log('info', 'All transactions have been successfuly categorized.')
 }
 
 categorization()

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -9,6 +9,7 @@ import matchFromBills from 'ducks/billsMatching/matchFromBills'
 import matchFromTransactions from 'ducks/billsMatching/matchFromTransactions'
 import { logResult } from 'ducks/billsMatching/utils'
 import { findAppSuggestions } from 'ducks/appSuggestions/services'
+import { isNew as isNewTransaction } from 'ducks/transactions/helpers'
 
 const log = logger.namespace('onOperationOrBillCreate')
 
@@ -77,7 +78,7 @@ const doTransactionsMatching = async setting => {
       transactionsLastSeq
     )
     transactionsChanges.documents = transactionsChanges.documents.filter(
-      isCreatedDoc
+      isNewTransaction
     )
     setting.billsMatching.transactionsLastSeq = transactionsChanges.newLastSeq
 

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -148,7 +148,7 @@
   "io.cozy.bank.operations": [
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'realEstateLoan' }}",
+      "manualCategoryId": "{{ categoryId 'realEstateLoan' }}",
       "account": "compteisa1",
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
@@ -158,7 +158,7 @@
     {
       "_id": "edf",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'power' }}",
+      "manualCategoryId": "{{ categoryId 'power' }}",
       "account": "compteisa1",
       "label": "EDF PARTICULIERS",
       "currency": "€",
@@ -167,7 +167,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "account": "compteisa1",
       "label": "FREEMOBILE",
       "currency": "€",
@@ -179,7 +179,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "account": "compteisa1",
       "label": "FREEMOBILE",
       "currency": "€",
@@ -192,7 +192,7 @@
     {
       "_id": "maifassurance",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'homeInsurance' }}",
+      "manualCategoryId": "{{ categoryId 'homeInsurance' }}",
       "account": "compteisa1",
       "label": "MAIF ASSURANCE HABITATION",
       "currency": "€",
@@ -205,7 +205,7 @@
     {
       "_id": "salaireisa1",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
       "account": "compteisa1",
       "label": "SALAIRE",
       "currency": "€",
@@ -220,7 +220,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'schoolRestaurant' }}",
+      "manualCategoryId": "{{ categoryId 'schoolRestaurant' }}",
       "account": "compteisa1",
       "label": "CANTINE SCOLAIRE",
       "currency": "€",
@@ -229,7 +229,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -238,7 +238,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -247,7 +247,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -256,7 +256,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -265,7 +265,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "account": "compteisa1",
       "label": "H&M",
       "currency": "€",
@@ -274,7 +274,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "{{ categoryId 'taxi' }}",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -283,7 +283,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "{{ categoryId 'taxi' }}",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -292,7 +292,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'dressing' }}",
+      "manualCategoryId": "{{ categoryId 'dressing' }}",
       "account": "compteisa1",
       "label": "FRANCK PROVOST MONCEAU",
       "currency": "€",
@@ -302,7 +302,7 @@
     {
       "_id": "fnac",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "account": "compteisa1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -317,7 +317,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
       "account": "compteisa1",
       "label": "LA BELLE ASSIETTE",
       "currency": "€",
@@ -326,7 +326,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "KAISER BOULANGERIE",
       "currency": "€",
@@ -335,7 +335,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "KAISER BOULANGERIE",
       "currency": "€",
@@ -344,7 +344,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'kidsAllowance' }}",
+      "manualCategoryId": "{{ categoryId 'kidsAllowance' }}",
       "account": "compteisa1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -353,7 +353,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "{{ categoryId 'dividends' }}",
       "account": "compteisa1",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -362,7 +362,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "{{ categoryId 'dividends' }}",
       "account": "compteisa3",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -371,7 +371,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
       "account": "comptelou1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -380,7 +380,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
+      "manualCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
       "account": "comptelou1",
       "label": "GAUMONTPARNASSE",
       "currency": "€",
@@ -389,7 +389,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
       "account": "comptelou1",
       "label": "MC DONALDS",
       "currency": "€",
@@ -398,7 +398,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -407,7 +407,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -416,7 +416,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptelou1",
       "label": "DR MARTIN CONSULTATION",
       "currency": "€",
@@ -426,7 +426,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:rembourcomplisa1",
       "label": "VIR COMPL SANTE",
@@ -437,7 +437,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:rembourcomplisa2",
       "label": "VIR COMPL SANTE",
@@ -448,7 +448,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "DR CHOLLET CHQ 18708914",
       "currency": "€",
@@ -458,7 +458,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "label": "CAB CARDIO CONSULT",
       "currency": "€",
@@ -468,7 +468,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:rembourcla3",
       "label": "CPAM PARIS",
@@ -479,7 +479,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:rembourcomplcla3",
       "label": "VIR COMPL SANTE",
@@ -491,7 +491,7 @@
     {
       "_id": "facturebouygues",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "account": "comptegene1",
       "label": "BOUYGUES TELECOM",
       "currency": "€",
@@ -503,7 +503,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'pensionPaid' }}",
+      "manualCategoryId": "{{ categoryId 'pensionPaid' }}",
       "account": "comptegene1",
       "label": "RETRAITE",
       "currency": "€",
@@ -512,7 +512,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
       "account": "comptegene1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -521,7 +521,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "comptegene1",
       "label": "AUCHAN",
       "currency": "€",
@@ -530,7 +530,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "comptegene1",
       "label": "CARREFOUR CITY",
       "currency": "€",
@@ -539,7 +539,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -548,7 +548,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'personalCare' }}",
+      "manualCategoryId": "{{ categoryId 'personalCare' }}",
       "account": "comptegene1",
       "label": "FRANCE MENAGE",
       "currency": "€",
@@ -557,7 +557,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptegene1",
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
@@ -566,7 +566,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -575,7 +575,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "account": "comptegene1",
       "label": "LA REDOUTE",
       "currency": "€",
@@ -584,7 +584,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptegene1",
       "label": "DOCTEUR LEFEBVRE",
       "currency": "€",
@@ -594,7 +594,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'realEstateLoan' }}",
+      "manualCategoryId": "{{ categoryId 'realEstateLoan' }}",
       "account": "compteisa1",
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
@@ -603,7 +603,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
       "account": "compteisa1",
       "label": "SALAIRE",
       "currency": "€",
@@ -612,7 +612,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -621,7 +621,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -630,7 +630,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -639,7 +639,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -648,7 +648,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "account": "compteisa1",
       "label": "ZARA",
       "currency": "€",
@@ -657,7 +657,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "{{ categoryId 'taxi' }}",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -666,7 +666,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "{{ categoryId 'taxi' }}",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -675,7 +675,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
       "account": "compteisa1",
       "label": "LE RICHER",
       "currency": "€",
@@ -684,7 +684,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "kAISER BOULANGERIE",
       "currency": "€",
@@ -693,7 +693,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "compteisa1",
       "label": "kAISER BOULANGERIE",
       "currency": "€",
@@ -702,7 +702,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'kidsAllowance' }}",
+      "manualCategoryId": "{{ categoryId 'kidsAllowance' }}",
       "account": "compteisa1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -711,7 +711,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "{{ categoryId 'dividends' }}",
       "account": "compteisa1",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -720,7 +720,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "{{ categoryId 'dividends' }}",
       "account": "compteisa3",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -729,7 +729,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
       "account": "comptelou1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -738,7 +738,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
+      "manualCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
       "account": "comptelou1",
       "label": "UGCCINECITE",
       "currency": "€",
@@ -747,7 +747,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
       "account": "comptelou1",
       "label": "KFC",
       "currency": "€",
@@ -756,7 +756,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -765,7 +765,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -774,7 +774,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "DR CHOLLET CHQ 18708912",
       "currency": "€",
@@ -784,7 +784,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:marsrembourcomplisa2",
       "label": "VIR COMPL SANTE",
@@ -795,7 +795,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "DR CHOLLET CHQ 18708913",
       "currency": "€",
@@ -805,7 +805,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:marsrembourcomplisa22",
       "label": "VIR COMPL SANTE",
@@ -816,7 +816,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "CAB OSTEOKINESITHERAPIE",
       "currency": "€",
@@ -826,7 +826,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:avrilrembourcomplisa2",
       "label": "VIR COMPL SANTE",
@@ -837,7 +837,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "CAB OSTEOKINESITHERAPIE",
       "currency": "€",
@@ -847,7 +847,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:avrilrembourcomplisa22",
       "label": "VIR COMPL SANTE",
@@ -858,7 +858,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "label": "KINE REUILLY",
       "currency": "€",
@@ -868,7 +868,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "compteisa1",
       "bill": "io.cozy.bills:avrilrembourcomplisa23",
       "label": "VIR COMPL SANTE",
@@ -879,7 +879,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "label": "CAB CARDIOLOGIE CONSULT",
       "currency": "€",
@@ -889,7 +889,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:avrilrembourcla3",
       "label": "CPAM PARIS",
@@ -900,7 +900,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:avrilrembourcomplcla3",
       "label": "VIR COMPL SANTE",
@@ -911,7 +911,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "label": "LABORATOIRE PUTEAUX",
       "currency": "€",
@@ -921,7 +921,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:avrilrembourcla32",
       "label": "CPAM PARIS",
@@ -932,7 +932,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'healthExpenses' }}",
+      "manualCategoryId": "{{ categoryId 'healthExpenses' }}",
       "account": "comptecla1",
       "bill": "io.cozy.bills:avrilrembourcomplcla32",
       "label": "VIR COMPL SANTE",
@@ -943,7 +943,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "account": "comptegene1",
       "label": "BOUYGUES TELECOM",
       "currency": "€",
@@ -955,7 +955,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'pensionPaid' }}",
+      "manualCategoryId": "{{ categoryId 'pensionPaid' }}",
       "account": "comptegene1",
       "label": "RETRAITE",
       "currency": "€",
@@ -964,7 +964,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
       "account": "comptegene1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -973,7 +973,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "comptegene1",
       "label": "AUCHAN",
       "currency": "€",
@@ -982,7 +982,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "{{ categoryId 'supermarket' }}",
       "account": "comptegene1",
       "label": "CARREFOUR CITY",
       "currency": "€",
@@ -991,7 +991,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -1000,7 +1000,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'personalCare' }}",
+      "manualCategoryId": "{{ categoryId 'personalCare' }}",
       "account": "comptegene1",
       "label": "FRANCE MENAGE",
       "currency": "€",
@@ -1009,7 +1009,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
       "account": "comptegene1",
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
@@ -1018,7 +1018,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -1028,7 +1028,7 @@
     {
       "_id": "normalshopping",
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "account": "comptegene1",
       "label": "SOMEWHERE",
       "currency": "€",
@@ -1039,7 +1039,7 @@
       "_id": "paiementdocteur",
       "account": "compteisa1",
       "amount": -25,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2018-01-03T00:00:00Z",
       "label": "Docteur",
@@ -1060,7 +1060,7 @@
       "_id": "paiementdocteur2",
       "account": "compteisa1",
       "amount": -25,
-      "automaticCategoryId": "400610",
+      "manualCategoryId": "400610",
       "currency": "€",
       "date": "2018-01-03T00:00:00Z",
       "label": "Docteur 2"
@@ -1069,7 +1069,7 @@
       "_id": "remboursementcomplementaire",
       "account": "compteisa1",
       "amount": 7.5,
-      "automaticCategoryId": "400620",
+      "manualCategoryId": "400620",
       "currency": "€",
       "date": "2018-01-08T00:00:00Z",
       "label": "Malakoff Mederic Prevoyance R172",
@@ -1081,7 +1081,7 @@
       "_id": "remboursementameli",
       "account": "compteisa1",
       "amount": 17.5,
-      "automaticCategoryId": "400620",
+      "manualCategoryId": "400620",
       "currency": "€",
       "date": "2018-01-06T00:00:00Z",
       "label": "Cpam Des Yvelines 173470021068",
@@ -1091,7 +1091,7 @@
     },
     {
       "demo": true,
-      "automaticCategoryId": "{{ categoryId 'incomeCat' }}",
+      "manualCategoryId": "{{ categoryId 'incomeCat' }}",
       "account": "comptegene1",
       "label": "Autre revenu",
       "currency": "€",
@@ -1099,7 +1099,7 @@
       "date": "2018-01-19T00:00:00Z"
     },
     {
-      "automaticCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
       "account": "compteisa1",
       "label": "Salaire juin 2018",
       "currency": "€",
@@ -1109,7 +1109,7 @@
     {
       "account": "compteisa1",
       "amount": -80,
-      "automaticCategoryId": "400410",
+      "manualCategoryId": "400410",
       "currency": "€",
       "date": "2018-06-01T00:00:00Z",
       "label": "ARGENT DE POCHE"
@@ -1117,7 +1117,7 @@
     {
       "account": "compteisa1",
       "amount": -120.44,
-      "automaticCategoryId": "400420",
+      "manualCategoryId": "400420",
       "currency": "€",
       "date": "2018-06-01T00:00:00Z",
       "label": "CANTINE SCOLAIRE"
@@ -1125,7 +1125,7 @@
     {
       "account": "comptelou1",
       "amount": 80,
-      "automaticCategoryId": "400180",
+      "manualCategoryId": "400180",
       "currency": "€",
       "date": "2018-06-02T00:00:00Z",
       "label": "ARGENT DE POCHE"
@@ -1133,7 +1133,7 @@
     {
       "account": "compteisa3",
       "amount": 400,
-      "automaticCategoryId": "600110",
+      "manualCategoryId": "600110",
       "currency": "€",
       "date": "2018-06-03T00:00:00Z",
       "label": "TRANSFERT LIVRET A"
@@ -1141,7 +1141,7 @@
     {
       "account": "compteisa1",
       "amount": -22.12,
-      "automaticCategoryId": "400290",
+      "manualCategoryId": "400290",
       "currency": "€",
       "date": "2018-06-03T00:00:00Z",
       "label": "UBER"
@@ -1149,7 +1149,7 @@
     {
       "account": "comptegene1",
       "amount": -42.3,
-      "automaticCategoryId": "400110",
+      "manualCategoryId": "400110",
       "currency": "€",
       "date": "2018-06-04T00:00:00Z",
       "label": "AUCHAN"
@@ -1157,7 +1157,7 @@
     {
       "account": "compteisa1",
       "amount": -7.5,
-      "automaticCategoryId": "400620",
+      "manualCategoryId": "400620",
       "currency": "€",
       "date": "2018-06-04T00:00:00Z",
       "label": "Generali remboursement médecin"
@@ -1165,7 +1165,7 @@
     {
       "account": "comptegene1",
       "amount": -100,
-      "automaticCategoryId": "300",
+      "manualCategoryId": "300",
       "currency": "€",
       "date": "2018-06-04T00:00:00Z",
       "label": "RETRAIT CREDIT AGRICOLE"
@@ -1173,7 +1173,7 @@
     {
       "account": "comptelou1",
       "amount": -20,
-      "automaticCategoryId": "300",
+      "manualCategoryId": "300",
       "currency": "€",
       "date": "2018-06-04T00:00:00Z",
       "label": "RETRAIT BNPPARIBAS"
@@ -1181,7 +1181,7 @@
     {
       "account": "compteisa1",
       "amount": -400,
-      "automaticCategoryId": "600110",
+      "manualCategoryId": "600110",
       "currency": "€",
       "date": "2018-06-03T00:00:00Z",
       "label": "TRANSFERT LIVRET A"
@@ -1189,7 +1189,7 @@
     {
       "account": "compteisa1",
       "amount": -62.3,
-      "automaticCategoryId": "400110",
+      "manualCategoryId": "400110",
       "currency": "€",
       "date": "2018-06-06T00:00:00Z",
       "label": "CARREFOUR MARKET"
@@ -1197,7 +1197,7 @@
     {
       "account": "compteisa1",
       "amount": -78.54,
-      "automaticCategoryId": "400810",
+      "manualCategoryId": "400810",
       "currency": "€",
       "date": "2018-06-08T00:00:00Z",
       "label": "LA BELLE ASSIETTE"
@@ -1205,7 +1205,7 @@
     {
       "account": "comptegene1",
       "amount": -18.22,
-      "automaticCategoryId": "400420",
+      "manualCategoryId": "400420",
       "currency": "€",
       "date": "2018-06-07T00:00:00Z",
       "label": "FRANPRIX"
@@ -1213,7 +1213,7 @@
     {
       "account": "compteisa1",
       "amount": -117,
-      "automaticCategoryId": "{{ categoryId 'goingOutAndTravel' }}",
+      "manualCategoryId": "{{ categoryId 'goingOutAndTravel' }}",
       "currency": "€",
       "date": "2018-06-08T00:00:00Z",
       "label": "Sncf"
@@ -1221,7 +1221,7 @@
     {
       "account": "compteisa1",
       "amount": -30,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
       "date": "2018-06-11T00:00:00Z",
       "label": "Free Mobile"
@@ -1229,7 +1229,7 @@
     {
       "account": "comptegene1",
       "amount": -80.44,
-      "automaticCategoryId": "400180",
+      "manualCategoryId": "400180",
       "currency": "€",
       "date": "2018-06-11T00:00:00Z",
       "label": "FNAC TERNES"
@@ -1237,7 +1237,7 @@
     {
       "account": "compteisa1",
       "amount": -98.22,
-      "automaticCategoryId": "400420",
+      "manualCategoryId": "400420",
       "currency": "€",
       "date": "2018-06-11T00:00:00Z",
       "label": "FRANPRIX"
@@ -1245,7 +1245,7 @@
     {
       "account": "comptelou1",
       "amount": -7.5,
-      "automaticCategoryId": "400740",
+      "manualCategoryId": "400740",
       "currency": "€",
       "date": "2018-06-12T00:00:00Z",
       "label": "GAUMONTPARNASSE"
@@ -1253,7 +1253,7 @@
     {
       "account": "compteisa1",
       "amount": -165.3,
-      "automaticCategoryId": "400110",
+      "manualCategoryId": "400110",
       "currency": "€",
       "date": "2018-06-12T00:00:00Z",
       "label": "CARREFOUR MARKET"
@@ -1261,7 +1261,7 @@
     {
       "account": "comptelou1",
       "amount": -8.5,
-      "automaticCategoryId": "400810",
+      "manualCategoryId": "400810",
       "currency": "€",
       "date": "2018-06-12T00:00:00Z",
       "label": "MC DONALDS"
@@ -1269,7 +1269,7 @@
     {
       "account": "comptegene1",
       "amount": -42.89,
-      "automaticCategoryId": "400130",
+      "manualCategoryId": "400130",
       "currency": "€",
       "date": "2018-06-13T00:00:00Z",
       "label": "LA REDOUTE"
@@ -1277,7 +1277,7 @@
     {
       "account": "compteisa1",
       "amount": -73.50,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
       "date": "2018-06-13T00:00:00Z",
       "label": "Leclerc Drive"
@@ -1285,7 +1285,7 @@
     {
       "account": "compteisa1",
       "amount": -8.09,
-      "automaticCategoryId": "400290",
+      "manualCategoryId": "400290",
       "currency": "€",
       "date": "2018-06-14T00:00:00Z",
       "label": "UBER"
@@ -1293,7 +1293,7 @@
     {
       "account": "comptegene1",
       "amount": -65.3,
-      "automaticCategoryId": "400110",
+      "manualCategoryId": "400110",
       "currency": "€",
       "date": "2018-06-14T00:00:00Z",
       "label": "CARREFOUR CITY"
@@ -1301,7 +1301,7 @@
     {
       "account": "compteisa1",
       "amount": -27.90,
-      "automaticCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
       "currency": "€",
       "date": "2018-06-15T00:00:00Z",
       "label": "Just Eat"
@@ -1309,7 +1309,7 @@
     {
       "account": "compteisa1",
       "amount": -9.90,
-      "automaticCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "{{ categoryId 'telecom' }}",
       "currency": "€",
       "date": "2018-06-15T00:00:00Z",
       "label": "Sosh"
@@ -1317,7 +1317,7 @@
     {
       "account": "compteisa1",
       "amount": -36,
-      "automaticCategoryId": "400130",
+      "manualCategoryId": "400130",
       "currency": "€",
       "date": "2018-06-17T00:00:00Z",
       "label": "FRANCK PROVOST MONCEAU"
@@ -1325,7 +1325,7 @@
     {
       "account": "compteisa1",
       "amount": -1231,
-      "automaticCategoryId": "400750",
+      "manualCategoryId": "400750",
       "currency": "€",
       "date": "2018-06-17T00:00:00Z",
       "label": "REMBOURSEMENT PRET LCL"
@@ -1333,7 +1333,7 @@
     {
       "account": "comptelou1",
       "amount": -20,
-      "automaticCategoryId": "300",
+      "manualCategoryId": "300",
       "currency": "€",
       "date": "2018-06-19T00:00:00Z",
       "label": "RETRAIT BNPPARIBAS 2018-01-19"
@@ -1341,7 +1341,7 @@
     {
       "account": "compteisa1",
       "amount": -11.90,
-      "automaticCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
+      "manualCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
       "currency": "€",
       "date": "2018-06-20T00:00:00Z",
       "label": "Netflix"
@@ -1349,7 +1349,7 @@
     {
       "account": "comptegene1",
       "amount": -40,
-      "automaticCategoryId": "400330",
+      "manualCategoryId": "400330",
       "currency": "€",
       "date": "2018-06-20T00:00:00Z",
       "label": "FRANCE MENAGE MONTLY SUBSCRIPTION"
@@ -1357,7 +1357,7 @@
     {
       "account": "compteisa1",
       "amount": -42.89,
-      "automaticCategoryId": "400130",
+      "manualCategoryId": "400130",
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
       "label": "H&M"
@@ -1365,7 +1365,7 @@
     {
       "account": "comptegene1",
       "amount": -48.22,
-      "automaticCategoryId": "400420",
+      "manualCategoryId": "400420",
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
       "label": "FRANPRIX ST LAZARE PR"
@@ -1374,7 +1374,7 @@
       "_id": "maintenance",
       "account": "comptegene1",
       "amount": -44.9,
-      "automaticCategoryId": "400140",
+      "manualCategoryId": "400140",
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
       "label": "maintenance"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2683,11 +2683,6 @@ bluebird-retry@0.11.0:
   resolved "https://registry.yarnpkg.com/bluebird-retry/-/bluebird-retry-0.11.0.tgz#1289ab22cbbc3a02587baad35595351dd0c1c047"
   integrity sha1-EomrIsu8OgJYe6rTVZU1HdDBwEc=
 
-bluebird@3.5.3, bluebird@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
-  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
-
 bluebird@3.5.4:
   version "3.5.4"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.4.tgz#d6cc661595de30d5b3af5fcedd3c0b3ef6ec5714"
@@ -2697,6 +2692,11 @@ bluebird@^3.0.5, bluebird@^3.5.0, bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+
+bluebird@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
+  integrity sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -3470,18 +3470,6 @@ check-types@^7.3.0:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-7.4.0.tgz#0378ec1b9616ec71f774931a3c6516fad8c152f4"
   integrity sha512-YbulWHdfP99UfZ73NcUDlNJhEIDgm9Doq9GhpyXbF+7Aegi3CVV7qqMCKTTqJxlvEvnQBp9IA+dxsGN6xK/nSg==
 
-cheerio@1.0.0-rc.2, cheerio@^1.0.0-rc.2:
-  version "1.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
-  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
-  dependencies:
-    css-select "~1.2.0"
-    dom-serializer "~0.1.0"
-    entities "~1.1.1"
-    htmlparser2 "^3.9.1"
-    lodash "^4.15.0"
-    parse5 "^3.0.1"
-
 cheerio@1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
@@ -3515,6 +3503,18 @@ cheerio@^0.22.0:
     lodash.reduce "^4.4.0"
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
+
+cheerio@^1.0.0-rc.2:
+  version "1.0.0-rc.2"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
+  integrity sha1-S59TqBsn5NXawxwP/Qz6A8xoMNs=
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
 
 chmodr@~1.0.2:
   version "1.0.2"
@@ -3678,10 +3678,10 @@ cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-highlight@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.0.0.tgz#e4ae60d46fd6a88e7d478499309b6618547991f0"
-  integrity sha512-cW9HBA7Z7YETTwncdScUBUUDj8AnBU4rq6qQt6NbSXG2sFLcQ1LHEAGadRWydVtNXnH6StuN4GDCX5yddJDgew==
+cli-highlight@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.0.tgz#1e2e6770b6c3d72c4c7d4e5ea27c496f82ec2c67"
+  integrity sha512-DxaFAFBGRaB+xueXP7jlJC5f867gZUZXz74RaxeZ9juEZM2Sm/s6ilzpz0uxKiT+Mj6TzHlibtXfG/dK5bSwDA==
   dependencies:
     chalk "^2.3.0"
     highlight.js "^9.6.0"
@@ -3899,6 +3899,11 @@ commander@2.19.0, commander@^2.14.1, commander@^2.18.0, commander@^2.19.0, comma
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
+
+commander@2.20.0:
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
+  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
 commander@2.9.0:
   version "2.9.0"
@@ -4327,10 +4332,10 @@ core-js@2.5.1:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
   integrity sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=
 
-core-js@2.6.5, core-js@^2.5.7, core-js@^2.6.5:
-  version "2.6.5"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
-  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
+core-js@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.0.1.tgz#1343182634298f7f38622f95e73f54e48ddf4738"
+  integrity sha512-sco40rF+2KlE0ROMvydjkrVMMG1vYilP2ALoRXcYR4obqbYIuV3Bg+51GEDW+HF8n7NRA+iaA4qD0nD9lo9mew==
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -4346,6 +4351,11 @@ core-js@^2.5.0, core-js@^2.5.3:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
   integrity sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=
+
+core-js@^2.5.7, core-js@^2.6.5:
+  version "2.6.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
+  integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -4573,16 +4583,6 @@ cozy-doctypes@1.33.0:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-doctypes@1.38.6:
-  version "1.38.6"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.38.6.tgz#7f797f25372a1589210d43f6df7f4eefef27b72a"
-  integrity sha512-ZKtq3SmqRtjDJH0y6EHf+4357BQCQoFjvy7/HriZuXL+TAlymY39FQtJ3Hyr/0vMoM9PFbRhwH9Z0JD9Tx4JJw==
-  dependencies:
-    "@babel/runtime" "7.3.1"
-    cozy-logger "1.3.1"
-    es6-promise-pool "2.5.0"
-    lodash "4.17.11"
-
 cozy-doctypes@1.39.0:
   version "1.39.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
@@ -4634,25 +4634,25 @@ cozy-interapp@0.4.5:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.4.5.tgz#115912a389448ebb8dc532972270b46e15010063"
   integrity sha512-CuiZ4PIrDj+jcK1sCizFNCC9r8+/sgKXLtDgkpKHRHk+q0lhvqz/fQAVPWiIsZAr9WdbfxaBfsJCoHP/41+G1Q==
 
-cozy-jobs-cli@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.8.1.tgz#a485f2633e96582175bb257b2827101b2cd7c860"
-  integrity sha512-xEDqoZ3FQ+jvrSed1rljcdTRhcu07gyGrh3NXvdI8qYGEqqSWmK9i0dklMLVkbIBucTjoZKfUDKckSflYXsloQ==
+cozy-jobs-cli@1.8.9:
+  version "1.8.9"
+  resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.8.9.tgz#57b68b72c016ffe4000c7121092aa8183024d1e7"
+  integrity sha512-kF7XLAyB1k7Wf5InIXnovJumA7Fz7h6BHPnNc5dM6YJ0dbKDSd0zLtFr3jbHelTQu8ysPJDt8j9SA9MRrE76EA==
   dependencies:
     btoa "1.2.1"
-    cheerio "1.0.0-rc.2"
-    cli-highlight "2.0.0"
-    commander "2.19.0"
-    core-js "2.6.5"
-    cozy-client-js "0.15.0"
-    cozy-konnector-libs "^4.15.1"
+    cheerio "1.0.0-rc.3"
+    cli-highlight "2.1.0"
+    commander "2.20.0"
+    core-js "3.0.1"
+    cozy-client-js "0.15.1"
+    cozy-konnector-libs "^4.15.8"
     cozy-logger "^1.3.1"
-    opn "5.4.0"
+    opn "6.0.0"
     pretty "2.0.0"
-    regenerator-runtime "0.13.1"
+    regenerator-runtime "0.13.2"
     replay "2.4.0"
 
-cozy-konnector-libs@4.15.8:
+cozy-konnector-libs@4.15.8, cozy-konnector-libs@^4.15.8:
   version "4.15.8"
   resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.15.8.tgz#495a6e0e249ac6912f23ea62626d337be187f75c"
   integrity sha512-6/w+Zvd5I71pvTjKfgeyO0Otng2q1ek8IjyjBWcXjSzY7HsfncBEn9g4sySG8PFz5eUZg9Sz34aLuHsGoKwaNg==
@@ -4674,32 +4674,6 @@ cozy-konnector-libs@4.15.8:
     pdfjs-dist "2.0.943"
     raven "2.6.4"
     raw-body "2.4.0"
-    request "2.88.0"
-    request-debug "0.2.0"
-    request-promise "4.2.4"
-
-cozy-konnector-libs@^4.15.1:
-  version "4.15.1"
-  resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.15.1.tgz#edd0c753d90695102dec584f1e26edfae7618e06"
-  integrity sha512-awK2M5ssMYlXaFVTNb8s/Q76PbMOsD75J6sSZNFto9GQkbMS9mXGnYMHzFRu/xkSUM7ouy4zHyG0NrKkmCsjbg==
-  dependencies:
-    bluebird "3.5.3"
-    bluebird-retry "0.11.0"
-    btoa "1.2.1"
-    cheerio "1.0.0-rc.2"
-    classificator "0.3.3"
-    cozy-client-js "0.15.0"
-    cozy-doctypes "1.38.6"
-    cozy-logger "1.3.1"
-    date-fns "1.30.1"
-    geco "0.11.1"
-    isomorphic-fetch "2.2.1"
-    lodash-id "0.14.0"
-    lowdb "1.0.0"
-    pdfjs "2.1.0"
-    pdfjs-dist "2.0.943"
-    raven "2.6.4"
-    raw-body "2.3.3"
     request "2.88.0"
     request-debug "0.2.0"
     request-promise "4.2.4"
@@ -12870,6 +12844,13 @@ opn@5.4.0:
   dependencies:
     is-wsl "^1.1.0"
 
+opn@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/opn/-/opn-6.0.0.tgz#3c5b0db676d5f97da1233d1ed42d182bc5a27d2d"
+  integrity sha512-I9PKfIZC+e4RXZ/qr1RhgyCnGgYX0UEIlXgWnCOVACIvFgaC9rz6Won7xbdhoHrd8IIhV7YEpHjreNUNkqCGkQ==
+  dependencies:
+    is-wsl "^1.1.0"
+
 opn@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.3.0.tgz#64871565c863875f052cfdf53d3e3cb5adb53b1c"
@@ -15412,10 +15393,10 @@ regenerator-runtime@0.11.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
   integrity sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==
 
-regenerator-runtime@0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.1.tgz#522ea2aafd9200a00eee143dc14219a35a0f3991"
-  integrity sha512-5KzMIyPLvfdPmvsdlYsHqITrDfK9k7bmvf97HvHSN4810i254ponbxCQ1NukpRWlu6en2MBWzAlhDExEKISwAA==
+regenerator-runtime@0.13.2, regenerator-runtime@^0.13.2:
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
+  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-runtime@^0.10.5:
   version "0.10.5"
@@ -15431,11 +15412,6 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
   integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
-
-regenerator-runtime@^0.13.2:
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz#32e59c9a6fb9b1a4aff09b4930ca2d4477343447"
-  integrity sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==
 
 regenerator-transform@^0.13.3:
   version "0.13.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1768,13 +1768,6 @@ abstract-leveldown@^4.0.0, abstract-leveldown@~4.0.0:
   dependencies:
     xtend "~4.0.0"
 
-abstract-leveldown@~2.6.0, abstract-leveldown@~2.6.1:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz#1c5e8c6a5ef965ae8c35dfb3a8770c476b82c4b8"
-  integrity sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==
-  dependencies:
-    xtend "~4.0.0"
-
 abstract-leveldown@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/abstract-leveldown/-/abstract-leveldown-5.0.0.tgz#f7128e1f86ccabf7d2893077ce5d06d798e386c6"
@@ -1839,11 +1832,6 @@ acorn-walk@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.1.tgz#d363b66f5fac5f018ff9c3a1e7b6f8e310cc3913"
   integrity sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==
 
-acorn@^1.0.3:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
-  integrity sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=
-
 acorn@^4.0.3:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
@@ -1878,11 +1866,6 @@ address@1.0.3, address@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/address/-/address-1.0.3.tgz#b5f50631f8d6cec8bd20c963963afb55e06cbce9"
   integrity sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==
-
-after@~0.8.1:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/after/-/after-0.8.2.tgz#fedb394f9f0e02aa9768e702bda23b505fae7e1f"
-  integrity sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=
 
 agent-base@4, agent-base@^4.1.0:
   version "4.2.0"
@@ -2202,14 +2185,6 @@ array-includes@^3.0.3:
     define-properties "^1.1.2"
     es-abstract "^1.7.0"
 
-array-index@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/array-index/-/array-index-1.0.0.tgz#ec56a749ee103e4e08c790b9c353df16055b97f9"
-  integrity sha1-7FanSe4QPk4Ix5C5w1PfFgVbl/k=
-  dependencies:
-    debug "^2.2.0"
-    es6-symbol "^3.0.2"
-
 array-iterate@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/array-iterate/-/array-iterate-1.1.2.tgz#f66a57e84426f8097f4197fbb6c051b8e5cdf7d8"
@@ -2334,16 +2309,6 @@ ast-types@0.11.6:
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.11.6.tgz#4e2266c2658829aef3b40cc33ad599c4e9eb89ef"
   integrity sha512-nHiuV14upVGl7MWwFUYbzJ6YlfwWS084CU9EA8HajfYQjMSli5TQi3UTRygGF58LFWVkXxS1rbgRhROEqlQkXg==
-
-ast-types@0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.8.15.tgz#8eef0827f04dff0ec8857ba925abe3fea6194e52"
-  integrity sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=
-
-ast-types@0.9.6:
-  version "0.9.6"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
-  integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
 
 ast-types@^0.11.6:
   version "0.11.7"
@@ -2599,11 +2564,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base62@^1.1.0:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/base62/-/base62-1.2.8.tgz#1264cb0fb848d875792877479dbe8bae6bae3428"
-  integrity sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==
-
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
@@ -2696,7 +2656,7 @@ bindings@~1.3.0:
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.3.0.tgz#b346f6ecf6a95f5a815c5839fc7cdb22502f1ed7"
   integrity sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==
 
-bl@^1.0.0, bl@~1.2.0:
+bl@^1.0.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
   integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
@@ -3106,28 +3066,10 @@ buble@0.19.4:
     regexpu-core "^4.1.3"
     vlq "^1.0.0"
 
-buffer-alloc-unsafe@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
-  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
-
-buffer-alloc@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
-  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
-  dependencies:
-    buffer-alloc-unsafe "^1.1.0"
-    buffer-fill "^1.0.0"
-
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
-
-buffer-fill@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
-  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
 
 buffer-from@0.1.1:
   version "0.1.1"
@@ -3140,11 +3082,6 @@ buffer-from@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.0.tgz#87fcaa3a298358e0ade6e442cfce840740d1ad04"
   integrity sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==
-
-buffer-from@^0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-0.1.2.tgz#15f4b9bcef012044df31142c14333caf6e0260d0"
-  integrity sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==
 
 buffer-from@^1.0.0:
   version "1.0.0"
@@ -3207,6 +3144,11 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
+bytes@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
+  integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
 
 cacache@^10.0.4:
   version "10.0.4"
@@ -3535,6 +3477,18 @@ cheerio@1.0.0-rc.2, cheerio@^1.0.0-rc.2:
   dependencies:
     css-select "~1.2.0"
     dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash "^4.15.0"
+    parse5 "^3.0.1"
+
+cheerio@1.0.0-rc.3:
+  version "1.0.0-rc.3"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.1"
     entities "~1.1.1"
     htmlparser2 "^3.9.1"
     lodash "^4.15.0"
@@ -3941,7 +3895,7 @@ commander@2.17.x, commander@^2.15.1, commander@^2.16.0, commander@^2.8.1, comman
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@2.19.0, commander@^2.14.1, commander@^2.18.0, commander@^2.19.0, commander@^2.5.0, commander@~2.19.0:
+commander@2.19.0, commander@^2.14.1, commander@^2.18.0, commander@^2.19.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -3986,21 +3940,6 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-
-commoner@^0.10.1:
-  version "0.10.8"
-  resolved "https://registry.yarnpkg.com/commoner/-/commoner-0.10.8.tgz#34fc3672cd24393e8bb47e70caa0293811f4f2c5"
-  integrity sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=
-  dependencies:
-    commander "^2.5.0"
-    detective "^4.3.1"
-    glob "^5.0.15"
-    graceful-fs "^4.1.2"
-    iconv-lite "^0.4.5"
-    mkdirp "^0.5.0"
-    private "^0.1.6"
-    q "^1.1.2"
-    recast "^0.11.17"
 
 compare-func@^1.3.1:
   version "1.3.2"
@@ -4535,15 +4474,15 @@ cozy-client-js@0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client-js@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.9.0.tgz#ef81ac66a2858427e23da3c214f1a169e9972a8c"
-  integrity sha1-74GsZqKFhCfiPaPCFPGhaemXKow=
+cozy-client-js@0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/cozy-client-js/-/cozy-client-js-0.15.1.tgz#187e83021a730291f6fdc6ac287c712f9bb56e3f"
+  integrity sha512-8qa6WeKkuYKQ04gaR8R4HJ/dKeeMNO389QrhJlh4TJnRDkqA4qM7vlCNwIjNQ9bRsy86CqtD/IAvU62QglF03Q==
   dependencies:
     core-js "^2.5.3"
-    pouchdb "6.1.1"
-    pouchdb-adapter-cordova-sqlite "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
-    pouchdb-find "0.10.4"
+    isomorphic-fetch "^2.2.1"
+    pouchdb-browser "7.0.0"
+    pouchdb-find "7.0.0"
 
 cozy-client-js@^0.3.4:
   version "0.3.21"
@@ -4703,28 +4642,28 @@ cozy-jobs-cli@1.8.1:
     regenerator-runtime "0.13.1"
     replay "2.4.0"
 
-cozy-konnector-libs@4.14.13:
-  version "4.14.13"
-  resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.14.13.tgz#0fe6e6623a821b863ce981a0e80dcc0519419256"
-  integrity sha512-3EtfwfIPhbU/KBou0W6w+SUpYkL/lILKcZZYHEg3UZIYHNuXklVWxsjRD96OoRAYQkCeVp2y+wVIe/hJUMEEWA==
+cozy-konnector-libs@4.15.8:
+  version "4.15.8"
+  resolved "https://registry.yarnpkg.com/cozy-konnector-libs/-/cozy-konnector-libs-4.15.8.tgz#495a6e0e249ac6912f23ea62626d337be187f75c"
+  integrity sha512-6/w+Zvd5I71pvTjKfgeyO0Otng2q1ek8IjyjBWcXjSzY7HsfncBEn9g4sySG8PFz5eUZg9Sz34aLuHsGoKwaNg==
   dependencies:
-    bluebird "3.5.3"
+    bluebird "3.5.4"
     bluebird-retry "0.11.0"
-    btoa "1.2.1"
-    cheerio "1.0.0-rc.2"
+    cheerio "1.0.0-rc.3"
     classificator "0.3.3"
-    cozy-client-js "0.9.0"
-    cozy-doctypes "1.38.6"
+    cozy-client-js "0.15.1"
+    cozy-doctypes "1.39.0"
     cozy-logger "1.3.1"
     date-fns "1.30.1"
+    file-type "10.11.0"
     geco "0.11.1"
-    isomorphic-fetch "2.2.1"
     lodash-id "0.14.0"
     lowdb "1.0.0"
+    mime-types "2.1.24"
     pdfjs "2.1.0"
     pdfjs-dist "2.0.943"
     raven "2.6.4"
-    raw-body "2.3.3"
+    raw-body "2.4.0"
     request "2.88.0"
     request-debug "0.2.0"
     request-promise "4.2.4"
@@ -5337,13 +5276,6 @@ d3@5.9.2:
     d3-voronoi "1"
     d3-zoom "1"
 
-d@1:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
-  integrity sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=
-  dependencies:
-    es5-ext "^0.10.9"
-
 dargs@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-4.1.0.tgz#03a9dbb4b5c2f139bf14ae53f0b8a2a6a86f4e17"
@@ -5403,14 +5335,7 @@ debug@*, debug@3.1.0, debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
-  integrity sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=
-  dependencies:
-    ms "0.7.2"
-
-debug@2.6.9, debug@^2.1.0, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6:
+debug@2.6.9, debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.6:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -5564,13 +5489,6 @@ defaults@^1.0.3:
   integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
   dependencies:
     clone "^1.0.2"
-
-deferred-leveldown@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz#3acd2e0b75d1669924bc0a4b642851131173e1eb"
-  integrity sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==
-  dependencies:
-    abstract-leveldown "~2.6.0"
 
 deferred-leveldown@~3.0.0:
   version "3.0.0"
@@ -5812,7 +5730,7 @@ detective-typescript@^5.1.0:
     typescript "^3.2.1"
     typescript-estree "^18.1.0"
 
-detective@^4.0.0, detective@^4.3.1:
+detective@^4.0.0:
   version "4.7.1"
   resolved "https://registry.yarnpkg.com/detective/-/detective-4.7.1.tgz#0eca7314338442febb6d65da54c10bb1c82b246e"
   integrity sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==
@@ -5925,6 +5843,14 @@ dom-serializer@0, dom-serializer@~0.1.0:
   dependencies:
     domelementtype "~1.1.1"
     entities "~1.1.1"
+
+dom-serializer@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.1.tgz#1ec4059e284babed36eec2941d4a970a189ce7c0"
+  integrity sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==
+  dependencies:
+    domelementtype "^1.3.0"
+    entities "^1.1.1"
 
 dom-walk@^0.1.0:
   version "0.1.1"
@@ -6040,13 +5966,6 @@ duplexer2@^0.1.2, duplexer2@~0.1.0, duplexer2@~0.1.2:
   integrity sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=
   dependencies:
     readable-stream "^2.0.2"
-
-duplexer2@~0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.0.2.tgz#c614dcf67e2fb14995a91711e5a617e8a60a31db"
-  integrity sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=
-  dependencies:
-    readable-stream "~1.1.9"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -6360,37 +6279,10 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es3ify@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/es3ify/-/es3ify-0.2.2.tgz#5dae3e650e5be3684b88066513d528d092629862"
-  integrity sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=
-  dependencies:
-    esprima "^2.7.1"
-    jstransform "~11.0.0"
-    through "~2.3.4"
-
-es5-ext@^0.10.35, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.49"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.49.tgz#059a239de862c94494fec28f8150c977028c6c5e"
-  integrity sha512-3NMEhi57E31qdzmYp2jwRArIUsj1HI/RxbQ4bgnSB+AIKIxsAmTiK83bYMifIcpWvEc3P1X30DhUKOqEtF/kvg==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.1"
-    next-tick "^1.0.0"
-
 es6-denodeify@^0.1.1:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/es6-denodeify/-/es6-denodeify-0.1.5.tgz#31d4d5fe9c5503e125460439310e16a2a3f39c1f"
   integrity sha1-MdTV/pxVA+ElRgQ5MQ4WoqPznB8=
-
-es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
 
 es6-object-assign@~1.1.0:
   version "1.1.0"
@@ -6413,14 +6305,6 @@ es6-promisify@^5.0.0:
   integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
   dependencies:
     es6-promise "^4.0.3"
-
-es6-symbol@^3.0.2, es6-symbol@^3.1.1, es6-symbol@~3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.1.tgz#bf00ef4fdab6ba1b46ecb7b629b4c7ed5715cc77"
-  integrity sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=
-  dependencies:
-    d "1"
-    es5-ext "~0.10.14"
 
 escape-html@~1.0.3:
   version "1.0.3"
@@ -6590,11 +6474,6 @@ eslint@5.15.1:
     table "^5.2.3"
     text-table "^0.2.0"
 
-esmangle-evaluator@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz#620d866ef4861b3311f75766d52a8572bb3c6336"
-  integrity sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY=
-
 espree@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-4.1.0.tgz#728d5451e0fd156c04384a7ad89ed51ff54eb25f"
@@ -6613,22 +6492,12 @@ espree@^5.0.1:
     acorn-jsx "^5.0.0"
     eslint-visitor-keys "^1.0.0"
 
-esprima-fb@^15001.1.0-dev-harmony-fb:
-  version "15001.1.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz#30a947303c6b8d5e955bee2b99b1d233206a6901"
-  integrity sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=
-
-esprima-fb@~15001.1001.0-dev-harmony-fb:
-  version "15001.1001.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz#43beb57ec26e8cf237d3dd8b33e42533577f2659"
-  integrity sha1-Q761fsJujPI3092LM+QlM1d/Jlk=
-
-esprima@^2.1.0, esprima@^2.7.1:
+esprima@^2.1.0:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
   integrity sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=
 
-esprima@^3.1.3, esprima@~3.1.0:
+esprima@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
   integrity sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=
@@ -6761,13 +6630,6 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-execspawn@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/execspawn/-/execspawn-1.0.1.tgz#8286f9dde7cecde7905fbdc04e24f368f23f8da6"
-  integrity sha1-gob53efOzeeQX73ATiTzaPI/jaY=
-  dependencies:
-    util-extend "^1.0.1"
-
 exenv@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
@@ -6810,7 +6672,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expand-template@^1.0.0, expand-template@^1.0.2:
+expand-template@^1.0.2:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/expand-template/-/expand-template-1.1.1.tgz#981f188c0c3a87d2e28f559bc541426ff94f21dd"
   integrity sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==
@@ -6981,16 +6843,6 @@ eyes@0.1.x:
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
 
-falafel@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/falafel/-/falafel-1.2.0.tgz#c18d24ef5091174a497f318cd24b026a25cddab4"
-  integrity sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=
-  dependencies:
-    acorn "^1.0.3"
-    foreach "^2.0.5"
-    isarray "0.0.1"
-    object-keys "^1.0.6"
-
 falafel@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.1.0.tgz#96bb17761daba94f46d001738b3cedf3a67fe06c"
@@ -7026,7 +6878,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
   integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
-fast-future@~1.0.0, fast-future@~1.0.2:
+fast-future@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/fast-future/-/fast-future-1.0.2.tgz#8435a9aaa02d79248d17d704e76259301d99280a"
   integrity sha1-hDWpqqAteSSNF9cE52JZMB2ZKAo=
@@ -7162,6 +7014,11 @@ file-loader@3.0.1:
   dependencies:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
+
+file-type@10.11.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.11.0.tgz#2961d09e4675b9fb9a3ee6b69e9cd23f43fd1890"
+  integrity sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==
 
 file-uri-to-path@1.0.0:
   version "1.0.0"
@@ -7449,11 +7306,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
-
 fs-extra@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
@@ -7700,33 +7552,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-ghreleases@^1.0.2:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/ghreleases/-/ghreleases-1.0.7.tgz#78214443d91ac3c651a4a7687a63da8651efa379"
-  integrity sha512-1lFGyLLF38Q6cFCDyebN5vzQ2P9DEaAgxPIDLmQwQDVDmUe2Wgv+6dhAIoHeA+My4HLpaJ+dKF73xtuykN2cbQ==
-  dependencies:
-    after "~0.8.1"
-    ghrepos "~2.1.0"
-    ghutils "~3.2.0"
-    simple-mime "~0.1.0"
-    url-template "~2.0.6"
-    xtend "~4.0.0"
-
-ghrepos@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/ghrepos/-/ghrepos-2.1.0.tgz#abaf558b690b722c70c7ad45076f6f9be8e495e1"
-  integrity sha512-6GM0ohSDTAv7xD6GsKfxJiV/CajoofRyUwu0E8l29d1o6lFAUxmmyMP/FH33afA20ZrXzxxcTtN6TsYvudMoAg==
-  dependencies:
-    ghutils "~3.2.0"
-
-ghutils@~3.2.0:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/ghutils/-/ghutils-3.2.6.tgz#d43986e267da02787464d97a6489659e4609bb1f"
-  integrity sha512-WpYHgLQkqU7Cv147wKUEThyj6qKHCdnAG2CL9RRsRQImVdLGdVqblJ3JUnj3ToQwgm1ALPS+FXgR0448AgGPUg==
-  dependencies:
-    jsonist "~2.1.0"
-    xtend "~4.0.1"
-
 git-directory-deploy@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/git-directory-deploy/-/git-directory-deploy-1.5.1.tgz#c4fad8c270d678d5f309fbddeac1eda60cad7fd2"
@@ -7796,18 +7621,6 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-"glob@3 || 4 || 5 || 6 || 7", glob@7.1.3, glob@^7.1.3:
-  version "7.1.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
-  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 glob@7.0.4:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.0.4.tgz#3b44afa0943bdc31b2037b934791e2e084bcb7f6"
@@ -7844,7 +7657,19 @@ glob@7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^5.0.13, glob@^5.0.15:
+glob@7.1.3, glob@^7.1.3:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
+  integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^5.0.13:
   version "5.0.15"
   resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
   integrity sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=
@@ -8482,6 +8307,17 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
 
+http-errors@1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.2.tgz#4f5029cf13239f31036e5b2e55292bcfbcc85c8f"
+  integrity sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.1"
+    statuses ">= 1.5.0 < 2"
+    toidentifier "1.0.0"
+
 http-parser-js@>=0.4.0:
   version "0.4.11"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.11.tgz#5b720849c650903c27e521633d94696ee95f3529"
@@ -8591,15 +8427,6 @@ husky@1.3.1:
     run-node "^1.0.0"
     slash "^2.0.0"
 
-hyperquest@~2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/hyperquest/-/hyperquest-2.1.3.tgz#523127d7a343181b40bf324e231d2576edf52633"
-  integrity sha512-fUuDOrB47PqNK/BAMOS13v41UoaqIxqSLHX6CAbOD7OfT+/GCWO1/vPLfTNutOeXrv1ikuaZ3yux+33Z9vh+rw==
-  dependencies:
-    buffer-from "^0.1.1"
-    duplexer2 "~0.0.2"
-    through2 "~0.6.3"
-
 hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -8622,7 +8449,7 @@ iconv-lite@0.4.19:
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
   integrity sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==
 
-iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@^0.4.5:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -8846,14 +8673,6 @@ init-package-json@~1.9.4:
     validate-npm-package-license "^3.0.1"
     validate-npm-package-name "^3.0.0"
 
-inline-process-browser@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/inline-process-browser/-/inline-process-browser-1.0.0.tgz#46a61b153dd3c9b1624b1a00626edb4f7f414f22"
-  integrity sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=
-  dependencies:
-    falafel "^1.0.1"
-    through2 "^0.6.5"
-
 inline-source-map@~0.6.0:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/inline-source-map/-/inline-source-map-0.6.2.tgz#f9393471c18a79d1724f863fa38b586370ade2a5"
@@ -9068,11 +8887,6 @@ is-array-buffer-x@^1.0.13:
     is-object-like-x "^1.5.1"
     object-get-own-property-descriptor-x "^3.2.0"
     to-string-tag-x "^1.4.1"
-
-is-array@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-array/-/is-array-1.0.1.tgz#e9850cc2cc860c3bc0977e84ccf0dd464584279a"
-  integrity sha1-6YUMwsyGDDvAl36EzPDdRkWEJ5o=
 
 is-arrayish@^0.2.1:
   version "0.2.1"
@@ -10219,16 +10033,6 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonist@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/jsonist/-/jsonist-2.1.0.tgz#4477a4d16cd377faec58d8cf870b7e392f6d7fe9"
-  integrity sha1-RHek0WzTd/rsWNjPhwt+OS9tf+k=
-  dependencies:
-    bl "~1.2.0"
-    hyperquest "~2.1.2"
-    json-stringify-safe "~5.0.1"
-    xtend "~4.0.1"
-
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -10322,17 +10126,6 @@ jss@^9.8.7:
     is-in-browser "^1.1.3"
     symbol-observable "^1.1.0"
     warning "^3.0.0"
-
-jstransform@~11.0.0:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/jstransform/-/jstransform-11.0.3.tgz#09a78993e0ae4d4ef4487f6155a91f6190cb4223"
-  integrity sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=
-  dependencies:
-    base62 "^1.1.0"
-    commoner "^0.10.1"
-    esprima-fb "^15001.1.0-dev-harmony-fb"
-    object-assign "^2.0.0"
-    source-map "^0.4.2"
 
 jsx-ast-utils@^2.0.1:
   version "2.0.1"
@@ -10465,11 +10258,6 @@ lerna-changelog@0.8.2:
     string.prototype.padend "^3.0.0"
     yargs "^11.0.0"
 
-level-codec@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-6.2.0.tgz#a4b5244bb6a4c2f723d68a1d64e980c53627d9d4"
-  integrity sha1-pLUkS7akwvcj1oodZOmAxTYn2dQ=
-
 level-codec@7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-7.0.1.tgz#341f22f907ce0f16763f24bddd681e395a0fb8a7"
@@ -10480,22 +10268,10 @@ level-codec@^8.0.0:
   resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-8.0.0.tgz#3a4a0de06dae20c2f5a57b3372c7651e67083e03"
   integrity sha512-gNZlo1HRHz0BWxzGCyNf7xntAs2HKOPvvRBWtXsoDvEX4vMYnSTBS6ZnxoaiX7nhxSBPpegRa8CQ/hnfGBKk3Q==
 
-level-codec@~6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/level-codec/-/level-codec-6.1.0.tgz#f5df0a99582f76dac43855151ab6f4e4d0d60045"
-  integrity sha1-9d8KmVgvdtrEOFUVGrb05NDWAEU=
-
-level-errors@^1.0.3, level-errors@^1.0.4, level-errors@~1.1.0:
+level-errors@^1.0.4, level-errors@~1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-1.1.2.tgz#4399c2f3d3ab87d0625f7e3676e2d807deff404d"
   integrity sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==
-  dependencies:
-    errno "~0.1.1"
-
-level-errors@~1.0.3:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/level-errors/-/level-errors-1.0.5.tgz#83dbfb12f0b8a2516bdc9a31c4876038e227b859"
-  integrity sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==
   dependencies:
     errno "~0.1.1"
 
@@ -10505,16 +10281,6 @@ level-errors@~2.0.0:
   integrity sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==
   dependencies:
     errno "~0.1.1"
-
-level-iterator-stream@~1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz#e43b78b1a8143e6fa97a4f485eb8ea530352f2ed"
-  integrity sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=
-  dependencies:
-    inherits "^2.0.1"
-    level-errors "^1.0.3"
-    readable-stream "^1.0.33"
-    xtend "^4.0.0"
 
 level-iterator-stream@~2.0.0:
   version "2.0.1"
@@ -10549,17 +10315,6 @@ level@3.0.2:
     leveldown "^3.0.0"
     opencollective-postinstall "^2.0.0"
 
-leveldown@1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-1.5.0.tgz#6b8d3cbea7a4a89aa47444607d7358213e6fcb81"
-  integrity sha1-a408vqekqJqkdERgfXNYIT5vy4E=
-  dependencies:
-    abstract-leveldown "~2.6.1"
-    bindings "~1.2.1"
-    fast-future "~1.0.0"
-    nan "~2.4.0"
-    prebuild "^4.1.1"
-
 leveldown@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/leveldown/-/leveldown-3.0.0.tgz#a42ef5d4029f88ba538ed8da3e6c34c5b008ddd7"
@@ -10581,19 +10336,6 @@ leveldown@^3.0.0:
     fast-future "~1.0.2"
     nan "~2.10.0"
     prebuild-install "^4.0.0"
-
-levelup@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/levelup/-/levelup-1.3.3.tgz#bf9db62bdb6188d08eaaa2efcf6cc311916f41fd"
-  integrity sha1-v522K9thiNCOqqLvz2zDEZFvQf0=
-  dependencies:
-    deferred-leveldown "~1.2.1"
-    level-codec "~6.1.0"
-    level-errors "~1.0.3"
-    level-iterator-stream "~1.3.0"
-    prr "~1.0.1"
-    semver "~5.1.0"
-    xtend "~4.0.0"
 
 levelup@3.0.1:
   version "3.0.1"
@@ -10651,23 +10393,6 @@ libxslt@0.7.0:
     bindings "~1.2.1"
     libxmljs-mt "0.18.0"
     nan "^2.1.0"
-
-lie@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.0.4.tgz#bc7ae1ebe7f1c8de39afdcd4f789076b47b0f634"
-  integrity sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=
-  dependencies:
-    es3ify "^0.2.2"
-    immediate "~3.0.5"
-    inline-process-browser "^1.0.0"
-    unreachable-branch-transform "^0.3.0"
-
-lie@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.0.tgz#65e0139eaef9ae791a1f5c8c53692c8d3b4718f4"
-  integrity sha1-ZeATnq75rnkaH1yMU2ksjTtHGPQ=
-  dependencies:
-    immediate "~3.0.5"
 
 lie@3.1.1:
   version "3.1.1"
@@ -11222,11 +10947,6 @@ lru-cache@~4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-ltgt@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.1.2.tgz#e7472324fee690afc0d5ecf900403ce5788a311d"
-  integrity sha1-50cjJP7mkK/A1ez5AEA85XiKMR0=
-
 ltgt@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ltgt/-/ltgt-2.2.1.tgz#f35ca91c493f7b73da0e07495304f17b31f87ee5"
@@ -11696,7 +11416,7 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-"minimatch@2 || 3", minimatch@3, minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.3:
+"minimatch@2 || 3", minimatch@3.0.4, minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -11721,7 +11441,7 @@ minimist@1.1.x:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
   integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
@@ -12172,11 +11892,6 @@ move-concurrently@^1.0.1:
     rimraf "^2.5.4"
     run-queue "^1.0.3"
 
-ms@0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
-  integrity sha1-riXPJRKziFodldfwN4aNhDESR2U=
-
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -12238,11 +11953,6 @@ nan@^2.9.2:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.1.tgz#a15bee3790bde247e8f38f1d446edcdaeb05f2dd"
   integrity sha512-I6YB/YEuDeUZMmhscXKxGgZlFnhsn5y0hgOZBadkzfTRrZBtJDZeg6eQf7PYMIEclwmorTKK8GztsyOUSVBREA==
-
-nan@~2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.4.0.tgz#fb3c59d45fe4effe215f0b890f8adf6eb32d2232"
-  integrity sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=
 
 nan@~2.8.0:
   version "2.8.0"
@@ -12318,11 +12028,6 @@ nested-error-stacks@^1.0.0:
   dependencies:
     inherits "~2.0.1"
 
-next-tick@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
-
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
@@ -12391,24 +12096,6 @@ node-fs@^0.1.7:
   resolved "https://registry.yarnpkg.com/node-fs/-/node-fs-0.1.7.tgz#32323cccb46c9fbf0fc11812d45021cc31d325bb"
   integrity sha1-MjI8zLRsn78PwRgS1FAhzDHTJbs=
 
-node-gyp@^3.0.3:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
-  integrity sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==
-  dependencies:
-    fstream "^1.0.0"
-    glob "^7.0.3"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2 || 3 || 4"
-    osenv "0"
-    request "^2.87.0"
-    rimraf "2"
-    semver "~5.3.0"
-    tar "^2.0.0"
-    which "1"
-
 node-gyp@~3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.6.2.tgz#9bfbe54562286284838e750eac05295853fa1c60"
@@ -12466,26 +12153,6 @@ node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
-
-node-ninja@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/node-ninja/-/node-ninja-1.0.2.tgz#20a09e57b92e2df591993d4bf098ac3e727062b6"
-  integrity sha1-IKCeV7kuLfWRmT1L8JisPnJwYrY=
-  dependencies:
-    fstream "^1.0.0"
-    glob "3 || 4 || 5 || 6 || 7"
-    graceful-fs "^4.1.2"
-    minimatch "3"
-    mkdirp "^0.5.0"
-    nopt "2 || 3"
-    npmlog "0 || 1 || 2"
-    osenv "0"
-    path-array "^1.0.0"
-    request "2"
-    rimraf "2"
-    semver "2.x || 3.x || 4 || 5"
-    tar "^2.0.0"
-    which "1"
 
 node-notifier@^5.2.1:
   version "5.2.1"
@@ -12581,7 +12248,7 @@ nomnom@~1.6.2:
     colors "0.5.x"
     underscore "~1.4.4"
 
-noop-logger@^0.1.0, noop-logger@^0.1.1:
+noop-logger@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/noop-logger/-/noop-logger-0.1.1.tgz#94a2b1633c4f1317553007d8966fd0e841b6a4c2"
   integrity sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=
@@ -12882,15 +12549,6 @@ npm@^2.10.x:
     wrappy "~1.0.2"
     write-file-atomic "~1.1.4"
 
-"npmlog@0 || 1 || 2", "npmlog@0.1 || 1 || 2", npmlog@^2.0.0, npmlog@~2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
-  integrity sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=
-  dependencies:
-    ansi "~0.3.1"
-    are-we-there-yet "~1.1.2"
-    gauge "~1.2.5"
-
 "npmlog@0 || 1 || 2 || 3 || 4", npmlog@^4.0.1, npmlog@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
@@ -12900,6 +12558,15 @@ npm@^2.10.x:
     console-control-strings "~1.1.0"
     gauge "~2.7.3"
     set-blocking "~2.0.0"
+
+"npmlog@0.1 || 1 || 2", npmlog@~2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-2.0.4.tgz#98b52530f2514ca90d09ec5b22c8846722375692"
+  integrity sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=
+  dependencies:
+    ansi "~0.3.1"
+    are-we-there-yet "~1.1.2"
+    gauge "~1.2.5"
 
 "npmlog@~2.0.0 || ~3.1.0":
   version "3.1.2"
@@ -12962,11 +12629,6 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
-object-assign@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
-  integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
 
 object-assign@^3.0.0:
   version "3.0.0"
@@ -13565,13 +13227,6 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
-path-array@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-array/-/path-array-1.0.1.tgz#7e2f0f35f07a2015122b868b7eac0eb2c4fec271"
-  integrity sha1-fi8PNfB6IBUSK4aLfqwOssT+wnE=
-  dependencies:
-    array-index "^1.0.0"
-
 path-browserify@0.0.0, path-browserify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-0.0.0.tgz#a0b870729aae214005b7d5032ec2cbbb0fb4451a"
@@ -14127,12 +13782,6 @@ pouchdb-adapter-cordova-sqlite@2.0.5:
   dependencies:
     pouchdb-adapter-websql-core "^6.4.3"
 
-"pouchdb-adapter-cordova-sqlite@https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a":
-  version "2.0.2"
-  resolved "https://github.com/SnceGroup/pouchdb-adapter-cordova-sqlite.git#f3ee23009b70209c611435d57491aa77fb88802a"
-  dependencies:
-    pouchdb-adapter-websql-core "^6.1.1"
-
 pouchdb-adapter-utils@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-6.4.3.tgz#384bb1bcd37dc7d473016eb450cec53d665bcae4"
@@ -14146,7 +13795,7 @@ pouchdb-adapter-utils@6.4.3:
     pouchdb-promise "6.4.3"
     pouchdb-utils "6.4.3"
 
-pouchdb-adapter-websql-core@^6.1.1, pouchdb-adapter-websql-core@^6.4.3:
+pouchdb-adapter-websql-core@^6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-websql-core/-/pouchdb-adapter-websql-core-6.4.3.tgz#8f992a46ca8a6870440d0c8699cfaa7ac1c382c4"
   integrity sha512-AmmHVksmx6w9mv/YYETx9ZWjzqco4TNSHujfsozUFxUu8OPLHYPkZjiTZhxMvnEB0LAJJZL2Iswp+9avVyuG1Q==
@@ -14190,11 +13839,6 @@ pouchdb-collate@7.0.0:
   resolved "https://registry.yarnpkg.com/pouchdb-collate/-/pouchdb-collate-7.0.0.tgz#4f9a0a03c236f1677a971c400b79b7baf6379a4d"
   integrity sha512-0O67rnNGVD9OUbDx+6DLPcE3zz7w6gieNCvrbvaI5ibIXuLpyMyLjD6OdRe/19LbstEfZaOp+SYUhQs+TP8Plg==
 
-pouchdb-collate@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-collate/-/pouchdb-collate-1.2.0.tgz#cae3b830fca124b7f97d23046e4faa311ec3828c"
-  integrity sha1-yuO4MPyhJLf5fSMEbk+qMR7Dgow=
-
 pouchdb-collections@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-collections/-/pouchdb-collections-6.4.3.tgz#2b70ca3143134c361dba6e466518b4f4d8e92ff4"
@@ -14219,11 +13863,6 @@ pouchdb-errors@7.0.0:
   dependencies:
     inherits "2.0.3"
 
-pouchdb-extend@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/pouchdb-extend/-/pouchdb-extend-0.1.2.tgz#d1ce511bf704ed2e29f7bf428a416acfffa124b8"
-  integrity sha1-0c5RG/cE7S4p979CikFqz/+hJLg=
-
 pouchdb-fetch@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pouchdb-fetch/-/pouchdb-fetch-7.0.0.tgz#6b56cc49863837f8d5e38b0956ace03f1fcaf8e0"
@@ -14231,21 +13870,6 @@ pouchdb-fetch@7.0.0:
   dependencies:
     fetch-cookie "0.7.0"
     node-fetch "^2.0.0"
-
-pouchdb-find@0.10.4:
-  version "0.10.4"
-  resolved "https://registry.yarnpkg.com/pouchdb-find/-/pouchdb-find-0.10.4.tgz#c8601200b695ea1ddc796761c675eed32984acc8"
-  integrity sha1-yGASALaV6h3ceWdhxnXu0ymErMg=
-  dependencies:
-    argsarray "0.0.1"
-    debug "^2.1.0"
-    inherits "^2.0.1"
-    is-array "^1.0.1"
-    pouchdb-collate "^1.2.0"
-    pouchdb-extend "^0.1.2"
-    pouchdb-promise "5.4.0"
-    pouchdb-upsert "~2.0.1"
-    spark-md5 "0.0.5"
 
 pouchdb-find@7.0.0:
   version "7.0.0"
@@ -14298,26 +13922,12 @@ pouchdb-merge@6.4.3:
   resolved "https://registry.yarnpkg.com/pouchdb-merge/-/pouchdb-merge-6.4.3.tgz#4ef901f4aaa27be6aec0108998a127fe55bb0628"
   integrity sha512-UuSpex/V1kNr1aXcmg+TQlOdjzMWc08AX/Ja6jrPq9J42M97UFF+7Ijx3JllxDK0j6QJZrvhpvjFzsRhFC4+zw==
 
-pouchdb-promise@5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/pouchdb-promise/-/pouchdb-promise-5.4.0.tgz#e277ac6bda1ac8504597abb5c43a7c3a9e56866f"
-  integrity sha1-4nesa9oayFBFl6u1xDp8Op5Whm8=
-  dependencies:
-    lie "3.0.4"
-
 pouchdb-promise@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-promise/-/pouchdb-promise-6.4.3.tgz#74516f4acf74957b54debd0fb2c0e5b5a68ca7b3"
   integrity sha512-ruJaSFXwzsxRHQfwNHjQfsj58LBOY1RzGzde4PM5CWINZwFjCQAhZwfMrch2o/0oZT6d+Xtt0HTWhq35p3b0qw==
   dependencies:
     lie "3.1.1"
-
-pouchdb-promise@^5.4.3:
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/pouchdb-promise/-/pouchdb-promise-5.4.5.tgz#5c2a69759141eb73be1e172e522fd84da2e0752e"
-  integrity sha1-XCppdZFB63O+HhcuUi/YTaLgdS4=
-  dependencies:
-    lie "3.0.4"
 
 pouchdb-selector-core@7.0.0:
   version "7.0.0"
@@ -14326,13 +13936,6 @@ pouchdb-selector-core@7.0.0:
   dependencies:
     pouchdb-collate "7.0.0"
     pouchdb-utils "7.0.0"
-
-pouchdb-upsert@~2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/pouchdb-upsert/-/pouchdb-upsert-2.0.2.tgz#c746cc9945e52d8c78e42f63ade0666777996712"
-  integrity sha1-x0bMmUXlLYx45C9jreBmZ3eZZxI=
-  dependencies:
-    pouchdb-promise "^5.4.3"
 
 pouchdb-utils@6.4.3:
   version "6.4.3"
@@ -14361,31 +13964,6 @@ pouchdb-utils@7.0.0:
     pouchdb-errors "7.0.0"
     pouchdb-md5 "7.0.0"
     uuid "3.2.1"
-
-pouchdb@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/pouchdb/-/pouchdb-6.1.1.tgz#cb477cc5e3f8fa36aafdcf9223fb77c7ffe5069a"
-  integrity sha1-y0d8xeP4+jaq/c+SI/t3x//lBpo=
-  dependencies:
-    argsarray "0.0.1"
-    buffer-from "0.1.1"
-    clone-buffer "1.0.0"
-    debug "2.6.0"
-    double-ended-queue "2.1.0-0"
-    immediate "3.0.6"
-    inherits "2.0.3"
-    level-codec "6.2.0"
-    level-write-stream "1.0.0"
-    leveldown "1.5.0"
-    levelup "1.3.3"
-    lie "3.1.0"
-    ltgt "2.1.2"
-    readable-stream "1.0.33"
-    request "2.79.0"
-    scope-eval "0.0.3"
-    spark-md5 "3.0.0"
-    through2 "2.0.1"
-    vuvuzela "1.0.3"
 
 pouchdb@7.0.0:
   version "7.0.0"
@@ -14458,30 +14036,6 @@ prebuild-install@^4.0.0:
     tar-fs "^1.13.0"
     tunnel-agent "^0.6.0"
     which-pm-runs "^1.0.0"
-
-prebuild@^4.1.1:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/prebuild/-/prebuild-4.5.0.tgz#2aaa0df2063bff814a803bd4dc94ff9b64e5df00"
-  integrity sha1-KqoN8gY7/4FKgDvU3JT/m2Tl3wA=
-  dependencies:
-    async "^1.4.0"
-    execspawn "^1.0.1"
-    expand-template "^1.0.0"
-    ghreleases "^1.0.2"
-    github-from-package "0.0.0"
-    minimist "^1.1.2"
-    mkdirp "^0.5.1"
-    node-gyp "^3.0.3"
-    node-ninja "^1.0.1"
-    noop-logger "^0.1.0"
-    npmlog "^2.0.0"
-    os-homedir "^1.0.1"
-    pump "^1.0.0"
-    rc "^1.0.3"
-    simple-get "^1.4.2"
-    tar-fs "^1.7.0"
-    tar-stream "^1.2.1"
-    xtend "^4.0.1"
 
 precinct@^6.1.1:
   version "6.1.1"
@@ -14822,7 +14376,7 @@ q@1.4.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.4.1.tgz#55705bcd93c5f3673530c2c2cbc0c2b3addc286e"
   integrity sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=
 
-q@^1.0.1, q@^1.1.2, q@^1.4.1, q@^1.5.1:
+q@^1.0.1, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
@@ -15008,6 +14562,16 @@ raw-body@2.3.3:
     iconv-lite "0.4.23"
     unpipe "1.0.0"
 
+raw-body@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.0.tgz#a1ce6fb9c9bc356ca52e89256ab59059e13d0332"
+  integrity sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
 raw-loader@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-1.0.0.tgz#3f9889e73dadbda9a424bce79809b4133ad46405"
@@ -15026,7 +14590,7 @@ rc@^1.0.1, rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-rc@^1.0.3, rc@^1.1.6, rc@^1.2.7:
+rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -15594,7 +15158,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
   dependencies:
     mute-stream "~0.0.4"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -15607,7 +15171,7 @@ read@1, read@1.0.x, read@~1.0.1, read@~1.0.7:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@1.0, "readable-stream@>=1.0.33-1 <1.1.0-0":
+readable-stream@1.0:
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
@@ -15621,16 +15185,6 @@ readable-stream@1.0.33:
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.33.tgz#3a360dd66c1b1d7fd4705389860eda1d0f61126c"
   integrity sha1-OjYN1mwbHX/UcFOJhg7aHQ9hEmw=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
-
-readable-stream@^1.0.33, readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.1"
@@ -15737,26 +15291,6 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
-
-recast@^0.10.1:
-  version "0.10.43"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.10.43.tgz#b95d50f6d60761a5f6252e15d80678168491ce7f"
-  integrity sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=
-  dependencies:
-    ast-types "0.8.15"
-    esprima-fb "~15001.1001.0-dev-harmony-fb"
-    private "~0.1.5"
-    source-map "~0.5.0"
-
-recast@^0.11.17:
-  version "0.11.23"
-  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
-  integrity sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=
-  dependencies:
-    ast-types "0.9.6"
-    esprima "~3.1.0"
-    private "~0.1.5"
-    source-map "~0.5.0"
 
 recast@^0.13.0:
   version "0.13.2"
@@ -16618,11 +16152,6 @@ schema-utils@^1.0.0:
     ajv-errors "^1.0.0"
     ajv-keywords "^3.1.0"
 
-scope-eval@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/scope-eval/-/scope-eval-0.0.3.tgz#166f2ccd1f3754429dec511805501f9d6923b5ec"
-  integrity sha1-Fm8szR83VEKd7FEYBVAfnWkjtew=
-
 section-iterator@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/section-iterator/-/section-iterator-2.0.0.tgz#bf444d7afeeb94ad43c39ad2fb26151627ccba2a"
@@ -16779,6 +16308,11 @@ setprototypeof@1.1.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
   integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
+setprototypeof@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
+  integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
+
 sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
@@ -16897,15 +16431,6 @@ simple-concat@^1.0.0:
   resolved "https://registry.yarnpkg.com/simple-concat/-/simple-concat-1.0.0.tgz#7344cbb8b6e26fb27d66b2fc86f9f6d5997521c6"
   integrity sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=
 
-simple-get@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-1.4.3.tgz#e9755eda407e96da40c5e5158c9ea37b33becbeb"
-  integrity sha1-6XVe2kB+ltpAxeUVjJ6jezO+y+s=
-  dependencies:
-    once "^1.3.1"
-    unzip-response "^1.0.0"
-    xtend "^4.0.0"
-
 simple-get@^2.7.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/simple-get/-/simple-get-2.8.1.tgz#0e22e91d4575d87620620bc91308d57a77f44b5d"
@@ -16921,11 +16446,6 @@ simple-git@^1.85.0:
   integrity sha512-t4OK1JRlp4ayKRfcW6owrWcRVLyHRUlhGd0uN6ZZTqfDq8a5XpcUdOKiGRNobHEuMtNqzp0vcJNvhYWwh5PsQA==
   dependencies:
     debug "^4.0.1"
-
-simple-mime@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/simple-mime/-/simple-mime-0.1.0.tgz#95f517c4f466d7cff561a71fc9dab2596ea9ef2e"
-  integrity sha1-lfUXxPRm18/1YacfydqyWW6p7y4=
 
 simple-plist@^0.2.1:
   version "0.2.1"
@@ -17141,12 +16661,12 @@ source-map@0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.3:
+source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.4.2, source-map@^0.4.4:
+source-map@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
   integrity sha1-66T12pwNyZneaAMti092FzZSA2s=
@@ -17157,11 +16677,6 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
-
-spark-md5@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-0.0.5.tgz#931da5e3b951d06527e9b7d90dfff578b6fcdc8e"
-  integrity sha1-kx2l47lR0GUn6bfZDf/1eLb83I4=
 
 spark-md5@3.0.0:
   version "3.0.0"
@@ -17322,7 +16837,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2":
+"statuses@>= 1.3.1 < 2", "statuses@>= 1.4.0 < 2", "statuses@>= 1.5.0 < 2":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
@@ -17771,7 +17286,7 @@ tapable@^1.1.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.0.tgz#0d076a172e3d9ba088fd2272b2668fb8d194b78c"
   integrity sha512-IlqtmLVaZA2qab8epUXbVWRn3aB1imbDMJtjB3nu4X0NqPkcY/JH9ZtCBWKHWPxs8Svi9tyo8w2dBoi07qZbBA==
 
-tar-fs@^1.13.0, tar-fs@^1.7.0:
+tar-fs@^1.13.0:
   version "1.16.3"
   resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
   integrity sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==
@@ -17803,19 +17318,6 @@ tar-stream@^1.1.2:
     bl "^1.0.0"
     end-of-stream "^1.0.0"
     readable-stream "^2.0.0"
-    xtend "^4.0.0"
-
-tar-stream@^1.2.1:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
-  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
-  dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.2.0"
-    end-of-stream "^1.0.0"
-    fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.1"
     xtend "^4.0.0"
 
 tar@2.2.1, tar@^2.0.0, tar@^2.2.1, tar@~2.2.1:
@@ -17907,14 +17409,6 @@ throat@^4.0.0:
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
   integrity sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=
 
-through2@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.1.tgz#384e75314d49f32de12eebb8136b8eb6b5d59da9"
-  integrity sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=
-  dependencies:
-    readable-stream "~2.0.0"
-    xtend "~4.0.0"
-
 through2@2.0.3, through2@^2.0.0, through2@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -17923,15 +17417,7 @@ through2@2.0.3, through2@^2.0.0, through2@^2.0.2:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through2@^0.6.2, through2@^0.6.5, through2@~0.6.3:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
-  integrity sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=
-  dependencies:
-    readable-stream ">=1.0.33-1 <1.1.0-0"
-    xtend ">=4.0.0 <4.1.0-0"
-
-"through@>=2.2.7 <3", through@^2.3.6, through@^2.3.7, through@~2.3.4:
+"through@>=2.2.7 <3", through@^2.3.6, through@^2.3.7:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -18014,11 +17500,6 @@ to-boolean-x@^1.0.1, to-boolean-x@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-boolean-x/-/to-boolean-x-1.0.3.tgz#cbe15e38a85d09553f29869a9b3e3b54ceef5af0"
   integrity sha512-kQiMyJUgFprL8J+0CfgJuaSFKJMs3EvFe27/6aj/hVzVZT0HY4aA1QjPldLNxzBmjhLcapp7CctYHuD8QqtS3g==
-
-to-buffer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
-  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -18126,6 +17607,11 @@ to-string-x@^1.4.2, to-string-x@^1.4.5:
   dependencies:
     cached-constructors-x "^1.0.0"
     is-symbol "^1.0.1"
+
+toidentifier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
+  integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
 toni@>=0.6.2:
   version "0.6.2"
@@ -18561,15 +18047,6 @@ unquote@^1.1.0:
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=
 
-unreachable-branch-transform@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz#d99cc4c6e746d264928845b611db54b0f3474caa"
-  integrity sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=
-  dependencies:
-    esmangle-evaluator "^1.0.0"
-    recast "^0.10.1"
-    through2 "^0.6.2"
-
 unset-value@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
@@ -18577,11 +18054,6 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
-
-unzip-response@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
-  integrity sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=
 
 upath@^1.0.0:
   version "1.0.4"
@@ -18670,11 +18142,6 @@ url-slug@2.0.0:
   integrity sha1-p4nVrtSZXA2VrzM3etHVxo1NcCc=
   dependencies:
     unidecode "0.1.8"
-
-url-template@~2.0.6:
-  version "2.0.8"
-  resolved "https://registry.yarnpkg.com/url-template/-/url-template-2.0.8.tgz#fc565a3cccbff7730c775f5641f9555791439f21"
-  integrity sha1-/FZaPMy/93MMd19WQflVV5FDnyE=
 
 url@^0.11.0, url@~0.11.0:
   version "0.11.0"
@@ -19462,7 +18929,7 @@ xregexp@4.0.0:
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.0.0.tgz#e698189de49dd2a18cc5687b05e17c8e43943020"
   integrity sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg==
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=

--- a/yarn.lock
+++ b/yarn.lock
@@ -4583,6 +4583,16 @@ cozy-doctypes@1.38.6:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
+cozy-doctypes@1.39.0:
+  version "1.39.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.39.0.tgz#edbd8b7575d858ce5305c0e7c6d14cf6c44b6d83"
+  integrity sha512-k/GgUs1K120hAtCdBRSE50L+wDHWn/HDErGNvzqXCSpQKicMrjVvFpD6EHie4thc5oNPzHn0RqWuT4gBFcfY9Q==
+  dependencies:
+    "@babel/runtime" "7.3.1"
+    cozy-logger "1.3.1"
+    es6-promise-pool "2.5.0"
+    lodash "4.17.11"
+
 cozy-doctypes@1.44.0:
   version "1.44.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.44.0.tgz#7ad05afb8f4ab807a6fe53ed97b1fd13aac9ee61"


### PR DESCRIPTION
This PR introduces the categorization service. This service is able to categorize new transactions.

To avoid race conditions between this service and `onOperationOrBillCreate` service that needs the result of the categorization to do its job, `onOperationOrBillCreate` is not triggered by the `io.cozy.bank.operations:CREATED` event anymore, but it's called programmatically by the categorization service when it has finished its work.