### PR TITLE
Update raven-js to v3.27.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "number-to-locale-string": "1.2.0",
     "piwik-react-router": "0.8.2",
     "pouchdb-adapter-cordova-sqlite": "2.0.5",
-    "raven-js": "3.27.0",
+    "raven-js": "3.27.2",
     "raw-loader": "1.0.0",
     "react": "16.8.6",
     "react-chartjs-2": "2.7.4",

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -24,8 +24,8 @@ const getReporterConfiguration = cozyClient => {
       const { auth, data } = options
       const parameters = {
         ...auth,
-        ...{ project: data.project },
-        ...{ data: JSON.stringify(data) }
+        project: data.project,
+        data: JSON.stringify(data)
       }
       cozyClient.stackClient
         .fetchJSON('POST', '/remote/cc.cozycloud.sentry', parameters)

--- a/yarn.lock
+++ b/yarn.lock
@@ -15361,10 +15361,10 @@ range-parser@~1.2.1:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
 
-raven-js@3.27.0:
-  version "3.27.0"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.0.tgz#9f47c03e17933ce756e189f3669d49c441c1ba6e"
-  integrity sha512-vChdOL+yzecfnGA+B5EhEZkJ3kY3KlMzxEhShKh6Vdtooyl0yZfYNFQfYzgMf2v4pyQa+OTZ5esTxxgOOZDHqw==
+raven-js@3.27.2:
+  version "3.27.2"
+  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.27.2.tgz#6c33df952026cd73820aa999122b7b7737a66775"
+  integrity sha512-mFWQcXnhRFEQe5HeFroPaEghlnqy7F5E2J3Fsab189ondqUzcjwSVi7el7F36cr6PvQYXoZ1P2F5CSF2/azeMQ==
 
 raven-js@^3.1.1:
   version "3.26.2"


### PR DESCRIPTION
This is not the reason why communication with sentry failed (see https://github.com/cozy/cozy-doctypes/pull/92 for that), but this way we use the latest raven-js version. We must keep in mind that this SDK is now deprecated and only receives bugfixes.