### PR TITLE
feat(DelayedDebitAlert): Use bank accounts relationships

### DIFF
--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "cozy-authentication": "1.14.0",
     "cozy-bar": "6.28.6",
     "cozy-ci": "0.2.0",
-    "cozy-client": "6.46.0",
+    "cozy-client": "6.48.0",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "1.7.2",
     "cozy-doctypes": "1.48.0",

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -120,7 +120,12 @@ export const schema = {
   bankAccounts: {
     doctype: ACCOUNT_DOCTYPE,
     attributes: {},
-    relationships: {}
+    relationships: {
+      checkingsAccount: {
+        type: 'has-one',
+        doctype: ACCOUNT_DOCTYPE
+      }
+    }
   },
   groups: {
     doctype: GROUP_DOCTYPE,

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -54,17 +54,17 @@ class Configuration extends React.Component {
     })
   }
 
-  onDelayedDebitAccountsAssociationChange = (index, association) => {
-    const { settingsCollection } = this.props
-    const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    set(
-      settings,
-      `notifications.delayedDebit.accountsAssociations[${index}]`,
-      association
-    )
-    this.saveDocument(settings, {
-      updateCollections: ['settings']
-    })
+  onDelayedDebitAccountsChange = async changes => {
+    if (
+      changes.previousCreditCard &&
+      changes.previousCreditCard !== changes.newCreditCard
+    ) {
+      changes.previousCreditCard.checkingsAccount.unset()
+      await this.saveDocument(changes.previousCreditCard)
+    }
+
+    changes.newCreditCard.checkingsAccount.set(changes.newCheckings)
+    await this.saveDocument(changes.newCreditCard)
   }
 
   render() {
@@ -99,9 +99,8 @@ class Configuration extends React.Component {
             <DelayedDebitAlert
               accounts={accounts}
               onToggle={this.onToggle('notifications.delayedDebit')}
-              onAccountsAssociationChange={
-                this.onDelayedDebitAccountsAssociationChange
-              }
+              onChangeValue={this.onChangeValue('notifications.delayedDebit')}
+              onAccountsChange={this.onDelayedDebitAccountsChange}
               {...settings.notifications.delayedDebit}
             />
           )}

--- a/src/ducks/settings/DelayedDebitAlert.styl
+++ b/src/ducks/settings/DelayedDebitAlert.styl
@@ -1,3 +1,8 @@
+.SelectBox
+    display inline-block
+    width 7rem
+    border-radius 0
+
 .AccountsAssociationSelect
     display flex
     align-items center

--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -24,8 +24,8 @@ Object {
       "value": 600,
     },
     "delayedDebit": Object {
-      "accountsAssociations": Array [],
       "enabled": false,
+      "value": 2,
     },
     "healthBillLinked": Object {
       "enabled": true,

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -22,7 +22,7 @@ export const DEFAULTS_SETTINGS = {
     },
     delayedDebit: {
       enabled: false,
-      accountsAssociations: []
+      value: 2
     },
     salaire: {
       enabled: false

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -456,10 +456,12 @@
     },
     "delayed_debit": {
       "settingTitle": "Delayed debit alert",
-      "description": "You will be notified when...",
-      "noCheckings": "You have no checkings account.",
-      "noCreditCard": "You have no credit card account.",
-      "noAccount": "You have no bank account."
+      "description": {
+        "start": "You will receive a notification when the outstanding card account ",
+        "accountsGlue": " generates a negative balance on its associated current account ",
+        "end": " before the end of the month"
+      },
+      "unit": "days"
     }
   },
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -467,11 +467,13 @@
       "support": "Aide et support"
     },
     "delayed_debit": {
-      "settingTitle": "Alerte de débit différé",
-      "description": "Vous recevrez une notification lorsque...",
-      "noCheckings": "Vous n'avez pas de compte courant.",
-      "noCreditCard": "Vous n'avez pas de compte de carte de crédit",
-      "noAccount": "Vous n'avez pas de compte bancaire."
+      "settingTitle": "Paiement de l'encours carte à débit différé",
+      "description": {
+        "start": "Vous recevrez une notification lorque l'encours carte du compte ",
+        "accountsGlue": " engendre un solde négatif sur son compte courant associé ",
+        "end": " avant la fin du mois"
+      },
+      "unit": "jours"
     }
   },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4929,13 +4929,13 @@ cozy-client-js@^0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@6.46.0:
-  version "6.46.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.46.0.tgz#2512541d65158e0c32e171eb7acbd1060475f46d"
-  integrity sha512-lmddGQ2LaHOB09Rq3q6/JVHBXQgYURmlTt5l6nGpAelZ5LBgEBEEqNQY4hgDajnVKEnGOlwgC58XcQ3d/6jvvg==
+cozy-client@6.48.0:
+  version "6.48.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.48.0.tgz#23bdf234b3837845d64912e9986a561b84cf0d67"
+  integrity sha512-HctMuTgOaWKL+xqH16Zy36AMTHAqg5k2BCWOuDDJbNGSluu2G52wt9Zpc9mUAkguemerwZ98jMMEfQXEcSiKdA==
   dependencies:
     cozy-device-helper "1.6.3"
-    cozy-stack-client "^6.46.0"
+    cozy-stack-client "^6.47.0"
     lodash "4.17.11"
     microee "0.0.6"
     prop-types "15.6.2"


### PR DESCRIPTION
Previously the delayed debit alert UI was using an object like `{ creditCardAccount: id, checkingsAccount: id  }` stored in `io.cozy.bank.settings`. But after thinking about what could happen when a user removes an account that is part of the associations, I thought this solution was not good enough because we would have to manually update the object everytime the user removes an account.

I think using a relationship on the account is better because it automatically handles bank accounts removal:

* If the credit card account is removed, then the relationship is also removed
* If the checkings account is removed, then the relationship is null

There are two remaining things to do:

* ~~Update cozy-client after https://github.com/cozy/cozy-client/pull/473 has been merged (we are using `HasOne::set` and `HasOne::unset` here)~~ (done in https://github.com/cozy/cozy-banks/pull/1335/commits/bb17d512df6fa2d744e9b68a3edd625a5e06dc47)
* Add tests

![image](https://user-images.githubusercontent.com/1606068/60276178-6a59e400-98fb-11e9-8443-9452bc2c5eb2.png)
