### PR TITLE
docs: Move email docs to the right place

### DIFF
--- a/docs/dev.md
+++ b/docs/dev.md
@@ -18,15 +18,14 @@
     - [Push iOS build](#push-ios-build)
   - [Android](#android)
 - [Notifications](#notifications)
-  - [Developing the templates](#developing-the-templates)
+  - [How to develop on templates](#how-to-develop-on-templates)
+    - [Under the covers](#under-the-covers)
+    - [Assets](#assets)
   - [Debug notification triggers](#debug-notification-triggers)
   - [When creating a notification](#when-creating-a-notification)
   - [Misc](#misc)
 - [Pouch On Web](#pouch-on-web)
 - [Fixtures](#fixtures)
-- [How to develop on templates](#how-to-develop-on-templates)
-  - [Under the covers](#under-the-covers)
-  - [Assets](#assets)
 
 <!-- /MarkdownTOC -->
 
@@ -191,9 +190,37 @@ This will upload create a new version in the store, in the `beta` track that you
 
 ## Notifications
 
-### Developing the templates
+### How to develop on templates
 
-Check the following [README](../src/ducks/notifications/html)
+With the `TEST_TEMPLATES` environment variable, an express server serving the HTML emails will be built.
+
+```
+$ env TEST_TEMPLATES=true yarn watch:services
+$ node build/testTemplates.js
+Rendering emails at http://localhost:8081!
+```
+
+You can open your browser to check the emails. The Preview feature
+in Mailchimp is also useful to check that everything is correctly rendered on the various email clients (just copy/paste the content of the page).
+
+#### Under the covers
+
+The templates are [Handlebars](handlebarsjs.com) templates using the
+[mjml](https://mjml.io/documentation) language. `mjml` greatly reduces the pains to develop an
+email template as it deals with a lot of quirks for you. It features ready-made
+components to make responsive email templates. Behind the scene, it uses `React`
+to implement custom components, and [juice](https://github.com/Automattic/juice)
+to inline the CSS into the HTML. The [handlebars-layouts](https://github.com/shannonmoeller/handlebars-layouts) plugin is used to provide an easy way to extend a base template (à la `jinja`)
+
+Other templates :
+
+```
+nodemon --exec "node transactions-notification.js" -e js,css,hbs,json
+```
+
+#### Assets
+
+Assets in `assets/` are uploaded to `https://downcloud.cozycloud.cc` on every deployment on CI. It can also be done manually with the `yarn uploadStaticFiles` script.
 
 ### Debug notification triggers
 
@@ -293,35 +320,3 @@ All fixtures are located in [`test/fixtures`](/test/fixtures).
 
 [pass]: https://www.passwordstore.org/
 [ACH]: https://github.com/cozy/ACH
-
-## How to develop on templates
-
-With the `TEST_TEMPLATES` environment variable, an express server serving the HTML emails will be built.
-
-```
-$ env TEST_TEMPLATES=true yarn watch:services
-$ node build/testTemplates.js
-Rendering emails at http://localhost:8081!
-```
-
-You can open your browser to check the emails. The Preview feature
-in Mailchimp is also useful to check that everything is correctly rendered on the various email clients (just copy/paste the content of the page).
-
-### Under the covers
-
-The templates are [Handlebars](handlebarsjs.com) templates using the
-[mjml](https://mjml.io/documentation) language. `mjml` greatly reduces the pains to develop an
-email template as it deals with a lot of quirks for you. It features ready-made
-components to make responsive email templates. Behind the scene, it uses `React`
-to implement custom components, and [juice](https://github.com/Automattic/juice)
-to inline the CSS into the HTML. The [handlebars-layouts](https://github.com/shannonmoeller/handlebars-layouts) plugin is used to provide an easy way to extend a base template (à la `jinja`)
-
-Other templates :
-
-```
-nodemon --exec "node transactions-notification.js" -e js,css,hbs,json
-```
-
-### Assets
-
-Assets in `assets/` are uploaded to `https://downcloud.cozycloud.cc` on every deployment on CI. It can also be done manually with the `yarn uploadStaticFiles` script.


### PR DESCRIPTION
I had put the docs to the bottom of the template without seeing that there was already a section linking to a dead doc. Fixed :)