### PR TITLE
fix: Issue with keyboard on iOS during login

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -12,7 +12,7 @@
   <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#16B52D">
   <% } %>
   <meta name="theme-color" content="#ffffff">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
   <% if (__TARGET__ === 'mobile') { %>
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -105,6 +105,7 @@
     </plugin>
     <plugin name="cordova-blur-app-privacy-screen" spec="https://github.com/lifeofcoding/cordova-blur-app-privacy-screen.git" />
     <engine name="ios" spec="4.5.5" />
-    <plugin name="cordova-universal-links-plugin" spec="https://github.com/Mailbutler/cordova-universal-links-plugin"/>
+    <plugin name="cordova-universal-links-plugin" spec="https://github.com/Mailbutler/cordova-universal-links-plugin" />
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
+    <plugin name="cordova-plugin-keyboard" spec="https://github.com/cozy/cordova-plugin-keyboard#4fa4850e6f0ea78e1e2ce573ccde5531a2353edb" />
 </widget>


### PR DESCRIPTION
We need to use our fork because we have a fix to handle correctly iOS 12. There is already a PR upstream (https://github.com/cjpearson/cordova-plugin-keyboard/pull/85). 

To work, we have to set the meta `viewport-fit=cover`. Without this attribute, the view-size is not well calculated and we have a wrong value. It makes the form not having the right size and having the footer displayed on the "input". 