### PR TITLE
Fixes on new actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-pouch-link": "6.18.0",
     "cozy-realtime": "3.0.0",
     "cozy-stack-client": "6.25.0",
-    "cozy-ui": "20.3.0",
+    "cozy-ui": "20.7.0",
     "d3": "5.9.2",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -10,7 +10,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import palette from 'cozy-ui/react/palette'
-import cx from 'classnames'
 import { findMatchingActions } from 'ducks/transactions/actions'
 import { TransactionActionsContext } from 'ducks/transactions/TransactionActionsContext'
 
@@ -58,14 +57,7 @@ export const SyncTransactionActions = ({
   compact,
   className
 }) => (
-  <span
-    className={cx(
-      {
-        'u-dib': !isModalItem
-      },
-      className
-    )}
-  >
+  <span className={className}>
     {(displayDefaultAction || onlyDefault) && actions.default && (
       <MenuAction
         action={actions.default}

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -211,7 +211,11 @@ class _RowMobile extends React.PureComponent {
             onlyDefault
             compact
             menuPosition="right"
-            className="u-mt-half u-ml-2-half"
+            className={cx(
+              'u-mt-half',
+              'u-ml-2-half',
+              styles.TransactionRowMobile__actions
+            )}
           />
         )}
       </List.Row>

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -83,3 +83,13 @@ for category in categories
 .TransactionRowMobile
     flex-direction column
     align-items flex-start
+    justify-content center
+
+.TransactionRowMobile__actions
+    display inline-block
+
+    // We may have an action that matches, but render nothing. In that case,
+    // this element exists, but is empty. We want to hide it to avoid extra
+    // margins
+    &:empty
+        display none

--- a/src/ducks/transactions/actions/AttachedDocsAction/FileIcon.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/FileIcon.jsx
@@ -5,7 +5,13 @@ import cx from 'classnames'
 const FileIcon = props => {
   const { className, ...rest } = props
 
-  return <Icon icon="file" className={cx('u-mr-half', className)} {...rest} />
+  return (
+    <Icon
+      icon="file-outline"
+      className={cx('u-mr-half', className)}
+      {...rest}
+    />
+  )
 }
 
 export default FileIcon

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
@@ -72,12 +72,12 @@ class ReimbursementStatusAction extends React.PureComponent {
       <Chip
         size="small"
         variant="outlined"
-        theme="error"
+        theme={isLate ? 'error' : 'normal'}
         onClick={this.showModal}
       >
         {t(`Transactions.actions.reimbursementStatus.${translateKey}`)}
         <Chip.Separator />
-        <Icon icon="hourglass" />
+        <Icon icon="hourglass" size={12} />
       </Chip>
     )
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4745,10 +4745,10 @@ cozy-ui@19.30.2:
     react-hot-loader "^4.3.11"
     react-select "2.2.0"
 
-cozy-ui@20.3.0:
-  version "20.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-20.3.0.tgz#9287d377cc53be6cd2615810cec52c73ab25b00d"
-  integrity sha512-cb4YCJKl+kc2RycwOZV23ffbM6hlcrkvv6awlR7j2X3h2GI6FvrioZCQ430V6iAlWYSSkc57Bb3xtRBZYNygew==
+cozy-ui@20.7.0:
+  version "20.7.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-20.7.0.tgz#f6704e0ae9702b6b3dc8dbf21ad8c0165111513d"
+  integrity sha512-xNznm8SQFkQzi0dkaLPaZCRWLXxJe/71SSfagokOuhHr3z0sZXybgVfPiHulha7cx230UFTe8nxMAKd1j4s15A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Some things that I missed while implementing new actions styles:

* Use `file-outline` icon
* Use `normal` Chip theme when a reimbursement is in pending state
* Properly align transaction row content on mobile