### PR TITLE
Add late health reimbursement notification UI

### DIFF
--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -68,6 +68,7 @@ class Configuration extends React.Component {
             enabled={settings.notifications.balanceLower.enabled}
             value={settings.notifications.balanceLower.value}
             name="balanceLower"
+            unit="€"
           />
           <ToggleRow
             title={t('Notifications.if_transaction_greater.settingTitle')}
@@ -79,6 +80,7 @@ class Configuration extends React.Component {
             enabled={settings.notifications.transactionGreater.enabled}
             value={settings.notifications.transactionGreater.value}
             name="transactionGreater"
+            unit="€"
           />
           <ToggleRow
             title={t('Notifications.when_health_bill_linked.settingTitle')}
@@ -101,6 +103,7 @@ class Configuration extends React.Component {
             enabled={settings.notifications.lateHealthReimbursement.enabled}
             value={settings.notifications.lateHealthReimbursement.value}
             name="lateHealthReimbursement"
+            unit={t('Notifications.when_late_health_reimbursement.unit')}
           />
         </TogglePane>
         <TogglePane>

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -89,22 +89,24 @@ class Configuration extends React.Component {
             enabled={settings.notifications.healthBillLinked.enabled}
             name="healthBillLinked"
           />
-          <ToggleRow
-            title={t(
-              'Notifications.when_late_health_reimbursement.settingTitle'
-            )}
-            description={t(
-              'Notifications.when_late_health_reimbursement.description'
-            )}
-            onToggle={this.onToggle('notifications.lateHealthReimbursement')}
-            onChangeValue={this.onChangeValue(
-              'notifications.lateHealthReimbursement'
-            )}
-            enabled={settings.notifications.lateHealthReimbursement.enabled}
-            value={settings.notifications.lateHealthReimbursement.value}
-            name="lateHealthReimbursement"
-            unit={t('Notifications.when_late_health_reimbursement.unit')}
-          />
+          {flag('late-health-reibursement-notification') && (
+            <ToggleRow
+              title={t(
+                'Notifications.when_late_health_reimbursement.settingTitle'
+              )}
+              description={t(
+                'Notifications.when_late_health_reimbursement.description'
+              )}
+              onToggle={this.onToggle('notifications.lateHealthReimbursement')}
+              onChangeValue={this.onChangeValue(
+                'notifications.lateHealthReimbursement'
+              )}
+              enabled={settings.notifications.lateHealthReimbursement.enabled}
+              value={settings.notifications.lateHealthReimbursement.value}
+              name="lateHealthReimbursement"
+              unit={t('Notifications.when_late_health_reimbursement.unit')}
+            />
+          )}
         </TogglePane>
         <TogglePane>
           <TogglePaneTitle>

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -37,6 +37,9 @@ class Configuration extends React.Component {
     flag(key, checked)
   }
 
+  // TODO the displayed value and the persisted value should not be the same.
+  // If the user empties the input, we may persist `0`, but we don't want to
+  // show `0` until he blurs the input
   onChangeValue = key => value => {
     const { settingsCollection } = this.props
     const settings = getDefaultedSettingsFromCollection(settingsCollection)

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -87,6 +87,21 @@ class Configuration extends React.Component {
             enabled={settings.notifications.healthBillLinked.enabled}
             name="healthBillLinked"
           />
+          <ToggleRow
+            title={t(
+              'Notifications.when_late_health_reimbursement.settingTitle'
+            )}
+            description={t(
+              'Notifications.when_late_health_reimbursement.description'
+            )}
+            onToggle={this.onToggle('notifications.lateHealthReimbursement')}
+            onChangeValue={this.onChangeValue(
+              'notifications.lateHealthReimbursement'
+            )}
+            enabled={settings.notifications.lateHealthReimbursement.enabled}
+            value={settings.notifications.lateHealthReimbursement.value}
+            name="lateHealthReimbursement"
+          />
         </TogglePane>
         <TogglePane>
           <TogglePaneTitle>

--- a/src/ducks/settings/ToggleRow.jsx
+++ b/src/ducks/settings/ToggleRow.jsx
@@ -5,7 +5,8 @@ import Toggle from 'cozy-ui/react/Toggle'
 import styles from 'ducks/settings/ToggleRow.styl'
 
 const parseNumber = val => {
-  return parseInt(val.replace(/\D/i, ''), 10)
+  val = val.replace(/\D/gi, '') || 0
+  return parseInt(val, 10)
 }
 
 class ToggleRow extends Component {

--- a/src/ducks/settings/ToggleRow.jsx
+++ b/src/ducks/settings/ToggleRow.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import cx from 'classnames'
 import Toggle from 'cozy-ui/react/Toggle'
 import styles from 'ducks/settings/ToggleRow.styl'
 
@@ -31,17 +30,17 @@ class ToggleRow extends Component {
           <p className={styles.ToggleRow__description}>
             <span dangerouslySetInnerHTML={{ __html: description }} />
             {hasValue && (
-              <input
-                type="number"
-                onChange={e => onChangeValue(parseNumber(e.target.value))}
-                value={value}
-                className={cx(
-                  styles.ToggleRow__input,
-                  styles['ToggleRow__input--suffixed']
-                )}
-              />
+              <span className={styles.ToggleRow__input}>
+                <span className={styles.ToggleRow__inputContainer}>
+                  <input
+                    type="text"
+                    onChange={e => onChangeValue(parseNumber(e.target.value))}
+                    value={value}
+                  />
+                </span>
+                {unit && <span>{unit}</span>}
+              </span>
             )}
-            {hasValue && unit && <span>{unit}</span>}
           </p>
 
           <div className={styles.ToggleRow__toggle}>

--- a/src/ducks/settings/ToggleRow.jsx
+++ b/src/ducks/settings/ToggleRow.jsx
@@ -17,7 +17,8 @@ class ToggleRow extends Component {
       description,
       onChangeValue,
       name,
-      onToggle
+      onToggle,
+      unit
     } = this.props
 
     const hasValue = value !== undefined
@@ -39,7 +40,7 @@ class ToggleRow extends Component {
                 )}
               />
             )}
-            {hasValue && <span>€</span>}
+            {hasValue && unit && <span>{unit}</span>}
           </p>
 
           <div className={styles.ToggleRow__toggle}>
@@ -62,7 +63,8 @@ ToggleRow.propTypes = {
   description: PropTypes.string.isRequired,
   onChangeValue: PropTypes.func,
   name: PropTypes.string.isRequired,
-  onToggle: PropTypes.func.isRequired
+  onToggle: PropTypes.func.isRequired,
+  unit: PropTypes.string
 }
 
 export default ToggleRow

--- a/src/ducks/settings/ToggleRow.styl
+++ b/src/ducks/settings/ToggleRow.styl
@@ -22,25 +22,34 @@ h5
     margin 0
     font-size .9em
 
-input[type='text'].ToggleRow__input,
-input[type='number'].ToggleRow__input
-    padding .5em .3em
+.ToggleRow__input
+    display inline-flex
     margin 0 5px
     width 4.5em
+    padding .5em .3em
+    align-items center
+    border 1px solid var(--silver)
 
-    &.ToggleRow__input--suffixed::-webkit-inner-spin-button
-    &.ToggleRow__input--suffixed::-webkit-outer-spin-button
+    input[type='text'],
+    input[type='number']
+        box-sizing border-box
+        width 100%
+        border 0
+        background-color var(--white)
+        color var(--black)
+        -moz-appearance textfield
+
+    ::-webkit-inner-spin-button,
+    ::-webkit-outer-spin-button
         -webkit-appearance none
 
-    &::-webkit-contacts-auto-fill-button
-        visibility     hidden
-        display        none
+    ::-webkit-contacts-auto-fill-button
+        visibility hidden
+        display none
         pointer-events none
 
-    &.ToggleRow__input--suffixed + span
-        position absolute
-        margin-left -1.5em
-        margin-top .6em
+.ToggleRow__inputContainer
+    flex-basis 100%
 
 .ToggleRow__toggle span
     vertical-align middle

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -30,6 +30,10 @@ Object {
       "enabled": false,
     },
     "lastSeq": 0,
+    "lateHealthReimbursement": Object {
+      "enabled": true,
+      "value": 30,
+    },
     "mensuel": Object {
       "enabled": false,
     },

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -16,6 +16,10 @@ export const DEFAULTS_SETTINGS = {
     healthBillLinked: {
       enabled: true
     },
+    lateHealthReimbursement: {
+      value: 30,
+      enabled: true
+    },
     salaire: {
       enabled: false
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -430,7 +430,8 @@
     },
     "when_late_health_reimbursement": {
       "settingTitle": "Late health reimbursement",
-      "description": "You will be notified when a health reimbursement is pending for more than"
+      "description": "You will be notified when a health reimbursement is pending for more than",
+      "unit": "d"
     },
     "email": {
       "settings": "Settings",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -431,7 +431,7 @@
     "when_late_health_reimbursement": {
       "settingTitle": "Late health reimbursement",
       "description": "You will be notified when a health reimbursement is pending for more than",
-      "unit": "d"
+      "unit": "days"
     },
     "email": {
       "settings": "Settings",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -428,6 +428,10 @@
         }
       }
     },
+    "when_late_health_reimbursement": {
+      "settingTitle": "Late health reimbursement",
+      "description": "You will be notified when a health reimbursement is pending for more than"
+    },
     "email": {
       "settings": "Settings",
       "support": "Help and support"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -442,7 +442,8 @@
     },
     "when_late_health_reimbursement": {
       "settingTitle": "Remboursement de santé en retard",
-      "description": "Vous recevrez une notification lorsqu'un remboursement de santé est en attente depuis plus de"
+      "description": "Vous recevrez une notification lorsqu'un remboursement de santé est en attente depuis plus de",
+      "unit": "j"
     },
     "email": {
       "settings": "Paramètres",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -443,7 +443,7 @@
     "when_late_health_reimbursement": {
       "settingTitle": "Remboursement de santé en retard",
       "description": "Vous recevrez une notification lorsqu'un remboursement de santé est en attente depuis plus de",
-      "unit": "j"
+      "unit": "jours"
     },
     "email": {
       "settings": "Paramètres",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -440,6 +440,10 @@
         }
       }
     },
+    "when_late_health_reimbursement": {
+      "settingTitle": "Remboursement de santé en retard",
+      "description": "Vous recevrez une notification lorsqu'un remboursement de santé est en attente depuis plus de"
+    },
     "email": {
       "settings": "Paramètres",
       "support": "Aide et support"


### PR DESCRIPTION
This is a first step of the implementation of the new health reimbursement notification: the UI. The toggle is hidden behind the `late-health-reimbursement-notification` flag.

![image](https://user-images.githubusercontent.com/1606068/59343165-85c5cc00-8d0b-11e9-818a-d055defe050e.png)

