### PR TITLE
fix: Make the Radio the same height as the List Row

### DIFF
--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
@@ -38,7 +38,7 @@ class _ReimbursementStatusModal extends React.PureComponent {
                   label={t(`Transactions.reimbursementStatus.${choice}`)}
                   checked={status === choice}
                   onChange={onChange}
-                  className="u-mb-0"
+                  className={cx('u-mb-0', styles.Radio)}
                 />
               </Row>
             ))}

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.styl
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.styl
@@ -1,2 +1,6 @@
 .ReimbursementStatusModal__transactionLabel
     color var(--coolGrey)
+
+.Radio
+    height 3rem // Give the same height as the List row
+    align-items center // Should be removed when https://github.com/cozy/cozy-ui/pull/1026 is merged


### PR DESCRIPTION
On iOS, clic on the radio buttons is not registered because the clic area
is too small. Here I make the Radio the same height as the list Rows.