### PR TITLE
feat(notifications): Make support link customizable

### DIFF
--- a/src/ducks/notifications/html/templates/cozy-layout.hbs
+++ b/src/ducks/notifications/html/templates/cozy-layout.hbs
@@ -100,7 +100,7 @@
               {{tGlobal 'settings'}}
             </a>
             {{#block 'supportLink'}}
-              <a css-class="footer__help" href="https://support.cozy.io/">
+              <a css-class="footer__help" href="{{#block 'supportUrl'}}https://support.cozy.io/{{/block}}">
                 {{tGlobal 'support'}}
               </a>
             {{/block}}


### PR DESCRIPTION
Put the support URL in a block, so we can easily override it.