### PR TITLE
feat: Large account icon for password

### DIFF
--- a/src/components/AccountIcon/index.jsx
+++ b/src/components/AccountIcon/index.jsx
@@ -2,15 +2,20 @@ import React from 'react'
 import KonnectorIcon from 'ducks/balance/components/KonnectorIcon'
 import { getAccountInstitutionSlug } from 'ducks/account/helpers'
 import styles from './styles.styl'
+import cx from 'classnames'
 
 /** Displays a konnector icon for an io.cozy.bank.accounts */
-const _AccountIcon = ({ account, className }) => {
+const _AccountIcon = ({ account, className, size }) => {
   const institutionSlug = getAccountInstitutionSlug(account)
   if (!institutionSlug) {
     return null
   }
   return (
-    <span className={styles.AccountIconContainer}>
+    <span
+      className={cx(styles.AccountIconContainer, {
+        [styles['AccountIconContainer--large']]: size === 'large'
+      })}
+    >
       <KonnectorIcon slug={institutionSlug} className={className} />
     </span>
   )

--- a/src/components/AccountIcon/styles.styl
+++ b/src/components/AccountIcon/styles.styl
@@ -2,3 +2,7 @@
     display inline-block
     width 24px
     height 24px
+
+.AccountIconContainer--large
+    width 4rem
+    height 4rem

--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -466,7 +466,7 @@ const _Password = ({
       {active && <PageTitle>{t('Transfer.password.page-title')}</PageTitle>}
       <Title>{t('Transfer.password.title')}</Title>
       <p className="u-ta-center">
-        <AccountIcon account={senderAccount} />
+        <AccountIcon account={senderAccount} size="large" />
       </p>
       <p>
         <Field


### PR DESCRIPTION
Needed to have a larger icon on password slide. Added a size prop
to AccountIcon