### PR TITLE
fix(BillChip): Render nothing if a bill has no invoice

### DIFF
--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -10,7 +10,7 @@ import FileIcon from 'ducks/transactions/actions/AttachedDocsAction/FileIcon'
 import { Figure } from 'components/Figure'
 import { AugmentedModalOpener } from 'components/AugmentedModal'
 
-class DumbBillChip extends React.PureComponent {
+export class DumbBillChip extends React.PureComponent {
   static propTypes = {
     bill: PropTypes.object.isRequired
   }
@@ -34,7 +34,15 @@ class DumbBillChip extends React.PureComponent {
 
   render() {
     const { bill, t } = this.props
-    const [, invoiceId] = this.getInvoiceId(bill)
+    let invoiceId
+
+    try {
+      invoiceId = this.getInvoiceId(bill)[1]
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.log(err)
+      return null
+    }
 
     const isVentePrivee = flag('demo') && bill.vendor === 'Vente Privée'
 

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.spec.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.spec.jsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { DumbBillChip } from './BillChip'
+import { shallow } from 'enzyme'
+
+describe('BillChip', () => {
+  it('should render nothing if the given bill has no invoice', () => {
+    const bill = { _id: 'fakebill' }
+
+    const t = key => key
+
+    expect(shallow(<DumbBillChip bill={bill} t={t} />).html()).toBe(null)
+  })
+})


### PR DESCRIPTION
When a bill has no invoice, it throws an error but we didn't catch it, so it was propagated until the error boundary. So the whole app crashed. Now we catch it and render nothing.