### PR TITLE
fix: UL bug on iOS

### DIFF
--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -9,7 +9,7 @@ import { protocol } from 'ducks/mobile/constants'
   deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)
   Since the json file is not downloaded, the device and the app don't know they have to 
   handle the universal link so we reached the registry (the server behind the universalink domain)
-  This server is pretty dump. If we reach it, it redirects the client to the fallback_url which is 
+  This server only does redirection. If we reach it, it redirects the client to the fallback_url which is 
   the web version of the app.
 
   But as we know that we are on the mobile app if we use this method, we add the custom_scheme to the 

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -8,7 +8,7 @@ import { protocol } from 'ducks/mobile/constants'
   We need to add a custom_scheme and custom_path search params in order to be able to 
   deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)
   Since the json file is not downloaded, the device and the app don't know they have to 
-  handle the universal link so we reached the registry (the server behind the universalink domain)
+  handle the universal link so we are redirected to the registry (the server behind the universalink domain)
   This server only does redirection. If we reach it, it redirects the client to the fallback_url which is 
   the web version of the app.
 

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -5,7 +5,7 @@ import { protocol } from 'ducks/mobile/constants'
 /**
   The redirect uri is by the stack to redirect the user loged from the app (OAuth Client)
   
-  We need to add a custome_scheme and custom_path search params in order to be able to 
+  We need to add a custom_scheme and custom_path search params in order to be able to 
   deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)
   Since the json file is not downloaded, the device and the app don't know they have to 
   handle the universal link so we reached the registry (the server behind the universalink domain)

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -1,10 +1,27 @@
-import { protocol } from 'ducks/mobile/constants'
-
 import { getUniversalLinkDomain } from 'cozy-ui/transpiled/react/AppLinker'
 import { isAndroidApp } from 'cozy-device-helper'
+import { protocol } from 'ducks/mobile/constants'
 
+/**
+  The redirect uri is by the stack to redirect the user loged from the app (OAuth Client)
+  
+  We need to add a custome_scheme and custom_path search params in order to be able to 
+  deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)
+  Since the json file is not downloaded, the device and the app don't know they have to 
+  handle the universal link so we reached the registry (the server behind the universalink domain)
+  This server is pretty dump. If we reach it, it redirects the client to the fallback_url which is 
+  the web version of the app.
+
+  But as we know that we are on the mobile app if we use this method, we add the custom_scheme to the 
+  request. Like that, if we reach the server, it can check if the url has the custom_scheme params and 
+  instead of redirecting to the web version of the app, redirect to this attribute
+*/
 export const getRedirectUri = appSlug => {
+  const redirectedPath = 'auth'
   return isAndroidApp()
-    ? protocol + 'auth'
-    : getUniversalLinkDomain() + '/' + appSlug + '/auth'
+    ? protocol + redirectedPath
+    : getUniversalLinkDomain() +
+        '/' +
+        appSlug +
+        `/${redirectedPath}?custom_scheme=${protocol}&custom_path=${redirectedPath}`
 }

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -3,7 +3,7 @@ import { isAndroidApp } from 'cozy-device-helper'
 import { protocol } from 'ducks/mobile/constants'
 
 /**
-  The redirect_uri is neeeded by the stack to redirect the user logged from the app (OAuth Client)
+  The redirect_uri is needed by the stack to redirect the user logged from the app (OAuth Client)
   
   We need to add a custom_scheme and custom_path search params in order to be able to 
   deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -14,7 +14,7 @@ import { protocol } from 'ducks/mobile/constants'
 
   But as we know that we are on the mobile app if we use this method, we add the custom_scheme to the 
   request. This way, if we reach the server, it can check if the url has the custom_scheme params and 
-  instead of redirecting to the web version of the app, redirect to this attribute
+  instead of redirecting to the web version of the app, redirect to the native app via the custom scheme.
 */
 export const getRedirectUri = appSlug => {
   const redirectedPath = 'auth'

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -13,7 +13,7 @@ import { protocol } from 'ducks/mobile/constants'
   the web version of the app.
 
   But as we know that we are on the mobile app if we use this method, we add the custom_scheme to the 
-  request. Like that, if we reach the server, it can check if the url has the custom_scheme params and 
+  request. This way, if we reach the server, it can check if the url has the custom_scheme params and 
   instead of redirecting to the web version of the app, redirect to this attribute
 */
 export const getRedirectUri = appSlug => {

--- a/src/ducks/client/mobile/redirect.js
+++ b/src/ducks/client/mobile/redirect.js
@@ -3,7 +3,7 @@ import { isAndroidApp } from 'cozy-device-helper'
 import { protocol } from 'ducks/mobile/constants'
 
 /**
-  The redirect uri is by the stack to redirect the user loged from the app (OAuth Client)
+  The redirect_uri is neeeded by the stack to redirect the user logged from the app (OAuth Client)
   
   We need to add a custom_scheme and custom_path search params in order to be able to 
   deal with an iOS bug during apple-app-site json file retrieving. (https://openradar.appspot.com/33893852)


### PR DESCRIPTION
Sometimes the iOS app can not retrieve the remote json apple app site validation. In this case the user can not login. 

We add a new fallback attribute only when login on mobile device to resolve this issue. 