### PR TITLE
fix(actions): Put reimbursement status last

### DIFF
--- a/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/index.js
@@ -105,6 +105,7 @@ class ReimbursementStatusAction extends React.PureComponent {
 const action = {
   name: 'ReimbursementStatus',
   match: transaction => {
+    // TODO match only if the component is going to render something
     return isExpense(transaction) && flag('reimbursement-tag')
   },
   Component: compose(

--- a/src/ducks/transactions/actions/index.js
+++ b/src/ducks/transactions/actions/index.js
@@ -19,12 +19,12 @@ const actions = {
   HealthLinkAction: HealthLinkAction,
   BillAction: BillAction,
   KonnectorAction: KonnectorAction,
-  ReimbursementStatusAction,
   UrlLinkAction: UrlLinkAction,
   AppLinkAction: AppLinkAction,
   AttachAction: AttachAction,
   CommentAction: CommentAction,
-  AlertAction: AlertAction
+  AlertAction: AlertAction,
+  ReimbursementStatusAction
 }
 
 export const findMatchingActions = async (transaction, actionProps) => {


### PR DESCRIPTION
ReimbursementStatusAction can match but render nothing. By putting it at
the latest position, we ensure that it doesn't prevent another action
from rendering.

This could be fixed in a better way, but there is a demo need for today.