### PR TITLE
Handle app contacts in reimbursement status modal

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -266,6 +266,11 @@ Array [
         "number": "09 69 39 39 39",
         "type": "phone",
       },
+      Object {
+        "href": "https://play.google.com/store/apps/details?id=fr.lamutuellegenerale.mamutuelle",
+        "platform": "android",
+        "type": "app",
+      },
     ],
     "health": true,
     "isInstalled": false,
@@ -787,6 +792,11 @@ Array [
       Object {
         "number": "09 69 39 39 39",
         "type": "phone",
+      },
+      Object {
+        "href": "https://play.google.com/store/apps/details?id=fr.lamutuellegenerale.mamutuelle",
+        "platform": "android",
+        "type": "app",
       },
     ],
     "health": true,

--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -3,6 +3,30 @@
 exports[`brandDictionary getBrandsWithInstallationInfo Should return the list of brands with a isInstalled boolean property 1`] = `
 Array [
   Object {
+    "contact": Array [
+      Object {
+        "action": "sendCareSheet",
+        "href": "https://alan.eu/login",
+        "type": "web",
+      },
+      Object {
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=android",
+        "platform": "android",
+        "type": "app",
+      },
+      Object {
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=ios",
+        "platform": "ios",
+        "type": "app",
+      },
+    ],
+    "health": true,
+    "isInstalled": false,
+    "konnectorSlug": "alan",
+    "name": "Alan",
+    "regexp": "\\\\balan\\\\b",
+  },
+  Object {
     "isInstalled": false,
     "konnectorSlug": "amazon",
     "name": "Amazon",
@@ -525,6 +549,30 @@ Array [
 
 exports[`brandDictionary getInstalledBrands Should return the not installed brands 1`] = `
 Array [
+  Object {
+    "contact": Array [
+      Object {
+        "action": "sendCareSheet",
+        "href": "https://alan.eu/login",
+        "type": "web",
+      },
+      Object {
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=android",
+        "platform": "android",
+        "type": "app",
+      },
+      Object {
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=ios",
+        "platform": "ios",
+        "type": "app",
+      },
+    ],
+    "health": true,
+    "isInstalled": false,
+    "konnectorSlug": "alan",
+    "name": "Alan",
+    "regexp": "\\\\balan\\\\b",
+  },
   Object {
     "isInstalled": false,
     "konnectorSlug": "amazon",

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -1,5 +1,28 @@
 [
   {
+    "name": "Alan",
+    "regexp": "\\balan\\b",
+    "konnectorSlug": "alan",
+    "health": true,
+    "contact": [
+      {
+        "type": "web",
+        "href": "https://alan.eu/login",
+        "action": "sendCareSheet"
+      },
+      {
+        "type": "app",
+        "platform": "android",
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=android"
+      },
+      {
+        "type": "app",
+        "platform": "ios",
+        "href": "https://alan.eu/open-or-download-mobile-app?origin=alanweb_landing_footer&os=ios"
+      }
+    ]
+  },
+  {
     "name": "Amazon",
     "regexp": "\\bamazo?n\\b",
     "konnectorSlug": "amazon"

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -231,6 +231,11 @@
       {
         "type": "phone",
         "number": "09 69 39 39 39"
+      },
+      {
+        "type": "app",
+        "platform": "android",
+        "href": "https://play.google.com/store/apps/details?id=fr.lamutuellegenerale.mamutuelle"
       }
     ]
   },

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/Card.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/Card.jsx
@@ -6,6 +6,7 @@ import { Caption, Text } from 'cozy-ui/react/Text'
 import Icon, { iconPropType } from 'cozy-ui/react/Icon'
 import cx from 'classnames'
 import styles from 'ducks/transactions/actions/ReimbursementStatusAction/Card.styl'
+import { getPlatform } from 'cozy-device-helper'
 
 // TODO use icons from cozy-ui when https://github.com/cozy/cozy-ui/pull/983
 // has been merged
@@ -97,6 +98,38 @@ DumbWebCard.propTypes = {
 
 export const WebCard = translate()(DumbWebCard)
 
+export const DumbAppCard = props => {
+  const { contact, t, ...rest } = props
+
+  if (getPlatform() !== contact.platform) {
+    return null
+  }
+
+  return (
+    <Card
+      href={contact.href}
+      title={t('ReimbursementStatusModal.contact.openApp.title')}
+      caption={t('ReimbursementStatusModal.contact.openApp.caption')}
+      icon="phone"
+      target="_blank"
+      tag="a"
+      {...rest}
+    />
+  )
+}
+
+const appContactShape = PropTypes.shape({
+  platform: PropTypes.oneOf(['android', 'ios']).isRequired,
+  href: PropTypes.string.isRequired
+})
+
+DumbAppCard.propTypes = {
+  contact: appContactShape.isRequired,
+  t: PropTypes.func.isRequired
+}
+
+export const AppCard = translate()(DumbAppCard)
+
 export const ContactCard = props => {
   const { type, ...rest } = props
 
@@ -107,12 +140,15 @@ export const ContactCard = props => {
     case 'web':
       return <WebCard {...rest} />
 
+    case 'app':
+      return <AppCard {...rest} />
+
     default:
       return null
   }
 }
 
 ContactCard.propTypes = {
-  type: PropTypes.oneOf(['phone', 'web']).isRequired,
+  type: PropTypes.oneOf(['phone', 'web', 'app']).isRequired,
   contact: PropTypes.object.isRequired
 }

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/Card.spec.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/Card.spec.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
-import { DumbPhoneCard, DumbWebCard } from './Card'
+import { DumbPhoneCard, DumbWebCard, DumbAppCard } from './Card'
 import { mount } from 'enzyme'
+import { getPlatform } from 'cozy-device-helper'
+
+jest.mock('cozy-device-helper')
 
 const t = key => key
 
@@ -36,6 +39,25 @@ describe('DumbWebCard', () => {
 
     expect(
       mount(<DumbWebCard contact={contact} t={t} />).html()
+    ).toMatchSnapshot()
+  })
+})
+
+describe('DumbAppCard', () => {
+  it('should render nothing if the platform does not match with the current device', () => {
+    getPlatform.mockReturnValueOnce('ios')
+
+    const contact = { platform: 'android', href: 'http://some.thing' }
+
+    expect(mount(<DumbAppCard contact={contact} t={t} />).html()).toBe(null)
+  })
+
+  it('should render correctly if the platform matches with the current device', () => {
+    getPlatform.mockReturnValueOnce('ios')
+
+    const contact = { platform: 'ios', href: 'http://some.thing' }
+    expect(
+      mount(<DumbAppCard contact={contact} t={t} />).html()
     ).toMatchSnapshot()
   })
 })

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/Card.styl
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/Card.styl
@@ -1,3 +1,4 @@
 .Card
     display flex
     align-items center
+    background-color var(--white)

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { flowRight as compose } from 'lodash'
 import { translate, withBreakpoints } from 'cozy-ui/react'
-import Modal from 'cozy-ui/react/Modal'
+import Modal, { ModalContent } from 'cozy-ui/react/Modal'
 import Icon from 'cozy-ui/react/Icon'
 import { Title, Text } from 'cozy-ui/react/Text'
 import cx from 'classnames'
@@ -33,57 +33,63 @@ class _ReimbursementStatusModal extends React.PureComponent {
     return (
       <Modal
         mobileFullscreen
-        className={cx('u-flex', 'u-flex-column', 'u-pv-2', className)}
+        className={cx('u-flex', 'u-flex-column', className)}
         {...rest}
       >
-        <header className="u-ta-center">
-          <Icon icon={iconReimbursement} size={56} color="var(--slateGrey)" />
-          <Title className="u-mt-1">
-            {t('Transactions.actions.reimbursementStatus.modal.title')}
-          </Title>
-          <Text className={styles.ReimbursementStatusModal__transactionLabel}>
-            {getLabel(transaction)}
-          </Text>
-        </header>
-        <form className="u-mt-1">
-          <List border="vertical">
-            {choices.map(choice => (
-              <Row key={choice}>
-                <Radio
-                  key={choice}
-                  name="reimbursementStatus"
-                  value={choice}
-                  label={t(`Transactions.reimbursementStatus.${choice}`)}
-                  checked={status === choice}
-                  onChange={onChange}
-                  className={cx('u-mb-0', styles.Radio)}
-                />
-              </Row>
-            ))}
-          </List>
-        </form>
-        {showContacts ? (
-          <div
-            className={cx(styles.ReimbursementStatusModal__contact, 'u-pt-2', {
-              'u-mt-auto': isMobile
-            })}
-          >
-            {brands
-              .filter(
-                brand => brand.health && brand.hasTrigger && brand.contact
-              )
-              .map((brand, index) => (
-                <ContactItem
-                  brand={brand}
-                  key={brand.name}
-                  // TODO use stack layout when https://github.com/cozy/cozy-banks/pull/1312 has been merged (see https://github.com/cozy/cozy-banks/pull/1312/commits/2bc1d75a25fe2c61f219579ac56407e356997105 more particularly)
-                  className={cx({
-                    'u-mt-1-half': index !== 0
-                  })}
-                />
+        <ModalContent className="u-ph-0">
+          <header className="u-ta-center">
+            <Icon icon={iconReimbursement} size={56} color="var(--slateGrey)" />
+            <Title className="u-mt-1">
+              {t('Transactions.actions.reimbursementStatus.modal.title')}
+            </Title>
+            <Text className={styles.ReimbursementStatusModal__transactionLabel}>
+              {getLabel(transaction)}
+            </Text>
+          </header>
+          <form className="u-mt-1">
+            <List border="vertical">
+              {choices.map(choice => (
+                <Row key={choice}>
+                  <Radio
+                    key={choice}
+                    name="reimbursementStatus"
+                    value={choice}
+                    label={t(`Transactions.reimbursementStatus.${choice}`)}
+                    checked={status === choice}
+                    onChange={onChange}
+                    className={cx('u-mb-0', styles.Radio)}
+                  />
+                </Row>
               ))}
-          </div>
-        ) : null}
+            </List>
+          </form>
+          {showContacts ? (
+            <div
+              className={cx(
+                styles.ReimbursementStatusModal__contact,
+                'u-pt-2',
+                {
+                  'u-mt-auto': isMobile
+                }
+              )}
+            >
+              {brands
+                .filter(
+                  brand => brand.health && brand.hasTrigger && brand.contact
+                )
+                .map((brand, index) => (
+                  <ContactItem
+                    brand={brand}
+                    key={brand.name}
+                    // TODO use stack layout when https://github.com/cozy/cozy-banks/pull/1312 has been merged (see https://github.com/cozy/cozy-banks/pull/1312/commits/2bc1d75a25fe2c61f219579ac56407e356997105 more particularly)
+                    className={cx({
+                      'u-mt-1-half': index !== 0
+                    })}
+                  />
+                ))}
+            </div>
+          ) : null}
+        </ModalContent>
       </Modal>
     )
   }

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/__snapshots__/Card.spec.jsx.snap
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/__snapshots__/Card.spec.jsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DumbAppCard should render correctly if the platform matches with the current device 1`] = `"<a class=\\"c-card Card\\" href=\\"http://some.thing\\" target=\\"_blank\\"><svg class=\\"icon\\" style=\\"fill: var(--coolGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#phone\\"></use></svg><div class=\\"u-ml-1\\"><div class=\\"u-text\\">ReimbursementStatusModal.contact.openApp.title</div><div class=\\"u-caption\\">ReimbursementStatusModal.contact.openApp.caption</div></div></a>"`;
+
 exports[`DumbPhoneCard should render correctly with number and price 1`] = `"<a class=\\"c-card Card\\" href=\\"tel:01 23 45 67 89\\"><svg class=\\"icon\\" style=\\"fill: var(--coolGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#test-file-stub\\"></use></svg><div class=\\"u-ml-1\\"><div class=\\"u-text\\">01 23 45 67 89</div><div class=\\"u-caption\\">0,06€/minReimbursementStatusModal.contact.phoneCallPrice</div></div></a>"`;
 
 exports[`DumbPhoneCard should render correctly with only number 1`] = `"<a class=\\"c-card Card\\" href=\\"tel:01 23 45 67 89\\"><svg class=\\"icon\\" style=\\"fill: var(--coolGrey);\\" width=\\"16\\" height=\\"16\\"><use xlink:href=\\"#test-file-stub\\"></use></svg><div class=\\"u-ml-1\\"><div class=\\"u-text\\">01 23 45 67 89</div><div class=\\"u-caption\\">ReimbursementStatusModal.contact.phoneCallFree</div></div></a>"`;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -699,7 +699,11 @@
         "contactComplementary": "Contact my complementary"
       },
       "phoneCallPrice": " + call price",
-      "phoneCallFree": "Not surcharged call"
+      "phoneCallFree": "Not surcharged call",
+      "openApp": {
+        "title": "Open the application",
+        "caption": "On my phone"
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -654,7 +654,11 @@
         "contactComplementary": "Contacter ma complémentaire"
       },
       "phoneCallPrice": " + prix appel",
-      "phoneCallFree": "Appel non surtaxé"
+      "phoneCallFree": "Appel non surtaxé",
+      "openApp": {
+        "title": "Ouvrir l'application",
+        "caption": "Depuis mon téléphone"
+      }
     }
   }
 }


### PR DESCRIPTION
Brands contacts can include their mobile app. In that case, we check if the current platform matches the contact app platform to show a card or not. The card redirects the user to an URL that allows him to open the app.