### PR TITLE
fix: Emails tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,9 +224,9 @@
     "moduleNameMapper": {
       "\\.(png|gif|jpe?g|svg)$": "<rootDir>/test/__mocks__/fileMock.js",
       "styl$": "identity-obj-proxy",
-      "css$": "identity-obj-proxy",
       "webapp$": "identity-obj-proxy",
-      "!!raw-loader!(.*)": "$1"
+      "!!raw-loader!(.*)": "$1",
+      "css$": "identity-obj-proxy"
     },
     "testPathIgnorePatterns": [
       "node_modules",


### PR DESCRIPTION
The style.css required in the emails passed into identity-obj-proxy instead of being served raw.