### PR TITLE
feat(BillChip): Show an AugmentedModal for vente privée if demo flag

### DIFF
--- a/src/components/AugmentedModal.jsx
+++ b/src/components/AugmentedModal.jsx
@@ -79,4 +79,33 @@ const AugmentedModal = ({ onClose, fileId }) => (
   </Modal>
 )
 
+/**
+ * This is like a `FileOpener`, but it opens an `AugmentedModal`.
+ * This is used for demo purposes only
+ */
+export class AugmentedModalOpener extends React.PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired
+  }
+
+  state = { isOpen: false }
+
+  handleOpen = () => this.setState({ isOpen: true })
+  handleClose = () => this.setState({ isOpen: false })
+
+  render() {
+    return (
+      <>
+        {React.cloneElement(this.props.children, { onClick: this.handleOpen })}
+        {this.state.isOpen && (
+          <AugmentedModal
+            onClose={this.handleClose}
+            fileId={this.props.fileId}
+          />
+        )}
+      </>
+    )
+  }
+}
+
 export default AugmentedModal

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -4,9 +4,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { translate } from 'cozy-ui/react'
 import Chip from 'cozy-ui/react/Chip'
+import flag from 'cozy-flags'
 import FileOpener from 'ducks/transactions/FileOpener'
 import FileIcon from 'ducks/transactions/actions/AttachedDocsAction/FileIcon'
 import { Figure } from 'components/Figure'
+import { AugmentedModalOpener } from 'components/AugmentedModal'
 
 class DumbBillChip extends React.PureComponent {
   static propTypes = {
@@ -34,8 +36,12 @@ class DumbBillChip extends React.PureComponent {
     const { bill, t } = this.props
     const [, invoiceId] = this.getInvoiceId(bill)
 
+    const isVentePrivee = flag('demo') && bill.vendor === 'Vente Privée'
+
+    const Wrapper = isVentePrivee ? AugmentedModalOpener : FileOpener
+
     return (
-      <FileOpener fileId={invoiceId} key={invoiceId}>
+      <Wrapper fileId={invoiceId} key={invoiceId}>
         <Chip component="button" size="small" variant="outlined">
           <FileIcon
             color={bill.isRefund ? 'var(--emerald)' : undefined}
@@ -47,7 +53,7 @@ class DumbBillChip extends React.PureComponent {
             t('Transactions.actions.attachedDocs.bill')
           )}
         </Chip>
-      </FileOpener>
+      </Wrapper>
     )
   }
 }

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -1801,15 +1801,11 @@
       "vendor": "Vente Privée",
       "subtype": "Facture Vente Privée 18/03/2018",
       "amount": -78.35,
-      "isRefund": true,
+      "isRefund": false,
       "date": "2018-10-18T22:00:00.000Z",
       "_id": "demo_venteprivee",
       "type": "shopping",
       "originalDate": "2018-10-16T00:00:00Z",
-      "socialSecurityRefund": 17.5,
-      "isThirdPartyPayer": false,
-      "originalAmount": 25,
-      "originalOperation": "io.cozy.bank.operations:paiementdocteur",
       "invoice": "io.cozy.files:{{reference 'io.cozy.files' 7 '_id' }}"
     },
     {


### PR DESCRIPTION
Add an `AugmentedModalOpener` component that acts like a `FileOpener`, but open an `AugmentedModal` for demo purposes.