### PR TITLE
feat(brands): Update amazon regexp

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -6,7 +6,7 @@ Array [
     "isInstalled": false,
     "konnectorSlug": "amazon",
     "name": "Amazon",
-    "regexp": "\\\\bamazon\\\\b",
+    "regexp": "\\\\bamazo?n\\\\b",
   },
   Object {
     "health": true,
@@ -463,7 +463,7 @@ Array [
     "isInstalled": false,
     "konnectorSlug": "amazon",
     "name": "Amazon",
-    "regexp": "\\\\bamazon\\\\b",
+    "regexp": "\\\\bamazo?n\\\\b",
   },
   Object {
     "isInstalled": false,

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "Amazon",
-    "regexp": "\\bamazon\\b",
+    "regexp": "\\bamazo?n\\b",
     "konnectorSlug": "amazon"
   },
   {


### PR DESCRIPTION
Some amazon bank transaction label includes the string `amazn` instead
of `amazon`. Setting the `o` to be optional matches these cases.