### PR TITLE
chore: Add Darty maintenance in brandDict

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -91,6 +91,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "darty",
+    "maintenance": true,
     "name": "Darty",
     "regexp": "\\\\bdarty\\\\b",
   },
@@ -522,6 +523,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "darty",
+    "maintenance": true,
     "name": "Darty",
     "regexp": "\\\\bdarty\\\\b",
   },

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -74,7 +74,8 @@
   {
     "name": "Darty",
     "regexp": "\\bdarty\\b",
-    "konnectorSlug": "darty"
+    "konnectorSlug": "darty",
+    "maintenance": true
   },
   {
     "name": "Deezer",


### PR DESCRIPTION
Add the flag maintenance: true in brand dictionnary for darty.
Can be merge as soon as you are ok with the commit.

Thank's