### PR TITLE
fix(Notification): Reference class name instead of this

### DIFF
--- a/src/ducks/notifications/Notification.js
+++ b/src/ducks/notifications/Notification.js
@@ -11,7 +11,7 @@ class Notification {
 
     const cozyUrl = this.cozyClient._url
 
-    this.urls = this.generateURLs(cozyUrl)
+    this.urls = this.constructor.generateURLs(cozyUrl)
 
     const tGlobal = (key, data) => this.t('Notifications.email.' + key, data)
     Handlebars.registerHelper({ tGlobal })

--- a/src/ducks/notifications/Notification.spec.js
+++ b/src/ducks/notifications/Notification.spec.js
@@ -1,0 +1,15 @@
+import Notification from './Notification'
+
+describe('Notification', () => {
+  it('should instantiate correctly', () => {
+    const config = {
+      t: () => {},
+      data: {},
+      cozyClient: { _url: 'http://cozy.tools' }
+    }
+
+    const notification = new Notification(config)
+
+    expect(notification).toBeDefined()
+  })
+})


### PR DESCRIPTION
We had a `this.generateURLs is not a function` error. Using the class name (`Notification`) fixes it.