### PR TITLE
Empty health reimbursements page

### DIFF
--- a/src/components/KonnectorChip/KonnectorChip.jsx
+++ b/src/components/KonnectorChip/KonnectorChip.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Chip from 'cozy-ui/react/Chip'
+import Icon from 'cozy-ui/react/Icon'
+import { translate } from 'cozy-ui/react'
+
+const DumbKonnectorChip = props => {
+  const { t, konnectorType, ...rest } = props
+
+  return (
+    <Chip size="small" variant="dashed" theme="primary" {...rest}>
+      <Icon icon="plus" className="u-mr-half" />
+      {t(`KonnectorChip.${konnectorType}`)}
+    </Chip>
+  )
+}
+
+DumbKonnectorChip.propTypes = {
+  konnectorType: PropTypes.oneOf(['health', 'generic'])
+}
+
+DumbKonnectorChip.defaultProps = {
+  konnectorType: 'generic'
+}
+
+const KonnectorChip = translate()(DumbKonnectorChip)
+
+export default KonnectorChip

--- a/src/components/KonnectorChip/index.js
+++ b/src/components/KonnectorChip/index.js
@@ -1,0 +1,3 @@
+export {
+  default as KonnectorChip
+} from 'components/KonnectorChip/KonnectorChip'

--- a/src/components/KonnectorChip/readme.md
+++ b/src/components/KonnectorChip/readme.md
@@ -1,0 +1,6 @@
+```
+<div>
+  <KonnectorChip konnectorType="health" />
+  <KonnectorChip />
+</div>
+```

--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import cx from 'classnames'
+import styles from 'components/Section/Section.styl'
+
+const Section = props => {
+  const { className, ...rest } = props
+
+  return <section className={cx(styles.Section, className)} {...rest} />
+}
+
+export default Section

--- a/src/components/Section/Section.styl
+++ b/src/components/Section/Section.styl
@@ -1,0 +1,24 @@
+@require 'settings/breakpoints'
+
+.Section
+    margin-top 24px
+
+    +small-screen()
+        position relative
+        margin-top 16px
+        border-top 1px solid var(--silver)
+        border-bottom: 1px solid var(--silver)
+        z-index 0
+
+        &::before
+            content ''
+            position absolute
+            bottom calc(100% + 1px)
+            left 0
+            right 0
+            height 16px
+            background-color var(--paleGrey)
+            z-index -1
+
+        &:last-child
+            border-bottom 0

--- a/src/components/Section/index.js
+++ b/src/components/Section/index.js
@@ -1,0 +1,1 @@
+export { default as Section } from 'components/Section/Section'

--- a/src/components/StoreLink/StoreLink.jsx
+++ b/src/components/StoreLink/StoreLink.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { pickBy } from 'lodash'
+import { withClient } from 'cozy-client'
+
+class DumbStoreLink extends React.Component {
+  static propTypes = {
+    type: PropTypes.oneOf(['konnector', 'webapp']),
+    category: PropTypes.string
+  }
+
+  redirect = async () => {
+    const { client: cozyClient, type, category } = this.props
+    const redirectionURL = await cozyClient.intents.getRedirectionURL(
+      'io.cozy.apps',
+      pickBy({ type, category }, Boolean)
+    )
+
+    // We use `window.location` because on desktop we want to stay in the same tab/window
+    // and on mobile we want to open the user's browser instead of an inapp browser
+    // because in the onboarding flow, the user clicks on email links, which open
+    // the "native" browser (external Firefox for example) instead of the in-app one.
+    // This means login cookies are stored in the external browser.
+    // To prevent asking the user to login again, we have to use an external browser
+    // instead of the in app browser.
+    window.location = redirectionURL
+  }
+
+  render() {
+    return React.cloneElement(this.props.children, { onClick: this.redirect })
+  }
+}
+
+const StoreLink = withClient(DumbStoreLink)
+
+export default StoreLink

--- a/src/components/StoreLink/StoreLink.jsx
+++ b/src/components/StoreLink/StoreLink.jsx
@@ -9,12 +9,32 @@ class DumbStoreLink extends React.Component {
     category: PropTypes.string
   }
 
-  redirect = async () => {
-    const { client: cozyClient, type, category } = this.props
-    const redirectionURL = await cozyClient.intents.getRedirectionURL(
+  async componentDidMount() {
+    await this.updateRedirectionURL()
+  }
+
+  async componentDidUpdate(prevProps) {
+    if (
+      this.props.type !== prevProps.type ||
+      this.props.category !== prevProps.category
+    ) {
+      await this.updateRedirectionURL()
+    }
+  }
+
+  async updateRedirectionURL() {
+    const { client, type, category } = this.props
+
+    this.redirectionURL = await client.intents.getRedirectionURL(
       'io.cozy.apps',
       pickBy({ type, category }, Boolean)
     )
+  }
+
+  redirect = async () => {
+    if (!this.redirectionURL) {
+      await this.updateRedirectionURL()
+    }
 
     // We use `window.location` because on desktop we want to stay in the same tab/window
     // and on mobile we want to open the user's browser instead of an inapp browser
@@ -23,7 +43,7 @@ class DumbStoreLink extends React.Component {
     // This means login cookies are stored in the external browser.
     // To prevent asking the user to login again, we have to use an external browser
     // instead of the in app browser.
-    window.location = redirectionURL
+    window.location = this.redirectionURL
   }
 
   render() {

--- a/src/components/StoreLink/index.js
+++ b/src/components/StoreLink/index.js
@@ -1,0 +1,1 @@
+export { default as StoreLink } from 'components/StoreLink/StoreLink'

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -21,6 +21,7 @@ import styles from 'ducks/reimbursements/HealthReimbursements.styl'
 import Loading from 'components/Loading'
 import { KonnectorChip } from 'components/KonnectorChip'
 import { StoreLink } from 'components/StoreLink'
+import { Section } from 'components/Section'
 
 const Caption = props => {
   const { className, ...rest } = props
@@ -71,49 +72,55 @@ class DumbHealthReimbursements extends Component {
 
     return (
       <>
-        <Padded className="u-pv-0">
+        <Section>
           <Title>
-            <Figure
-              symbol="€"
-              total={pendingAmount}
-              className={styles.HealthReimbursements__figure}
-              signed
-            />{' '}
-            {t('Reimbursements.awaiting')}
+            <Padded className="u-pv-0">
+              <Figure
+                symbol="€"
+                total={pendingAmount}
+                className={styles.HealthReimbursements__figure}
+                signed
+              />{' '}
+              {t('Reimbursements.awaiting')}
+            </Padded>
           </Title>
-        </Padded>
-        {pendingTransactions ? (
-          <TransactionsWithSelection
-            transactions={pendingTransactions}
-            brands={this.props.brands}
-            urls={this.props.urls}
-            withScroll={false}
-            className={styles.HealthReimbursements__transactionsList}
-          />
-        ) : (
-          <Padded className="u-pv-0">
-            <Caption>{t('Reimbursements.noAwaiting')}</Caption>
-          </Padded>
-        )}
-        <Padded className="u-pv-0">
-          <Title>{t('Reimbursements.alreadyReimbursed')}</Title>
-        </Padded>
-        {reimbursedTransactions ? (
-          <TransactionsWithSelection
-            transactions={reimbursedTransactions}
-            brands={this.props.brands}
-            urls={this.props.urls}
-            withScroll={false}
-            className={styles.HealthReimbursements__transactionsList}
-          />
-        ) : (
-          <Padded className="u-pv-0">
-            <Caption>{t('Reimbursements.noReimbursed')}</Caption>
-            <StoreLink type="konnector" category="insurance">
-              <KonnectorChip konnectorType="health" />
-            </StoreLink>
-          </Padded>
-        )}
+          {pendingTransactions ? (
+            <TransactionsWithSelection
+              transactions={pendingTransactions}
+              brands={this.props.brands}
+              urls={this.props.urls}
+              withScroll={false}
+              className={styles.HealthReimbursements__transactionsList}
+            />
+          ) : (
+            <Padded className="u-pv-0">
+              <Caption>{t('Reimbursements.noAwaiting')}</Caption>
+            </Padded>
+          )}
+        </Section>
+        <Section>
+          <Title>
+            <Padded className="u-pv-0">
+              {t('Reimbursements.alreadyReimbursed')}
+            </Padded>
+          </Title>
+          {reimbursedTransactions ? (
+            <TransactionsWithSelection
+              transactions={reimbursedTransactions}
+              brands={this.props.brands}
+              urls={this.props.urls}
+              withScroll={false}
+              className={styles.HealthReimbursements__transactionsList}
+            />
+          ) : (
+            <Padded className="u-pv-0">
+              <Caption>{t('Reimbursements.noReimbursed')}</Caption>
+              <StoreLink type="konnector" category="insurance">
+                <KonnectorChip konnectorType="health" />
+              </StoreLink>
+            </Padded>
+          )}
+        </Section>
       </>
     )
   }

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -4,6 +4,7 @@ import { queryConnect } from 'cozy-client'
 import { transactionsConn } from 'doctypes'
 import { flowRight as compose, sumBy, groupBy } from 'lodash'
 import flag from 'cozy-flags'
+import cx from 'classnames'
 import { getHealthExpensesByPeriod } from 'ducks/filters'
 import { TransactionsWithSelection } from 'ducks/transactions/Transactions'
 import withBrands from 'ducks/brandDictionary/withBrands'
@@ -18,6 +19,12 @@ import { Padded } from 'components/Spacing'
 import { Figure } from 'components/Figure'
 import styles from 'ducks/reimbursements/HealthReimbursements.styl'
 import Loading from 'components/Loading'
+
+const Caption = props => {
+  const { className, ...rest } = props
+
+  return <p className={cx(styles.Caption, className)} {...rest} />
+}
 
 class DumbHealthReimbursements extends Component {
   getGroups() {
@@ -72,7 +79,7 @@ class DumbHealthReimbursements extends Component {
           />
         ) : (
           <Padded className="u-pv-0">
-            <p>{t('Reimbursements.noAwaiting')}</p>
+            <Caption>{t('Reimbursements.noAwaiting')}</Caption>
           </Padded>
         )}
         <Padded className="u-pv-0">
@@ -90,7 +97,7 @@ class DumbHealthReimbursements extends Component {
           />
         ) : (
           <Padded className="u-pv-0">
-            <p>{t('Reimbursements.noReimbursed')}</p>
+            <Caption>{t('Reimbursements.noReimbursed')}</Caption>
           </Padded>
         )}
       </>

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -14,7 +14,7 @@ import {
   getReimbursementStatus
 } from 'ducks/transactions/helpers'
 import { translate } from 'cozy-ui/react'
-import { Title } from 'cozy-ui/react/Text'
+import { Title as BaseTitle } from 'cozy-ui/react/Text'
 import { Padded } from 'components/Spacing'
 import { Figure } from 'components/Figure'
 import styles from 'ducks/reimbursements/HealthReimbursements.styl'
@@ -26,6 +26,17 @@ const Caption = props => {
   const { className, ...rest } = props
 
   return <p className={cx(styles.Caption, className)} {...rest} />
+}
+
+const Title = props => {
+  const { className, ...rest } = props
+
+  return (
+    <BaseTitle
+      className={cx(styles.HealthReimbursements__title, className)}
+      {...rest}
+    />
+  )
 }
 
 class DumbHealthReimbursements extends Component {
@@ -61,7 +72,7 @@ class DumbHealthReimbursements extends Component {
     return (
       <>
         <Padded className="u-pv-0">
-          <Title className={styles.HealthReimbursements__title}>
+          <Title>
             <Figure
               symbol="€"
               total={pendingAmount}
@@ -85,9 +96,7 @@ class DumbHealthReimbursements extends Component {
           </Padded>
         )}
         <Padded className="u-pv-0">
-          <Title className={styles.HealthReimbursements__title}>
-            {t('Reimbursements.alreadyReimbursed')}
-          </Title>
+          <Title>{t('Reimbursements.alreadyReimbursed')}</Title>
         </Padded>
         {reimbursedTransactions ? (
           <TransactionsWithSelection

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -19,6 +19,7 @@ import { Padded } from 'components/Spacing'
 import { Figure } from 'components/Figure'
 import styles from 'ducks/reimbursements/HealthReimbursements.styl'
 import Loading from 'components/Loading'
+import { KonnectorChip } from 'components/KonnectorChip'
 
 const Caption = props => {
   const { className, ...rest } = props
@@ -98,6 +99,10 @@ class DumbHealthReimbursements extends Component {
         ) : (
           <Padded className="u-pv-0">
             <Caption>{t('Reimbursements.noReimbursed')}</Caption>
+            <KonnectorChip
+              onClick={() => console.log('clicked')}
+              konnectorType="health"
+            />
           </Padded>
         )}
       </>

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -62,25 +62,37 @@ class DumbHealthReimbursements extends Component {
             {t('Reimbursements.awaiting')}
           </Title>
         </Padded>
-        <TransactionsWithSelection
-          transactions={pendingTransactions}
-          brands={this.props.brands}
-          urls={this.props.urls}
-          withScroll={false}
-          className={styles.HealthReimbursements__transactionsList}
-        />
+        {pendingTransactions ? (
+          <TransactionsWithSelection
+            transactions={pendingTransactions}
+            brands={this.props.brands}
+            urls={this.props.urls}
+            withScroll={false}
+            className={styles.HealthReimbursements__transactionsList}
+          />
+        ) : (
+          <Padded className="u-pv-0">
+            <p>{t('Reimbursements.noAwaiting')}</p>
+          </Padded>
+        )}
         <Padded className="u-pv-0">
           <Title className={styles.HealthReimbursements__title}>
             {t('Reimbursements.alreadyReimbursed')}
           </Title>
         </Padded>
-        <TransactionsWithSelection
-          transactions={reimbursedTransactions}
-          brands={this.props.brands}
-          urls={this.props.urls}
-          withScroll={false}
-          className={styles.HealthReimbursements__transactionsList}
-        />
+        {reimbursedTransactions ? (
+          <TransactionsWithSelection
+            transactions={reimbursedTransactions}
+            brands={this.props.brands}
+            urls={this.props.urls}
+            withScroll={false}
+            className={styles.HealthReimbursements__transactionsList}
+          />
+        ) : (
+          <Padded className="u-pv-0">
+            <p>{t('Reimbursements.noReimbursed')}</p>
+          </Padded>
+        )}
       </>
     )
   }

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -40,7 +40,7 @@ const Title = props => {
   )
 }
 
-class DumbHealthReimbursements extends Component {
+export class DumbHealthReimbursements extends Component {
   getGroups() {
     return groupBy(this.props.filteredTransactions, getReimbursementStatus)
   }

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -20,6 +20,7 @@ import { Figure } from 'components/Figure'
 import styles from 'ducks/reimbursements/HealthReimbursements.styl'
 import Loading from 'components/Loading'
 import { KonnectorChip } from 'components/KonnectorChip'
+import { StoreLink } from 'components/StoreLink'
 
 const Caption = props => {
   const { className, ...rest } = props
@@ -99,10 +100,9 @@ class DumbHealthReimbursements extends Component {
         ) : (
           <Padded className="u-pv-0">
             <Caption>{t('Reimbursements.noReimbursed')}</Caption>
-            <KonnectorChip
-              onClick={() => console.log('clicked')}
-              konnectorType="health"
-            />
+            <StoreLink type="konnector" category="insurance">
+              <KonnectorChip konnectorType="health" />
+            </StoreLink>
           </Padded>
         )}
       </>

--- a/src/ducks/reimbursements/HealthReimbursements.spec.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.spec.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+import { DumbHealthReimbursements } from './HealthReimbursements'
+import Loading from 'components/Loading'
+import fixtures from 'test/fixtures/unit-tests.json'
+import { TransactionsWithSelection } from 'ducks/transactions/Transactions'
+import { StoreLink } from 'components/StoreLink'
+
+describe('HealthReimbursements', () => {
+  it('should show a loading if the transactions are loading', () => {
+    const root = shallow(
+      <DumbHealthReimbursements
+        fetchStatus="loading"
+        filteredTransactions={[]}
+      />
+    )
+
+    expect(root.find(Loading).length).toBe(1)
+  })
+
+  it('should show the pending reimbursements', () => {
+    const pending = fixtures['io.cozy.bank.operations'].filter(
+      transaction => transaction._id === 'paiementdocteur2'
+    )
+
+    // Wrapping in `AppLike` instead of giving `t` manually makes the test
+    // fail: no `TransactionsWithSelection` exists
+    const root = shallow(
+      <DumbHealthReimbursements
+        fetchStatus="loaded"
+        filteredTransactions={pending}
+        t={key => key}
+      />
+    )
+
+    expect(root.find(TransactionsWithSelection).length).toBe(1)
+  })
+
+  it('should show the reimbursed transactions', () => {
+    const reimbursed = fixtures['io.cozy.bank.operations'].filter(
+      transaction => transaction._id === 'paiementdocteur'
+    )
+
+    const root = shallow(
+      <DumbHealthReimbursements
+        fetchStatus="loaded"
+        filteredTransactions={reimbursed}
+        t={key => key}
+      />
+    )
+
+    expect(root.find(TransactionsWithSelection).length).toBe(1)
+  })
+
+  it('should show a button to open the store if there is no reimbursed transactions', () => {
+    const root = shallow(
+      <DumbHealthReimbursements
+        fetchStatus="loaded"
+        filteredTransactions={[]}
+        t={key => key}
+      />
+    )
+
+    expect(root.find(StoreLink).length).toBe(1)
+  })
+})

--- a/src/ducks/reimbursements/HealthReimbursements.styl
+++ b/src/ducks/reimbursements/HealthReimbursements.styl
@@ -13,3 +13,8 @@
 
     +small-screen()
         margin-top 16px
+
+.Caption
+    font-size 14px
+    line-height 1.7
+    color var(--coolGrey)

--- a/src/ducks/reimbursements/HealthReimbursements.styl
+++ b/src/ducks/reimbursements/HealthReimbursements.styl
@@ -10,10 +10,10 @@
 .HealthReimbursements__title
     font-size 18px
     line-height 56px
-    margin-top 24px
+    border-bottom 1px solid var(--silver)
 
     +small-screen()
-        margin-top 16px
+        font-size 16px
 
 .Caption
     font-size 14px

--- a/src/ducks/reimbursements/HealthReimbursements.styl
+++ b/src/ducks/reimbursements/HealthReimbursements.styl
@@ -8,6 +8,7 @@
         border-top: 1px solid var(--silver)
 
 .HealthReimbursements__title
+    font-size 18px
     line-height 56px
     margin-top 24px
 

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -1,69 +1,12 @@
-import React, { Component } from 'react'
-import { withClient } from 'cozy-client'
-
-// import { IntentOpener } from 'cozy-ui/react'
-
-/*
- * This component aims to open collect:
- * - on browser, it displays collect intent
- * - on mobile, it opens a new window with collect url
- *
- * TODO: remove this component when intents will work on mobile
- */
-
-// Mobile
-
-class SameWindowLink extends Component {
-  redirect = async () => {
-    const cozyClient = this.props.client
-    const redirectionURL = await cozyClient.intents.getRedirectionURL(
-      'io.cozy.apps',
-      {
-        type: 'konnector',
-        category: 'banking'
-      }
-    )
-
-    // We use `window.location` because on desktop we want to stay in the same tab/window
-    // and on mobile we want to open the user's browser instead of an inapp browser
-    // because in the onboarding flow, the user clicks on email links, which open
-    // the "native" browser (external Firefox for example) instead of the in-app one.
-    // This means login cookies are stored in the external browser.
-    // To prevent asking the user to login again, we have to use an external browser
-    // instead of the in app browser.
-    window.location = redirectionURL
-  }
-
-  render() {
-    return React.cloneElement(this.props.children, { onClick: this.redirect })
-  }
-}
-
-// Browser
-
-// For now we don't use intent anymore, but we will use it later
-// See https://gitlab.cozycloud.cc/labs/cozy-bank/merge_requests/256
-// class IntentLink extends Component {
-//   render () {
-//     return (
-//       <IntentOpener
-//         action='CREATE'
-//         doctype='io.cozy.accounts'
-//         options={{dataType: 'bankAccounts'}}
-//       >
-//         <span>{this.props.children}</span>
-//       </IntentOpener>
-//     )
-//   }
-// }
-
-// Switch according to target
+import React from 'react'
+import { StoreLink } from 'components/StoreLink'
 
 const AddAccountLink = props => {
-  // For now we redirect on collect on both mobile app and browsers
-  // since this is not possible to show a waiting message
-  // const Link = __TARGET__ === 'mobile' ? NewWindowLink : IntentLink
-  return <SameWindowLink {...props} />
+  return (
+    <StoreLink type="konnector" category="banking">
+      {props.children}
+    </StoreLink>
+  )
 }
 
-export default withClient(AddAccountLink)
+export default AddAccountLink

--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -4,8 +4,6 @@ import { flowRight as compose } from 'lodash'
 import { findMatchingBrand } from 'ducks/brandDictionary'
 import { translate } from 'cozy-ui/react'
 import ButtonAction from 'cozy-ui/react/ButtonAction'
-import Chip from 'cozy-ui/react/Chip'
-import Icon from 'cozy-ui/react/Icon'
 import flag from 'cozy-flags'
 import icon from 'assets/icons/actions/icon-link-out.svg'
 import styles from 'ducks/transactions/TransactionActions.styl'
@@ -16,6 +14,7 @@ import InformativeModal from 'ducks/transactions/actions/KonnectorAction/Informa
 import ConfigurationModal from 'ducks/transactions/actions/KonnectorAction/ConfigurationModal'
 import { getBrandsWithoutTrigger } from 'ducks/transactions/actions/KonnectorAction/helpers'
 import match from 'ducks/transactions/actions/KonnectorAction/match'
+import { KonnectorChip } from 'components/KonnectorChip'
 
 const name = 'konnector'
 
@@ -76,19 +75,14 @@ class Component extends React.Component {
     )
   }
 
-  renderTransactionRow(label) {
+  renderTransactionRow(label, brand) {
     const { compact } = this.props
 
     return flag('reimbursement-tag') ? (
-      <Chip
-        size="small"
-        variant="dashed"
-        theme="primary"
+      <KonnectorChip
         onClick={this.showInformativeModal}
-      >
-        <Icon icon="plus" className="u-mr-half" />
-        {label}
-      </Chip>
+        konnectorType={brand.health ? 'health' : 'generic'}
+      />
     ) : (
       <ButtonAction
         label={label}
@@ -115,7 +109,7 @@ class Component extends React.Component {
       <>
         {isModalItem
           ? this.renderModalItem(label)
-          : this.renderTransactionRow(label)}
+          : this.renderTransactionRow(label, brand)}
         {this.state.showInformativeModal && (
           <InformativeModal
             onCancel={this.hideInformativeModal}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -588,6 +588,8 @@
   "Reimbursements": {
     "title": "Reimbursements",
     "awaiting": "awaiting",
-    "alreadyReimbursed": "Already reimbursed"
+    "alreadyReimbursed": "Already reimbursed",
+    "noAwaiting": "No awaiting reimbursement.",
+    "noReimbursed": "Automatically detect your health reimbursements by connecting your health insurance to your Cozy."
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -591,5 +591,10 @@
     "alreadyReimbursed": "Already reimbursed",
     "noAwaiting": "No awaiting reimbursement.",
     "noReimbursed": "Automatically detect your health reimbursements by connecting your health insurance to your Cozy."
+  },
+
+  "KonnectorChip": {
+    "health": "My reimbursements",
+    "generic": "My invoices"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -540,6 +540,8 @@
   "Reimbursements": {
     "title": "Remboursements",
     "awaiting": "en attente",
-    "alreadyReimbursed": "Déjà remboursés"
+    "alreadyReimbursed": "Déjà remboursés",
+    "noAwaiting": "Aucun remboursement attendu.",
+    "noReimbursed": "Détecter automatiquement vos remboursements en connectant votre assurance santé à votre Cozy."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -543,5 +543,11 @@
     "alreadyReimbursed": "Déjà remboursés",
     "noAwaiting": "Aucun remboursement attendu.",
     "noReimbursed": "Détecter automatiquement vos remboursements en connectant votre assurance santé à votre Cozy."
+  },
+
+
+  "KonnectorChip": {
+    "health": "Mes remboursements",
+    "generic": "Mes factures"
   }
 }

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -21,7 +21,8 @@ module.exports = {
         'src/components/SelectDates/SelectDates.jsx',
         'src/components/Select/index.jsx',
         'src/components/Switch.jsx',
-        'src/components/PageModal/PageModal.jsx'
+        'src/components/PageModal/PageModal.jsx',
+        'src/components/KonnectorChip/index.js'
       ]
     },
     {


### PR DESCRIPTION
* Show some messages when there is no pending reimbursements and/or reimbursed transactions
* Show a link to the store filtered on insurance konnectors when there is no reimbursed transactions
* Dinstinguish the sections visually
* Some minor style updates

Live on https://testbanksemptyreimbursementspage-banks.cozy.works