### PR TITLE
fix: Add connectors to "maintenance"

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -37,6 +37,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "autolib",
+    "maintenance": true,
     "name": "Autolib",
     "regexp": "\\\\bautolib\\\\b",
   },
@@ -49,6 +50,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "bookingdotcom",
+    "maintenance": true,
     "name": "Booking.com",
     "regexp": "\\\\bbooking.com\\\\b",
   },
@@ -91,6 +93,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "cultura",
+    "maintenance": true,
     "name": "Cultura",
     "regexp": "\\\\bcultura\\\\b",
   },
@@ -104,12 +107,14 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "deezer",
+    "maintenance": true,
     "name": "Deezer",
     "regexp": "\\\\bdeezer\\\\b",
   },
   Object {
     "isInstalled": false,
     "konnectorSlug": "deliveroo",
+    "maintenance": true,
     "name": "Deliveroo",
     "regexp": "\\\\bdeliveroo\\\\b",
   },
@@ -133,6 +138,13 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "electricitestrasbourg",
+    "maintenance": true,
+    "name": "Electricité de Strabourg",
+    "regexp": "es energies strasbourg\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "enercoop",
     "name": "Enercoop",
     "regexp": "\\\\benercoop\\\\b",
@@ -140,6 +152,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "engie",
+    "maintenance": true,
     "name": "Engie",
     "regexp": "\\\\bengie\\\\b",
   },
@@ -214,6 +227,13 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "ldlc",
+    "maintenance": true,
+    "name": "LDLC",
+    "regexp": "\\\\bldlc\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "mondediplo",
     "name": "Le Monde Diplomatique",
     "regexp": "\\\\bmonde-diplomatique\\\\b",
@@ -221,6 +241,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "leclercdrive",
+    "maintenance": true,
     "name": "Leclerc Drive",
     "regexp": "\\\\bleclerc\\\\b",
   },
@@ -235,6 +256,13 @@ Array [
     "konnectorSlug": "maifecheancier",
     "name": "Maif - Echeancier",
     "regexp": "\\\\bmaif\\\\b",
+  },
+  Object {
+    "isInstalled": false,
+    "konnectorSlug": "macif",
+    "maintenance": true,
+    "name": "Macif",
+    "regexp": "\\\\bmacif\\\\b",
   },
   Object {
     "health": true,
@@ -409,6 +437,7 @@ Array [
   Object {
     "isInstalled": true,
     "konnectorSlug": "zalando",
+    "maintenance": true,
     "name": "Zalando",
     "regexp": "\\\\bzalando\\\\b",
   },
@@ -451,6 +480,7 @@ Array [
   Object {
     "isInstalled": true,
     "konnectorSlug": "zalando",
+    "maintenance": true,
     "name": "Zalando",
     "regexp": "\\\\bzalando\\\\b",
   },
@@ -487,6 +517,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "autolib",
+    "maintenance": true,
     "name": "Autolib",
     "regexp": "\\\\bautolib\\\\b",
   },
@@ -499,6 +530,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "bookingdotcom",
+    "maintenance": true,
     "name": "Booking.com",
     "regexp": "\\\\bbooking.com\\\\b",
   },
@@ -535,6 +567,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "cultura",
+    "maintenance": true,
     "name": "Cultura",
     "regexp": "\\\\bcultura\\\\b",
   },
@@ -548,12 +581,14 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "deezer",
+    "maintenance": true,
     "name": "Deezer",
     "regexp": "\\\\bdeezer\\\\b",
   },
   Object {
     "isInstalled": false,
     "konnectorSlug": "deliveroo",
+    "maintenance": true,
     "name": "Deliveroo",
     "regexp": "\\\\bdeliveroo\\\\b",
   },
@@ -577,6 +612,13 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "electricitestrasbourg",
+    "maintenance": true,
+    "name": "Electricité de Strabourg",
+    "regexp": "es energies strasbourg\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "enercoop",
     "name": "Enercoop",
     "regexp": "\\\\benercoop\\\\b",
@@ -584,6 +626,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "engie",
+    "maintenance": true,
     "name": "Engie",
     "regexp": "\\\\bengie\\\\b",
   },
@@ -658,6 +701,13 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "ldlc",
+    "maintenance": true,
+    "name": "LDLC",
+    "regexp": "\\\\bldlc\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "mondediplo",
     "name": "Le Monde Diplomatique",
     "regexp": "\\\\bmonde-diplomatique\\\\b",
@@ -665,6 +715,7 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "leclercdrive",
+    "maintenance": true,
     "name": "Leclerc Drive",
     "regexp": "\\\\bleclerc\\\\b",
   },
@@ -679,6 +730,13 @@ Array [
     "konnectorSlug": "maifecheancier",
     "name": "Maif - Echeancier",
     "regexp": "\\\\bmaif\\\\b",
+  },
+  Object {
+    "isInstalled": false,
+    "konnectorSlug": "macif",
+    "maintenance": true,
+    "name": "Macif",
+    "regexp": "\\\\bmacif\\\\b",
   },
   Object {
     "health": true,

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -29,7 +29,8 @@
   {
     "name": "Autolib",
     "regexp": "\\bautolib\\b",
-    "konnectorSlug": "autolib"
+    "konnectorSlug": "autolib",
+    "maintenance": true
   },
   {
     "name": "Bipandgo",
@@ -114,7 +115,8 @@
   {
     "name": "Electricité de Strabourg",
     "regexp": "es energies strasbourg\\b",
-    "konnectorSlug": "electricitestrasbourg"
+    "konnectorSlug": "electricitestrasbourg",
+    "maintenance": true
   },
   {
     "name": "Enercoop",
@@ -188,7 +190,8 @@
   {
     "name": "LDLC",
     "regexp": "\\bldlc\\b",
-    "konnectorSlug": "ldlc"
+    "konnectorSlug": "ldlc",
+    "maintenance": true
   },
   {
     "name": "Le Monde Diplomatique",
@@ -214,7 +217,8 @@
   {
     "name": "Macif",
     "regexp": "\\bmacif\\b",
-    "konnectorSlug": "macif"
+    "konnectorSlug": "macif",
+    "maintenance": true
   },
   {
     "name": "Malakoff Mederic",

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -39,7 +39,8 @@
   {
     "name": "Booking.com",
     "regexp": "\\bbooking.com\\b",
-    "konnectorSlug": "bookingdotcom"
+    "konnectorSlug": "bookingdotcom",
+    "maintenance": true
   },
   {
     "name": "Boulanger",
@@ -74,7 +75,8 @@
   {
     "name": "Cultura",
     "regexp": "\\bcultura\\b",
-    "konnectorSlug": "cultura"
+    "konnectorSlug": "cultura",
+    "maintenance": true
   },
   {
     "name": "Darty",
@@ -85,12 +87,14 @@
   {
     "name": "Deezer",
     "regexp": "\\bdeezer\\b",
-    "konnectorSlug": "deezer"
+    "konnectorSlug": "deezer",
+    "maintenance": true
   },
   {
     "name": "Deliveroo",
     "regexp": "\\bdeliveroo\\b",
-    "konnectorSlug": "deliveroo"
+    "konnectorSlug": "deliveroo",
+    "maintenance": true
   },
   {
     "name": "Direct Energie",
@@ -108,6 +112,11 @@
     "konnectorSlug": "ekwateur"
   },
   {
+    "name": "Electricité de Strabourg",
+    "regexp": "es energies strasbourg\\b",
+    "konnectorSlug": "electricitestrasbourg"
+  },
+  {
     "name": "Enercoop",
     "regexp": "\\benercoop\\b",
     "konnectorSlug": "enercoop"
@@ -115,7 +124,8 @@
   {
     "name": "Engie",
     "regexp": "\\bengie\\b",
-    "konnectorSlug": "engie"
+    "konnectorSlug": "engie",
+    "maintenance": true
   },
   {
     "name": "Ensap",
@@ -176,6 +186,11 @@
     "konnectorSlug": "lamutuellegenerale"
   },
   {
+    "name": "LDLC",
+    "regexp": "\\bldlc\\b",
+    "konnectorSlug": "ldlc"
+  },
+  {
     "name": "Le Monde Diplomatique",
     "regexp": "\\bmonde-diplomatique\\b",
     "konnectorSlug": "mondediplo"
@@ -183,7 +198,8 @@
   {
     "name": "Leclerc Drive",
     "regexp": "\\bleclerc\\b",
-    "konnectorSlug": "leclercdrive"
+    "konnectorSlug": "leclercdrive",
+    "maintenance": true
   },
   {
     "name": "Ma lentille",
@@ -194,6 +210,11 @@
     "name": "Maif - Echeancier",
     "regexp": "\\bmaif\\b",
     "konnectorSlug": "maifecheancier"
+  },
+  {
+    "name": "Macif",
+    "regexp": "\\bmacif\\b",
+    "konnectorSlug": "macif"
   },
   {
     "name": "Malakoff Mederic",
@@ -340,7 +361,8 @@
   {
     "name": "Zalando",
     "regexp": "\\bzalando\\b",
-    "konnectorSlug": "zalando"
+    "konnectorSlug": "zalando",
+    "maintenance": true
   },
   {
     "name": "ZooPlus",


### PR DESCRIPTION
Added to maintenance : autolib, booking, cultura, deezer, deliveroo, engie, leclercdrive, zalando
Added : electricitestrasbourg, ldlc, macif