### PR TITLE
fix: Transfers

### DIFF
--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -119,7 +119,13 @@ const transfers = {
 }
 
 const getAccountForBeneficiary = (beneficiary, accounts) => {
-  const account = accounts.find(acc => acc.iban === beneficiary.iban)
+  const account = accounts.find(acc => {
+    if (acc.iban) {
+      return acc.iban === beneficiary.iban
+    } else {
+      return beneficiary.iban.includes(acc.number)
+    }
+  })
   return account || null
 }
 

--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -585,6 +585,15 @@ class TransferPage extends React.Component {
     )
   }
 
+  componentDidUpdate() {
+    if (
+      this.props.recipients.hasMore &&
+      this.props.recipients.fetchStatus !== 'loading'
+    ) {
+      this.props.recipients.fetchMore()
+    }
+  }
+
   handleJobChange(job, unsubscribe) {
     if (job.state === 'done') {
       this.setState({ transferState: 'success' })


### PR DESCRIPTION
- Some accounts have no IBAN so they could not be matched with beneficiaries. We can use
account number instead of IBAN.

- We need to have all recipients, so we use fetch more to load them all.