### PR TITLE
fix(ReimbursementStatusAction): Card styles are applied on mobile app

### DIFF
--- a/src/ducks/transactions/actions/ReimbursementStatusAction/Card.styl
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/Card.styl
@@ -1,4 +1,4 @@
-.Card
+.Card.Card
     display flex
     align-items center
     background-color var(--white)


### PR DESCRIPTION
As usual, we need to double a selector so it's applied on the mobile app, where the cozy-bar's CSS is taking precedence over app's CSS. This issue will be fixed when the cozy-bar really bundles its own cozy-ui.