### PR TITLE
Use Chip for all CTAs on transaction row

### DIFF
--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -58,7 +58,14 @@ export const SyncTransactionActions = ({
   compact,
   className
 }) => (
-  <span className={cx('u-dib', className)}>
+  <span
+    className={cx(
+      {
+        'u-dib': !isModalItem
+      },
+      className
+    )}
+  >
     {(displayDefaultAction || onlyDefault) && actions.default && (
       <MenuAction
         action={actions.default}

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -204,17 +204,15 @@ class _RowMobile extends React.PureComponent {
           )}
         </Media>
         {flag('reimbursement-tag') && (
-          <div style={{ flexBasis: '100%', flexShrink: '0', flexGrow: '1' }}>
-            <TransactionActions
-              transaction={transaction}
-              urls={urls}
-              brands={brands}
-              onlyDefault
-              compact
-              menuPosition="right"
-              className="u-mt-half u-ml-2-half"
-            />
-          </div>
+          <TransactionActions
+            transaction={transaction}
+            urls={urls}
+            brands={brands}
+            onlyDefault
+            compact
+            menuPosition="right"
+            className="u-mt-half u-ml-2-half"
+          />
         )}
       </List.Row>
     )

--- a/src/ducks/transactions/actions/AppLinkAction.jsx
+++ b/src/ducks/transactions/actions/AppLinkAction.jsx
@@ -2,6 +2,9 @@ import React from 'react'
 import { capitalize, findKey, omit } from 'lodash'
 import { translate } from 'cozy-ui/react'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
+import Chip from 'cozy-ui/react/Chip'
+import Icon from 'cozy-ui/react/Icon'
+import flag from 'cozy-flags'
 import icon from 'assets/icons/actions/icon-link-out.svg'
 import styles from 'ducks/transactions/TransactionActions.styl'
 import { TransactionModalRow } from 'ducks/transactions/TransactionModal'
@@ -49,7 +52,13 @@ const Component = ({
     )
   }
 
-  return (
+  return flag('reimbursement-tag') ? (
+    <Chip size="small" variant="outlined" onClick={() => open(url)}>
+      {label}
+      <Chip.Separator />
+      <Icon icon="openwith" />
+    </Chip>
+  ) : (
     <ButtonAction
       onClick={() => open(url)}
       label={label}

--- a/src/ducks/transactions/actions/HealthLinkAction.jsx
+++ b/src/ducks/transactions/actions/HealthLinkAction.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { translate } from 'cozy-ui/react'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
+import Chip from 'cozy-ui/react/Chip'
+import Icon from 'cozy-ui/react/Icon'
+import flag from 'cozy-flags'
 import icon from 'assets/icons/actions/icon-link-out.svg'
 import { isHealth } from 'ducks/categories/helpers'
 import palette from 'cozy-ui/react/palette'
@@ -26,10 +29,16 @@ const Component = ({ t, actionProps: { urls }, compact, isModalItem }) => {
     )
   }
 
-  return (
+  return flag('reimbursement-tag') ? (
+    <Chip size="small" variant="outlined" onClick={() => open(url)}>
+      {label}
+      <Chip.Separator />
+      <Icon icon="openwith" />
+    </Chip>
+  ) : (
     <ButtonAction
       onClick={() => open(url)}
-      label={t(`Transactions.actions.${name}`)}
+      label={label}
       rightIcon="openwith"
       compact={compact}
       className={styles.TransactionActionButton}

--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -4,6 +4,9 @@ import { flowRight as compose } from 'lodash'
 import { findMatchingBrand } from 'ducks/brandDictionary'
 import { translate } from 'cozy-ui/react'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
+import Chip from 'cozy-ui/react/Chip'
+import Icon from 'cozy-ui/react/Icon'
+import flag from 'cozy-flags'
 import icon from 'assets/icons/actions/icon-link-out.svg'
 import styles from 'ducks/transactions/TransactionActions.styl'
 import { TransactionModalRow } from 'ducks/transactions/TransactionModal'
@@ -76,7 +79,17 @@ class Component extends React.Component {
   renderTransactionRow(label) {
     const { compact } = this.props
 
-    return (
+    return flag('reimbursement-tag') ? (
+      <Chip
+        size="small"
+        variant="dashed"
+        theme="primary"
+        onClick={this.showInformativeModal}
+      >
+        <Icon icon="plus" className="u-mr-half" />
+        {label}
+      </Chip>
+    ) : (
       <ButtonAction
         label={label}
         leftIcon="plus"
@@ -89,7 +102,7 @@ class Component extends React.Component {
   }
 
   render() {
-    const { t, compact, isModalItem } = this.props
+    const { t, isModalItem } = this.props
 
     const brand = this.findMatchingBrand()
     if (!brand) return

--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -61,6 +61,33 @@ class Component extends React.Component {
     return findMatchingBrand(brandsWithoutTrigger, this.props.transaction.label)
   }
 
+  renderModalItem(label) {
+    return (
+      <TransactionModalRow
+        iconLeft="plus"
+        style={transactionModalRowStyle}
+        onClick={this.showInformativeModal}
+      >
+        {label}
+      </TransactionModalRow>
+    )
+  }
+
+  renderTransactionRow(label) {
+    const { compact } = this.props
+
+    return (
+      <ButtonAction
+        label={label}
+        leftIcon="plus"
+        type="new"
+        compact={compact}
+        className={styles.TransactionActionButton}
+        onClick={this.showInformativeModal}
+      />
+    )
+  }
+
   render() {
     const { t, compact, isModalItem } = this.props
 
@@ -73,24 +100,9 @@ class Component extends React.Component {
 
     return (
       <>
-        {isModalItem ? (
-          <TransactionModalRow
-            iconLeft="plus"
-            style={transactionModalRowStyle}
-            onClick={this.showInformativeModal}
-          >
-            {label}
-          </TransactionModalRow>
-        ) : (
-          <ButtonAction
-            label={label}
-            leftIcon="plus"
-            type="new"
-            compact={compact}
-            className={styles.TransactionActionButton}
-            onClick={this.showInformativeModal}
-          />
-        )}
+        {isModalItem
+          ? this.renderModalItem(label)
+          : this.renderTransactionRow(label)}
         {this.state.showInformativeModal && (
           <InformativeModal
             onCancel={this.hideInformativeModal}

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import flag from 'cozy-flags'
-import { translate, withBreakpoints } from 'cozy-ui/react'
+import { translate } from 'cozy-ui/react'
 import Icon from 'cozy-ui/react/Icon'
-import ButtonAction from 'cozy-ui/react/ButtonAction'
+import Chip from 'cozy-ui/react/Chip'
 import Alerter from 'cozy-ui/react/Alerter'
 import { flowRight as compose } from 'lodash'
 import { withMutations } from 'cozy-client'
@@ -47,13 +47,48 @@ class ReimbursementStatusAction extends React.PureComponent {
     const label = t(`Transactions.actions.reimbursementStatus.${translateKey}`)
 
     return (
+      <TransactionModalRow
+        iconLeft={<Icon icon={iconReimbursement} />}
+        onClick={this.showModal}
+      >
+        {label}
+      </TransactionModalRow>
+    )
+  }
+
+  renderTransactionRow() {
+    const { transaction, t } = this.props
+
+    const status = getReimbursementStatus(transaction)
+    const isLate = isReimbursementLate(transaction)
+
+    if (status !== 'pending') {
+      return null
+    }
+
+    const translateKey = isLate ? 'late' : status
+
+    return (
+      <Chip
+        size="small"
+        variant="outlined"
+        theme="error"
+        onClick={this.showModal}
+      >
+        {t(`Transactions.actions.reimbursementStatus.${translateKey}`)}
+        <Chip.Separator />
+        <Icon icon="hourglass" />
+      </Chip>
+    )
+  }
+
+  render() {
+    const { isModalItem, transaction } = this.props
+    const status = getReimbursementStatus(transaction)
+
+    return (
       <>
-        <TransactionModalRow
-          iconLeft={<Icon icon={iconReimbursement} />}
-          onClick={this.showModal}
-        >
-          {label}
-        </TransactionModalRow>
+        {isModalItem ? this.renderModalItem() : this.renderTransactionRow()}
         {this.state.showModal && (
           <ReimbursementStatusModal
             into="body"
@@ -66,42 +101,6 @@ class ReimbursementStatusAction extends React.PureComponent {
       </>
     )
   }
-
-  renderTransactionRow() {
-    const {
-      breakpoints: { isMobile },
-      transaction,
-      t
-    } = this.props
-
-    const status = getReimbursementStatus(transaction)
-    const isLate = isReimbursementLate(transaction)
-
-    if (status !== 'pending') {
-      return null
-    }
-
-    const translateKey = isLate ? 'late' : status
-
-    return (
-      <ButtonAction
-        label={t(`Transactions.actions.reimbursementStatus.${translateKey}`)}
-        type="error"
-        rightIcon={<Icon icon="hourglass" />}
-        compact={isMobile}
-      />
-    )
-  }
-
-  render() {
-    const { isModalItem } = this.props
-
-    if (isModalItem) {
-      return this.renderModalItem()
-    } else {
-      return this.renderTransactionRow()
-    }
-  }
 }
 
 const action = {
@@ -111,7 +110,6 @@ const action = {
   },
   Component: compose(
     translate(),
-    withBreakpoints(),
     withMutations()
   )(ReimbursementStatusAction)
 }

--- a/src/ducks/transactions/actions/UrlLinkAction.jsx
+++ b/src/ducks/transactions/actions/UrlLinkAction.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import icon from 'assets/icons/actions/icon-link-out.svg'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
+import Chip from 'cozy-ui/react/Chip'
+import Icon from 'cozy-ui/react/Icon'
+import flag from 'cozy-flags'
 import styles from 'ducks/transactions/TransactionActions.styl'
 import { TransactionModalRow } from 'ducks/transactions/TransactionModal'
 import palette from 'cozy-ui/react/palette'
@@ -23,7 +26,17 @@ const Component = ({ transaction, compact, isModalItem }) => {
     )
   }
 
-  return (
+  return flag('reimbursement-tag') ? (
+    <Chip
+      size="small"
+      variant="outlined"
+      onClick={() => open(action.url, action.target)}
+    >
+      {action.trad}
+      <Chip.Separator />
+      <Icon icon="openwith" />
+    </Chip>
+  ) : (
     <ButtonAction
       onClick={() => open(action.url, action.target)}
       label={action.trad}


### PR DESCRIPTION
Render a `Chip` instead of a `ButtonAction` for every CTA in the transaction row. This is behind the `reimbursement-tag` flag.

![image](https://user-images.githubusercontent.com/1606068/58492438-3317dc00-8171-11e9-9e02-d06473c570c2.png)
![image](https://user-images.githubusercontent.com/1606068/58492455-3b701700-8171-11e9-9b41-29dcc7771ac0.png)
![image](https://user-images.githubusercontent.com/1606068/58492504-52166e00-8171-11e9-949f-544d1e305236.png)
![image](https://user-images.githubusercontent.com/1606068/58492529-5e023000-8171-11e9-9f83-1a6e27b6dffc.png)
