### PR TITLE
feat(ReimbursementsPage): Scroll to the top of the page on mount

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+
+class ScrollToTop extends React.Component {
+  componentDidMount() {
+    window.scrollTo(0, 0)
+  }
+
+  render() {
+    return null
+  }
+}
+
+export default ScrollToTop

--- a/src/ducks/reimbursements/ReimbursementsPage.jsx
+++ b/src/ducks/reimbursements/ReimbursementsPage.jsx
@@ -11,6 +11,7 @@ import BackButton from 'components/BackButton'
 import { ConnectedSelectDates } from 'components/SelectDates'
 import HealthReimbursements from 'ducks/reimbursements/HealthReimbursements'
 import styles from 'ducks/reimbursements/ReimbursementsPage.styl'
+import ScrollToTop from 'components/ScrollToTop'
 
 function getSubComponent(filteringDoc) {
   switch (filteringDoc._id) {
@@ -35,6 +36,7 @@ class RawReimbursementsPage extends React.Component {
 
     return (
       <>
+        <ScrollToTop />
         <BarTheme theme="primary" />
         <Header color="primary" fixed>
           <Padded


### PR DESCRIPTION
When navigating to this page, the scroll level from the previous page is
kept. We need to scroll to the top of the page when it is mounted.