### PR TITLE
Use late health reimbursement notification value to show status

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -23,6 +23,10 @@ const ReactHint = ReactHintFactory(React)
 const App = props => {
   const settings = getDefaultedSettingsFromCollection(props.settingsCollection)
   flag('local-model-override', settings.community.localModelOverride.enabled)
+  flag(
+    'late-health-reimbursement-limit',
+    settings.notifications.lateHealthReimbursement.value
+  )
 
   return (
     <Layout>

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -185,7 +185,10 @@ export const isReimbursementLate = transaction => {
   const transactionDate = parseDate(getDate(transaction))
   const today = new Date()
 
-  return differenceInDays(today, transactionDate) > 30
+  return (
+    differenceInDays(today, transactionDate) >
+    flag('late-health-reimbursement-limit')
+  )
 }
 
 export const hasPendingReimbursement = transaction => {

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -3,7 +3,7 @@ import findLast from 'lodash/findLast'
 import get from 'lodash/get'
 import sumBy from 'lodash/sumBy'
 import flag from 'cozy-flags'
-import { differenceInMonths, parse as parseDate } from 'date-fns'
+import { differenceInDays, parse as parseDate } from 'date-fns'
 import { isHealthExpense } from 'ducks/categories/helpers'
 
 const prevRecurRx = /\bPRLV SEPA RECU RCUR\b/
@@ -185,7 +185,7 @@ export const isReimbursementLate = transaction => {
   const transactionDate = parseDate(getDate(transaction))
   const today = new Date()
 
-  return differenceInMonths(today, transactionDate) >= 1
+  return differenceInDays(today, transactionDate) > 30
 }
 
 export const hasPendingReimbursement = transaction => {

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -12,6 +12,7 @@ import {
 } from './helpers'
 import { BILLS_DOCTYPE } from 'doctypes'
 import MockDate from 'mockdate'
+import flag from 'cozy-flags'
 
 const fakeCozyClient = {
   attachStore: () => {},
@@ -181,6 +182,10 @@ describe('getReimbursementStatus', () => {
 })
 
 describe('isReimbursementLate', () => {
+  beforeEach(() => {
+    flag('late-health-reimbursement-limit', 30)
+  })
+
   afterEach(() => {
     MockDate.reset()
   })


### PR DESCRIPTION
Before, we showed that a health reimbursement is late if it was pending for more than 1 month. Now, we want to use the late health reimbursement notification value instead of the hard coded `1 month`.

To do that, we need the setting. Since we don't want to fetch the settings everytime we want to show a reimbursement status, and we will need it in services too, we store the value in a flag just like we did for the local categorization model override setting.