### PR TITLE
chore: Remove unnecessary stuff from webpack

### DIFF
--- a/config/webpack.target.browser.js
+++ b/config/webpack.target.browser.js
@@ -10,9 +10,6 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, '../build')
   },
-  externals: {
-    'cozy-client-js': 'cozy'
-  },
   resolve: {
     extensions: ['.browser.js', '.browser.jsx']
   },

--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -33,10 +33,6 @@ module.exports = {
       __POUCH__: JSON.stringify(true)
     }),
     new webpack.ProvidePlugin({
-      PouchDB: 'pouchdb',
-      pouchdbFind: 'pouchdb-find',
-      pouchdbAdapterCordovaSqlite: 'pouchdb-adapter-cordova-sqlite',
-      'cozy.client': 'cozy-client-js/dist/cozy-client.js',
       'cozy.bar': `cozy-bar/dist/cozy-bar.mobile${production ? '.min' : ''}.js`
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
> j'ai l'impression qu'il y a des restes de cozy-client-js alors qu'on ne l'utilise plus (sauf via cozy-konnector-libs dans les services. On a encore a dépendance, et je vois aussi un 'cozy.client': 'cozy-client-js/dist/cozy-client.js dans la config webpack mobile

drazik ^