### PR TITLE
Refactor apps suggestions

### DIFF
--- a/src/ducks/appSuggestions/AppSuggestion.js
+++ b/src/ducks/appSuggestions/AppSuggestion.js
@@ -1,21 +1,6 @@
 import { Document } from 'cozy-doctypes'
 import { head } from 'lodash'
 import { TRANSACTION_DOCTYPE } from 'doctypes'
-import get from 'lodash/get'
-import setWith from 'lodash/setWith'
-import clone from 'lodash/clone'
-
-/* Set a value inside an object, by path, immutably */
-const setIn = (obj, path, value) => {
-  return setWith(clone(obj), path, value, clone)
-}
-
-/* Push value into nested array, immutably */
-const pushAtPath = (obj, path, value) => {
-  const arr = get(obj, path, [])
-  arr.push(value)
-  return setIn(obj, path, arr)
-}
 
 class AppSuggestion extends Document {
   static fetchBySlug(slug) {
@@ -27,11 +12,11 @@ class AppSuggestion extends Document {
       _id: transaction._id,
       _type: TRANSACTION_DOCTYPE
     }
-    return pushAtPath(
-      suggestion,
-      'relationships.transactions.data',
-      transactionRelationship
-    )
+
+    suggestion.relationships.transactions.data = [
+      transactionRelationship,
+      ...suggestion.relationships.transactions.data
+    ]
   }
 
   static init(slug, reasonCode) {

--- a/src/ducks/appSuggestions/AppSuggestion.js
+++ b/src/ducks/appSuggestions/AppSuggestion.js
@@ -13,9 +13,11 @@ class AppSuggestion extends Document {
       _type: TRANSACTION_DOCTYPE
     }
 
+    // We slice 9 existing transactions because we want to store only 10 items
+    // in the transactions relationship
     suggestion.relationships.transactions.data = [
       transactionRelationship,
-      ...suggestion.relationships.transactions.data
+      ...suggestion.relationships.transactions.data.slice(0, 9)
     ]
   }
 

--- a/src/ducks/appSuggestions/__snapshots__/services.spec.js.snap
+++ b/src/ducks/appSuggestions/__snapshots__/services.spec.js.snap
@@ -29,11 +29,11 @@ Object {
     "transactions": Object {
       "data": Array [
         Object {
-          "_id": "o2",
+          "_id": "o1",
           "_type": "io.cozy.bank.operations",
         },
         Object {
-          "_id": "o1",
+          "_id": "o2",
           "_type": "io.cozy.bank.operations",
         },
       ],

--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -9,7 +9,7 @@ import { groupBy, flatMap } from 'lodash'
 
 const log = logger.namespace('app-suggestions')
 
-export const findSuggestionForTransaction = async (
+export const findSuggestionForTransaction = (
   transaction,
   brands,
   existingSuggestions
@@ -94,10 +94,8 @@ export const findAppSuggestions = async setting => {
   log('info', `${brands.length} not installed brands`)
 
   log('info', 'Find suggestions')
-  const suggestionsFound = await Promise.all(
-    transactionsToCheck.documents.map(t =>
-      findSuggestionForTransaction(t, brands, suggestions)
-    )
+  const suggestionsFound = transactionsToCheck.documents.map(t =>
+    findSuggestionForTransaction(t, brands, suggestions)
   )
 
   const normalizedSuggestions = normalizeSuggestions(suggestionsFound)

--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -17,6 +17,7 @@ export const findSuggestionForTransaction = (
   const matchingBrand = findMatchingBrand(brands, getLabel(transaction))
 
   if (!matchingBrand) {
+    log('info', `No matching brand found for transaction ${transaction._id}`)
     return null
   }
 
@@ -99,6 +100,8 @@ export const findAppSuggestions = async setting => {
   )
 
   const normalizedSuggestions = normalizeSuggestions(suggestionsFound)
+
+  log('info', `Found ${normalizedSuggestions.length} suggestions`)
 
   log('info', 'Save suggestions')
   for (const suggestion of normalizedSuggestions) {

--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -16,10 +16,10 @@ export const findSuggestionForTransaction = async (transaction, brands) => {
     return null
   }
 
-  let originalSuggestion
+  let suggestion
 
   try {
-    originalSuggestion = await AppSuggestion.fetchBySlug(
+    suggestion = await AppSuggestion.fetchBySlug(
       matchingBrand.konnectorSlug
     )
   } catch (e) {
@@ -27,23 +27,20 @@ export const findSuggestionForTransaction = async (transaction, brands) => {
     log('info', e)
   }
 
-  if (!originalSuggestion) {
+  if (!suggestion) {
     log(
       'info',
       `No existing suggestion for ${
         matchingBrand.konnectorSlug
       }. Creating a new one`
     )
-    originalSuggestion = AppSuggestion.init(
+    suggestion = AppSuggestion.init(
       matchingBrand.konnectorSlug,
       'FOUND_TRANSACTION'
     )
   }
 
-  const suggestion = AppSuggestion.linkTransaction(
-    originalSuggestion,
-    transaction
-  )
+  AppSuggestion.linkTransaction(suggestion, transaction)
 
   return suggestion
 }

--- a/src/ducks/appSuggestions/services.spec.js
+++ b/src/ducks/appSuggestions/services.spec.js
@@ -1,5 +1,4 @@
 import { findSuggestionForTransaction, normalizeSuggestions } from './services'
-import AppSuggestion from './AppSuggestion'
 import { TRANSACTION_DOCTYPE } from '../../doctypes'
 import { getBrands } from '../brandDictionary'
 
@@ -8,28 +7,37 @@ describe('findSuggestionForTransaction', () => {
   const transaction = { _id: 'o1', label: 'boulanger' }
 
   it('should return a fresh io.cozy.apps.suggestions document', async () => {
-    jest.spyOn(AppSuggestion, 'fetchBySlug').mockResolvedValueOnce(null)
-
-    const suggestion = await findSuggestionForTransaction(transaction, brands)
+    const suggestions = []
+    const suggestion = await findSuggestionForTransaction(
+      transaction,
+      brands,
+      suggestions
+    )
 
     expect(suggestion).toMatchSnapshot()
   })
 
   it('should update an existing io.cozy.apps.suggestions document', async () => {
-    jest.spyOn(AppSuggestion, 'fetchBySlug').mockResolvedValueOnce({
-      slug: 'boulanger',
-      silenced: false,
-      reason: {
-        code: 'FOUND_TRANSACTION'
-      },
-      relationships: {
-        transactions: {
-          data: [{ _id: 'o2', _type: TRANSACTION_DOCTYPE }]
+    const suggestions = [
+      {
+        slug: 'boulanger',
+        silenced: false,
+        reason: {
+          code: 'FOUND_TRANSACTION'
+        },
+        relationships: {
+          transactions: {
+            data: [{ _id: 'o2', _type: TRANSACTION_DOCTYPE }]
+          }
         }
       }
-    })
+    ]
 
-    const suggestion = await findSuggestionForTransaction(transaction, brands)
+    const suggestion = await findSuggestionForTransaction(
+      transaction,
+      brands,
+      suggestions
+    )
 
     expect(suggestion).toMatchSnapshot()
   })


### PR DESCRIPTION
The apps suggestions were crashing when there was a certain amount of transactions to analyze. There was two problems:

* A request to the DB was made for each transaction to find a potential corresponding app suggestion : now we fetch all existing suggestions in a single request
* The number of transactions listed in the relationships of a `io.cozy.apps.suggestions` document was not constrained, so it could grow very quickly. Writing big documents was  causing errors. We now save only the last 10 linked transactions