### PR TITLE
fix(AccountRow): Show a pointer when hovering the row

### DIFF
--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -57,7 +57,7 @@ class AccountRow extends React.PureComponent {
 
     return (
       <li
-        className={cx(styles.AccountRow, 'u-c-pointer', {
+        className={cx(styles.AccountRow, 'u-clickable', {
           [styles['AccountRow--hasWarning']]: hasWarning,
           [styles['AccountRow--hasAlert']]: hasAlert,
           [styles['AccountRow--disabled']]:


### PR DESCRIPTION
The `u-c-pointer` class is not automatically imported by cozy-ui because no react component uses it. So for now we use a custom `u-clickable`.