### PR TITLE
Handle reimbursement tag on balance and health reimbursements pages

### DIFF
--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -27,6 +27,8 @@ class DumbHealthReimbursements extends Component {
     const { filteredTransactions, t } = this.props
     const reimbursementTagFlag = flag('reimbursement-tag')
 
+    // This grouping logic should be extracted to a selector, so this is
+    // easily memoizable
     const groupedTransactions = groupBy(
       filteredTransactions,
       reimbursementTagFlag ? getReimbursementStatus : isFullyReimbursed

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -36,11 +36,11 @@ class DumbHealthReimbursements extends Component {
       ? groupedTransactions.reimbursed
       : groupedTransactions.true
 
-    const awaitingTransactions = reimbursementTagFlag
+    const pendingTransactions = reimbursementTagFlag
       ? groupedTransactions.pending
       : groupedTransactions.false
 
-    const awaitingAmount = sumBy(awaitingTransactions, t => -t.amount)
+    const pendingAmount = sumBy(pendingTransactions, t => -t.amount)
 
     return (
       <>
@@ -48,7 +48,7 @@ class DumbHealthReimbursements extends Component {
           <Title className={styles.HealthReimbursements__title}>
             <Figure
               symbol="€"
-              total={awaitingAmount}
+              total={pendingAmount}
               className={styles.HealthReimbursements__figure}
               signed
             />{' '}
@@ -56,7 +56,7 @@ class DumbHealthReimbursements extends Component {
           </Title>
         </Padded>
         <TransactionsWithSelection
-          transactions={awaitingTransactions}
+          transactions={pendingTransactions}
           brands={this.props.brands}
           urls={this.props.urls}
           withScroll={false}

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -3,11 +3,15 @@ import { connect } from 'react-redux'
 import { queryConnect } from 'cozy-client'
 import { transactionsConn } from 'doctypes'
 import { flowRight as compose, sumBy, groupBy } from 'lodash'
+import flag from 'cozy-flags'
 import { getHealthExpensesByPeriod } from 'ducks/filters'
 import { TransactionsWithSelection } from 'ducks/transactions/Transactions'
 import withBrands from 'ducks/brandDictionary/withBrands'
 import withAppsUrls from 'ducks/apps/withAppsUrls'
-import { isFullyReimbursed } from 'ducks/transactions/helpers'
+import {
+  isFullyReimbursed,
+  getReimbursementStatus
+} from 'ducks/transactions/helpers'
 import { translate } from 'cozy-ui/react'
 import { Title } from 'cozy-ui/react/Text'
 import { Padded } from 'components/Spacing'
@@ -15,12 +19,26 @@ import { Figure } from 'components/Figure'
 import styles from 'ducks/reimbursements/HealthReimbursements.styl'
 
 class DumbHealthReimbursements extends Component {
+  getGroups() {
+    return groupBy(this.props.filteredTransactions, getReimbursementStatus)
+  }
+
   render() {
     const { filteredTransactions, t } = this.props
-    const {
-      true: reimbursedTransactions,
-      false: awaitingTransactions
-    } = groupBy(filteredTransactions, isFullyReimbursed)
+    const reimbursementTagFlag = flag('reimbursement-tag')
+
+    const groupedTransactions = groupBy(
+      filteredTransactions,
+      reimbursementTagFlag ? getReimbursementStatus : isFullyReimbursed
+    )
+
+    const reimbursedTransactions = reimbursementTagFlag
+      ? groupedTransactions.reimbursed
+      : groupedTransactions.true
+
+    const awaitingTransactions = reimbursementTagFlag
+      ? groupedTransactions.pending
+      : groupedTransactions.false
 
     const awaitingAmount = sumBy(awaitingTransactions, t => -t.amount)
 

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -187,3 +187,7 @@ export const isReimbursementLate = transaction => {
 
   return differenceInMonths(today, transactionDate) >= 1
 }
+
+export const hasPendingReimbursement = transaction => {
+  return getReimbursementStatus(transaction) === 'pending'
+}


### PR DESCRIPTION
The reimbursement tag was not taken into account on these pages. This is now the case. Still behind the `reimbursement-tag` flag.

The health reimbursement virtual account's balance is computed by taking only pending reimbursements. And the reimbursements page split the transaction according to their reimbursement tag.