### PR TITLE
fix: Add index to key otherwise account row can have same key

### DIFF
--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -44,6 +44,7 @@ class AccountsList extends React.PureComponent {
       <ol className={styles.AccountsList}>
         {sortBy(accounts.filter(Boolean), getAccountBalance).map((a, i) =>
           a.loading ? (
+            // When loading, a._id is the slug of the connector and can be non-unique, this is why we concat the index
             <AccountRowLoading key={i + '_' + a._id} institutionSlug={a._id} />
           ) : (
             <AccountRow

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -42,9 +42,9 @@ class AccountsList extends React.PureComponent {
 
     return (
       <ol className={styles.AccountsList}>
-        {sortBy(accounts.filter(Boolean), getAccountBalance).map(a =>
+        {sortBy(accounts.filter(Boolean), getAccountBalance).map((a, i) =>
           a.loading ? (
-            <AccountRowLoading key={a._id} institutionSlug={a._id} />
+            <AccountRowLoading key={i + '_' + a._id} institutionSlug={a._id} />
           ) : (
             <AccountRow
               key={a._id}


### PR DESCRIPTION
When importing accounts, the key is based on the slug of the konnector
of the trigger. Since there can be two (or more) triggers on the same
slug, I added the index to the key.