### PR TITLE
Automatic reimbursement status on health expenses

### DIFF
--- a/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
+++ b/src/ducks/transactions/actions/HealthExpenseStatusAction.jsx
@@ -5,6 +5,7 @@ import ButtonAction from 'cozy-ui/react/ButtonAction'
 import Menu, { MenuItem } from 'cozy-ui/react/Menu'
 import Badge from 'cozy-ui/react/Badge'
 import palette from 'cozy-ui/react/palette'
+import flag from 'cozy-flags'
 import { isHealthExpense } from 'ducks/categories/helpers'
 import { BillComponent } from './BillAction'
 import styles from 'ducks/transactions/TransactionActions.styl'
@@ -168,7 +169,11 @@ const action = {
     return <Icon icon="hourglass" color={color} />
   },
   match: transaction => {
-    return isHealthExpense(transaction) && getVendors(transaction)
+    return (
+      isHealthExpense(transaction) &&
+      getVendors(transaction) &&
+      !flag('reimbursement-tag')
+    )
   },
   Component: compose(
     withBreakpoints(),

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -123,8 +123,21 @@ export const isNew = transaction => {
   return parseInt(transaction._rev.split('-').shift(), 10) <= 2
 }
 
-export const getReimbursementStatus = transaction =>
-  transaction.reimbursementStatus || 'no-reimbursement'
+export const getReimbursementStatus = transaction => {
+  if (isHealthExpense(transaction)) {
+    return getHealthExpenseReimbursementStatus(transaction)
+  }
+
+  return transaction.reimbursementStatus || 'no-reimbursement'
+}
+
+export const getHealthExpenseReimbursementStatus = transaction => {
+  if (transaction.reimbursementStatus) {
+    return transaction.reimbursementStatus
+  }
+
+  return isFullyReimbursed(transaction) ? 'reimbursed' : 'pending'
+}
 
 export const isReimbursementLate = transaction => {
   if (!isHealthExpense(transaction)) {

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -139,14 +139,52 @@ describe('isExpense', () => {
 })
 
 describe('getReimbursementStatus', () => {
-  it("should return the reimbursement status if it's defined", () => {
-    const transaction = { reimbursementStatus: 'reimbursed' }
-    expect(getReimbursementStatus(transaction)).toBe('reimbursed')
+  describe('General case', () => {
+    it("should return the reimbursement status if it's defined", () => {
+      const transaction = { reimbursementStatus: 'reimbursed' }
+      expect(getReimbursementStatus(transaction)).toBe('reimbursed')
+    })
+
+    it("should return no-reimbursement status if it's undefined", () => {
+      const transaction = {}
+      expect(getReimbursementStatus(transaction)).toBe('no-reimbursement')
+    })
   })
 
-  it("should return no-reimbursement status if it's undefined", () => {
-    const transaction = {}
-    expect(getReimbursementStatus(transaction)).toBe('no-reimbursement')
+  describe('Health expense case', () => {
+    it('should return `pending` if the status is undefined and the transaction is not fully reimbursed', () => {
+      const t1 = {
+        manualCategoryId: '400610',
+        amount: -10
+      }
+
+      const t2 = {
+        manualCategoryId: '400610',
+        amount: -10,
+        reimbursements: {
+          target: {
+            reimbursements: [{ amount: 5 }]
+          }
+        }
+      }
+
+      expect(getReimbursementStatus(t1)).toBe('pending')
+      expect(getReimbursementStatus(t2)).toBe('pending')
+    })
+
+    it('should return `reimbursed` if the status is undefined and the transaction is fully reimbursed', () => {
+      const transaction = {
+        manualCategoryId: '400610',
+        amount: -10,
+        reimbursements: {
+          target: {
+            reimbursements: [{ amount: 10 }]
+          }
+        }
+      }
+
+      expect(getReimbursementStatus(transaction)).toBe('reimbursed')
+    })
   })
 })
 


### PR DESCRIPTION
For health expenses, we want the reimbursement status to be controlled by the reimbursements we matched for a given transaction.

Here is the rule :

* If the user manually placed a reimbursement status, just show it
* If the user didn't manually placed a reimbursement status, check the reimbursements
  * If the transaction is fully reimbursed, then show "reimbursed"
  * If the transaction is not fully reimbursed, then show "pending"

This way, if we matched some reimbursements, we can show a status reflecting this, but the user can still manually override the status we infered.

By doing this on the client side, we avoid too many refactors and data duplication between the `reimbursementStatus` and the `reimbursements` array.