### PR TITLE
fix(transactions): Late reimbursement use real months difference

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "lint-staged": "8.1.5",
     "madge": "3.4.4",
     "mini-css-extract-plugin": "0.6.0",
+    "mockdate": "2.0.2",
     "npm-run-all": "4.1.5",
     "postcss": "7.0.14",
     "postcss-assets-webpack-plugin": "3.0.0",

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -3,7 +3,7 @@ import findLast from 'lodash/findLast'
 import get from 'lodash/get'
 import sumBy from 'lodash/sumBy'
 import flag from 'cozy-flags'
-import { differenceInCalendarMonths, parse as parseDate } from 'date-fns'
+import { differenceInMonths, parse as parseDate } from 'date-fns'
 import { isHealthExpense } from 'ducks/categories/helpers'
 
 const prevRecurRx = /\bPRLV SEPA RECU RCUR\b/
@@ -185,5 +185,5 @@ export const isReimbursementLate = transaction => {
   const transactionDate = parseDate(getDate(transaction))
   const today = new Date()
 
-  return differenceInCalendarMonths(today, transactionDate) >= 1
+  return differenceInMonths(today, transactionDate) >= 1
 }

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -1,5 +1,4 @@
 import configureStore from 'store/configureStore'
-import differenceInMonths from 'date-fns/difference_in_calendar_months'
 import {
   hydrateTransaction,
   getDate,
@@ -12,6 +11,7 @@ import {
   hasBills
 } from './helpers'
 import { BILLS_DOCTYPE } from 'doctypes'
+import MockDate from 'mockdate'
 
 const fakeCozyClient = {
   attachStore: () => {},
@@ -21,8 +21,6 @@ const fakeCozyClient = {
     return Promise.resolve({ data: [doc] })
   }
 }
-
-jest.mock('date-fns/difference_in_calendar_months')
 
 xdescribe('transaction', () => {
   const healthId = '400610'
@@ -183,6 +181,9 @@ describe('getReimbursementStatus', () => {
 })
 
 describe('isReimbursementLate', () => {
+  afterEach(() => {
+    MockDate.reset()
+  })
   it('should return false if the transaction is not an health expense', () => {
     const transaction = {
       manualCategoryId: '400310',
@@ -209,7 +210,8 @@ describe('isReimbursementLate', () => {
   })
 
   it('should return false if the transaction reimbursement is pending but for less than one month', () => {
-    differenceInMonths.mockReturnValueOnce(0)
+    MockDate.set('06/03/2019')
+
     const transaction = {
       reimbursementStatus: 'pending',
       date: '2019-05-23',
@@ -221,10 +223,11 @@ describe('isReimbursementLate', () => {
   })
 
   it('should return true if the transaction reimbursement is pending for more than one month', () => {
-    differenceInMonths.mockReturnValueOnce(2)
+    MockDate.set(new Date(2019, 4, 24))
+
     const transaction = {
       reimbursementStatus: 'pending',
-      date: '2018-05-23',
+      date: '2019-04-23',
       manualCategoryId: '400610',
       amount: -10
     }

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -1,5 +1,5 @@
 import configureStore from 'store/configureStore'
-import differenceInCalendarMonths from 'date-fns/difference_in_calendar_months'
+import differenceInMonths from 'date-fns/difference_in_calendar_months'
 import {
   hydrateTransaction,
   getDate,
@@ -209,7 +209,7 @@ describe('isReimbursementLate', () => {
   })
 
   it('should return false if the transaction reimbursement is pending but for less than one month', () => {
-    differenceInCalendarMonths.mockReturnValueOnce(0)
+    differenceInMonths.mockReturnValueOnce(0)
     const transaction = {
       reimbursementStatus: 'pending',
       date: '2019-05-23',
@@ -221,7 +221,7 @@ describe('isReimbursementLate', () => {
   })
 
   it('should return true if the transaction reimbursement is pending for more than one month', () => {
-    differenceInCalendarMonths.mockReturnValueOnce(2)
+    differenceInMonths.mockReturnValueOnce(2)
     const transaction = {
       reimbursementStatus: 'pending',
       date: '2018-05-23',

--- a/yarn.lock
+++ b/yarn.lock
@@ -11821,6 +11821,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@0.x.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdir
   dependencies:
     minimist "0.0.8"
 
+mockdate@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.2.tgz#5ae0c0eaf8fe23e009cd01f9889b42c4f634af12"
+  integrity sha1-WuDA6vj+I+AJzQH5iJtCxPY0rxI=
+
 module-definition@^3.0.0, module-definition@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/module-definition/-/module-definition-3.1.0.tgz#201c062b89f81ed18018e1a2f15afc0c8089a126"


### PR DESCRIPTION
Using calendar months difference was not the good solution because the
calendar months difference between `2019-05-31` and `2019-06-01` is `1`.
We want to have the difference in full months.