### PR TITLE
fix: Use a more recent universal link plugin

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -105,6 +105,6 @@
     </plugin>
     <plugin name="cordova-blur-app-privacy-screen" spec="https://github.com/lifeofcoding/cordova-blur-app-privacy-screen.git" />
     <engine name="ios" spec="4.5.5" />
-    <plugin name="cordova-universal-links-plugin" spec="https://github.com/walteram/cordova-universal-links-plugin.git" />
+    <plugin name="cordova-universal-links-plugin" spec="https://github.com/Mailbutler/cordova-universal-links-plugin"/>
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
 </widget>


### PR DESCRIPTION
This fork is up to date, and support the new iOS system for `entitlements`. 

Before, it was not possible to have universal links support by building the app from the cli. It worked from XCode, though. 

Now, with this forks, we can build from testflight... ;)