### PR TITLE
fix: Add vertical margins to Loading

### DIFF
--- a/src/components/Loading/Loading.styl
+++ b/src/components/Loading/Loading.styl
@@ -3,6 +3,7 @@
 
 .bnk-loading
     text-align center
+    margin 5rem auto
 
     h2
         font-size(24px)


### PR DESCRIPTION
Vertical margins had disappeared after 5acaf522a8717a2c8764ab10d23d687899b04b5f