### PR TITLE
fix: Ability for KonnectorIcon to be like AppIcon

### DIFF
--- a/src/ducks/balance/components/KonnectorIcon.jsx
+++ b/src/ducks/balance/components/KonnectorIcon.jsx
@@ -10,10 +10,10 @@ class KonnectorIcon extends React.PureComponent {
   }
 
   fetchIcon() {
-    const { client, slug } = this.props
+    const { client, slug, app } = this.props
     return client.stackClient.getIconURL({
       type: 'konnector',
-      slug: slug
+      slug: slug || app.slug
     })
   }
 


### PR DESCRIPTION
KonnectorIcon can use the app prop to get the slug. This way it behaves
more like an AppIcon and becomes interchangeable.