### PR TITLE
feat: Realtime fallback

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -206,7 +206,7 @@ class Balance extends PureComponent {
   async handleRealtime() {
     const { client } = this.props
     if (__TARGET__ === 'mobile') {
-      await syncPouchImmediately(client)
+      syncPouchImmediately(client)
     }
     // TODO discriminate on the ev received to only fetch what is important
     this.updateQueries()

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -71,6 +71,7 @@ class Balance extends PureComponent {
     }).bind(this)
 
     this.handleResume = this.handleResume.bind(this)
+    this.updateQueries = this.updateQueries.bind(this)
     this.handleRealtime = debounce(this.handleRealtime.bind(this), 1000, {
       leading: false,
       trailing: true
@@ -242,6 +243,7 @@ class Balance extends PureComponent {
 
   componentWillUnmount() {
     this.stopRealtime()
+    this.stopRealtimeFallback()
     this.stopResumeListeners()
   }
 
@@ -274,11 +276,39 @@ class Balance extends PureComponent {
 
     if (accounts.length > 0) {
       this.stopRealtime()
+      this.stopRealtimeFallback()
       this.stopResumeListeners()
     } else {
       this.startRealtime()
+      this.startRealtimeFallback()
       this.startResumeListeners()
     }
+  }
+
+  /**
+   * Starts setInterval loop, as a fallback in case realtime does not work.
+   * If already started, does nothing.
+   */
+  startRealtimeFallback() {
+    if (this.realtimeFallbackInterval) {
+      return
+    }
+    this.realtimeFallbackInterval = setInterval(
+      this.updateQueries,
+      30 * 1000
+    )
+  }
+
+  /**
+   * Stops  the realtime fallback loop, and clears the setIntervalId
+   * If not started, does nothing.
+   */
+  stopRealtimeFallback() {
+    if (!this.realtimeFallbackInterval) {
+      return
+    }
+    clearInterval(this.realtimeFallbackInterval)
+    this.realtimeFallbackInterval = null
   }
 
   render() {

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -209,15 +209,17 @@ class Balance extends PureComponent {
       await syncPouchImmediately(client)
     }
     // TODO discriminate on the ev received to only fetch what is important
+    this.updateQueries()
+  }
+
+  updateQueries() {
     this.props.accounts.fetch()
     this.props.transactions.fetch()
     this.props.triggers.fetch()
   }
 
   handleResume() {
-    this.props.accounts.fetch()
-    this.props.transactions.fetch()
-    this.props.triggers.fetch()
+    this.updateQueries()
   }
 
   startResumeListeners() {

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -4,6 +4,7 @@ import getClient from 'test/client'
 const React = require('react')
 const { DumbBalance } = require('./Balance')
 const debounce = require('lodash/debounce')
+import fixtures from 'test/fixtures'
 
 jest.mock('lodash/debounce', () => jest.fn(fn => fn))
 
@@ -16,7 +17,7 @@ const fakeCollection = (doctype, data) => ({
 describe('Balance page', () => {
   let root, instance, saveDocumentMock, router, filterByAccounts
 
-  const setup = () => {
+  const setup = ({ accountsData } = {}) => {
     saveDocumentMock = jest.fn()
     filterByAccounts = jest.fn()
     router = {
@@ -25,7 +26,7 @@ describe('Balance page', () => {
     const settingDoc = {}
     root = shallow(
       <DumbBalance
-        accounts={fakeCollection('io.cozy.bank.accounts')}
+        accounts={fakeCollection('io.cozy.bank.accounts', accountsData || [])}
         groups={fakeCollection('io.cozy.bank.groups')}
         settings={fakeCollection('io.cozy.bank.settings', [settingDoc])}
         triggers={fakeCollection('io.cozy.triggers')}
@@ -39,6 +40,10 @@ describe('Balance page', () => {
     instance = root.instance()
   }
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   it('should call filterByAccounts prop with getCheckAccounts', () => {
     setup()
     let accounts = []
@@ -50,9 +55,51 @@ describe('Balance page', () => {
     expect(filterByAccounts).toHaveBeenCalledWith(accounts)
   })
 
+  describe('data fetching', () => {
+    it('should start periodic data fetch if no accounts', () => {
+      setup()
+      jest.spyOn(instance, 'startRealtimeFallback')
+      jest.spyOn(instance, 'stopRealtimeFallback')
+      instance.ensureListenersProperlyConfigured()
+      expect(instance.startRealtimeFallback).toHaveBeenCalled()
+      expect(instance.startRealtimeFallback).toHaveBeenCalled()
+    })
+    it('should stop periodic data fetch if there are accounts', () => {
+      const accounts = fixtures['io.cozy.bank.accounts']
+      setup({ accountsData: accounts })
+      jest.spyOn(instance, 'startRealtimeFallback')
+      jest.spyOn(instance, 'stopRealtimeFallback')
+      instance.ensureListenersProperlyConfigured()
+      expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
+      expect(instance.stopRealtimeFallback).toHaveBeenCalled()
+    })
+
+    it('should correctly start realtime fallback', () => {
+      setup()
+      jest.spyOn(global, 'setInterval').mockReset().mockImplementation(() => 1337)
+      instance.startRealtimeFallback()
+      expect(global.setInterval).toHaveBeenCalledWith(instance.updateQueries, 30000)
+      expect(global.setInterval).toHaveBeenCalledTimes(1)
+      instance.startRealtimeFallback()
+      expect(global.setInterval).toHaveBeenCalledTimes(1)
+    })
+
+    it('should correctly stop realtime fallback', () => {
+      setup()
+      jest.spyOn(global, 'setInterval').mockReset().mockImplementation(() => 1337)
+      jest.spyOn(global, 'clearInterval').mockReset().mockImplementation(() => {})
+      instance.startRealtimeFallback()
+      instance.stopRealtimeFallback()
+      expect(global.clearInterval).toHaveBeenCalledWith(1337)
+      expect(instance.realtimeFallbackInterval).toBe(null)
+      instance.stopRealtimeFallback()
+      expect(global.clearInterval).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe('panel toggling', () => {
     it('should debounce handlePanelChange', () => {
-      setup()
+      setup({ accountsData: [{ balance: 12345 }] })
       expect(debounce).toHaveBeenCalledWith(instance.handlePanelChange, 3000, {
         leading: false,
         trailing: true

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -16,7 +16,7 @@ const fakeCollection = (doctype, data) => ({
 describe('Balance page', () => {
   let root, instance, saveDocumentMock, router, filterByAccounts
 
-  beforeEach(() => {
+  const setup = () => {
     saveDocumentMock = jest.fn()
     filterByAccounts = jest.fn()
     router = {
@@ -37,10 +37,10 @@ describe('Balance page', () => {
       />
     )
     instance = root.instance()
-  })
+  }
 
   it('should call filterByAccounts prop with getCheckAccounts', () => {
-    const instance = root.instance()
+    setup()
     let accounts = []
     instance.getCheckedAccounts = () => {
       return accounts
@@ -52,6 +52,7 @@ describe('Balance page', () => {
 
   describe('panel toggling', () => {
     it('should debounce handlePanelChange', () => {
+      setup()
       expect(debounce).toHaveBeenCalledWith(instance.handlePanelChange, 3000, {
         leading: false,
         trailing: true
@@ -59,6 +60,7 @@ describe('Balance page', () => {
     })
 
     it('should call savePanelState when handling panel change', () => {
+      setup()
       instance.setState = (fn, callback) => callback.apply(instance)
       jest.spyOn(instance, 'savePanelState')
       instance.handlePanelChange()
@@ -68,6 +70,7 @@ describe('Balance page', () => {
     })
 
     it('should call saveDocument when saving panel state', () => {
+      setup()
       instance.savePanelState()
       expect(saveDocumentMock).toHaveBeenCalled()
     })


### PR DESCRIPTION
It seems that on some Android device, the realtime does not work correctly. As a fallback, a simple setInterval loop is used to fetch data periodically.