### PR TITLE
fix: Click on list radio was not working well

### DIFF
--- a/src/components/List/index.jsx
+++ b/src/components/List/index.jsx
@@ -5,8 +5,8 @@ import ListItemText from 'cozy-ui/react/ListItemText'
 import { Radio as UIRadio } from 'cozy-ui/react'
 import cx from 'classnames'
 
-export const Radio = props => {
-  return <UIRadio {...props} className={styles.Radio} />
+export const Radio = ({ className, ...props }) => {
+  return <UIRadio {...props} className={cx(styles.Radio, className)} />
 }
 
 const _List = props => {


### PR DESCRIPTION
Since I changed to use List.Radio instead of Radio, the classname
removing pointer-events on the children was not added to the element.