### PR TITLE
fix: Export dumb configuration component

### DIFF
--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -22,7 +22,7 @@ import ToggleRow, {
 } from 'ducks/settings/ToggleRow'
 import DelayedDebitAlert from 'ducks/settings/DelayedDebitAlert'
 
-class Configuration extends React.Component {
+export class Configuration extends React.Component {
   saveDocument = async doc => {
     const { saveDocument } = this.props
     await saveDocument(doc)


### PR DESCRIPTION
We need to export the "dumb" component to use the next override method.