### PR TITLE
feat(notifications): Enable late reimb notif flag by default

### DIFF
--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -43,4 +43,7 @@ flag('transaction-history', true)
 // Turn on reimbursement tags + new CTAs UI
 flag('reimbursement-tag', true)
 
+// Turn on late health reimbursement notification
+flag('late-health-reibursement-notification', true)
+
 window.flag = flag


### PR DESCRIPTION
The user has access to the setting to enable the late health reimbursement notification by default.