### PR TITLE
chore(deps): Remove yarn.lock

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,8 +207,7 @@
     "timezone": "1.0.22",
     "velocity-animate": "1.5.2",
     "webpack-bundle-analyzer": "3.3.2",
-    "whatwg-fetch": "3.0.0",
-    "yarn.lock": "0.0.1-security"
+    "whatwg-fetch": "3.0.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -20165,11 +20165,6 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yarn.lock@0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/yarn.lock/-/yarn.lock-0.0.1-security.tgz#8e7117924bfe916671b21f14212ba1bb49dfe0c7"
-  integrity sha512-ZRX6v5zGCJMI1T2aO+BQxJggy1vvorXEwonQhWXIC+brO7lkDB3zWelVNAti183ddH6FmJP8z4UDCJnJlioK4Q==
-
 yarnhook@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/yarnhook/-/yarnhook-0.4.0.tgz#767b22f4ad446553c6eb86090c326d6e32ad0fe2"


### PR DESCRIPTION
This dependency seems to have been added by mistake since it is only a
security holding package (see https://npmjs.org/yarn.lock).

Closes #1293.