### PR TITLE
fix: Remove keyboard plugin since it works on iOS 10 & 12 but not on 11

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -107,5 +107,4 @@
     <engine name="ios" spec="4.5.5" />
     <plugin name="cordova-universal-links-plugin" spec="https://github.com/Mailbutler/cordova-universal-links-plugin" />
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
-    <plugin name="cordova-plugin-keyboard" spec="https://github.com/cozy/cordova-plugin-keyboard#4fa4850e6f0ea78e1e2ce573ccde5531a2353edb" />
 </widget>


### PR DESCRIPTION
Actually the plugin works great on iOS 10 and iOS 12 but not on iOS 11. So removing it ATM. 