### PR TITLE
Notifications debug

### DIFF
--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import Checkbox from 'cozy-ui/react/Checkbox'
+import Button from 'cozy-ui/react/Button'
+import Alerter from 'cozy-ui/react/Alerter'
 import { Title, SubTitle } from 'cozy-ui/react/Text'
 import flag, { FlagSwitcher } from 'cozy-flags'
 import { withClient } from 'cozy-client'
@@ -21,6 +23,30 @@ class DumbDebugSettings extends React.PureComponent {
     flag('account-loading', accountLoadingValue)
     if (accountLoadingValue) {
       flag('no-account', false)
+    }
+  }
+
+  async sendNotification() {
+    const { client } = this.props
+
+    try {
+      await client.stackClient.fetchJSON('POST', '/notifications', {
+        data: {
+          type: 'io.cozy.notifications',
+          attributes: {
+            category: 'transaction-greater',
+            title: 'Test notification',
+            message: 'This is a test notification message',
+            preferred_channels: ['mail', 'mobile'],
+            content: 'This is a test notification text content',
+            content_html: 'This is a test notification HTML content'
+          }
+        }
+      })
+
+      Alerter.success('Notification sent')
+    } catch (err) {
+      Alerter.error('Failed to send notification: ' + err)
     }
   }
 
@@ -50,6 +76,9 @@ class DumbDebugSettings extends React.PureComponent {
             <p>{client.stackClient.oauthOptions.notification_device_token}</p>
           </>
         ) : null}
+        <Button onClick={() => this.sendNotification()}>
+          Send notification
+        </Button>
         <Title>Flags</Title>
         <FlagSwitcher.List />
       </div>

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import Checkbox from 'cozy-ui/react/Checkbox'
+import { Title, SubTitle } from 'cozy-ui/react/Text'
 import flag, { FlagSwitcher } from 'cozy-flags'
+import { withClient } from 'cozy-client'
+import { isMobileApp } from 'cozy-device-helper'
 
-class DebugSettings extends React.PureComponent {
+class DumbDebugSettings extends React.PureComponent {
   toggleNoAccount() {
     const noAccountValue = !flag('no-account')
 
@@ -25,8 +28,11 @@ class DebugSettings extends React.PureComponent {
     const noAccountChecked = !!flag('no-account')
     const accountLoadingChecked = !!flag('account-loading')
 
+    const { client } = this.props
+
     return (
       <div>
+        <Title>Misc</Title>
         <Checkbox
           defaultChecked={noAccountChecked}
           label="Display no account page"
@@ -37,10 +43,19 @@ class DebugSettings extends React.PureComponent {
           label="Display accounts loading"
           onClick={this.toggleAccountsLoading}
         />
+        <Title>Notifications</Title>
+        {isMobileApp() ? (
+          <>
+            <SubTitle>Device token</SubTitle>
+            <p>{client.stackClient.oauthOptions.notification_device_token}</p>
+          </>
+        ) : null}
+        <Title>Flags</Title>
         <FlagSwitcher.List />
       </div>
     )
   }
 }
 
+const DebugSettings = withClient(DumbDebugSettings)
 export default DebugSettings


### PR DESCRIPTION
This adds two things in the settings debug panel:

* Show the device token so we can grab it and use it to send a test notification directly from Firebase UI
* Show a « send notification » button that asks the stack to send a dummy notification when we press it. This is not working on mobile app for now. The backformers will have a look at it asap