### PR TITLE
feat(HealthReimbursements): Show store link if no health brands

### DIFF
--- a/src/ducks/brandDictionary/withBrands.jsx
+++ b/src/ducks/brandDictionary/withBrands.jsx
@@ -6,7 +6,7 @@ import { includes } from 'lodash'
 import { isCollectionLoading } from 'ducks/client/utils'
 import { getKonnectorFromTrigger } from 'utils/triggers'
 
-const withBrands = Wrapped => {
+const withBrands = (options = { queryName: 'triggers' }) => Wrapped => {
   class RawWithBrands extends Component {
     getInstalledKonnectorsSlugs() {
       const { triggers } = this.props
@@ -37,7 +37,7 @@ const withBrands = Wrapped => {
   }
 
   const WithBrands = queryConnect({
-    triggers: triggersConn
+    triggers: { ...triggersConn, as: options.queryName }
   })(RawWithBrands)
 
   return WithBrands

--- a/src/ducks/reimbursements/HealthReimbursements.spec.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.spec.jsx
@@ -11,6 +11,20 @@ describe('HealthReimbursements', () => {
     const root = shallow(
       <DumbHealthReimbursements
         fetchStatus="loading"
+        triggers={{ fetchStatus: 'loaded' }}
+        filteredTransactions={[]}
+        addFilterByPeriod={jest.fn()}
+      />
+    )
+
+    expect(root.find(Loading).length).toBe(1)
+  })
+
+  it('should show a loading if the brands are loading', () => {
+    const root = shallow(
+      <DumbHealthReimbursements
+        fetchStatus="loaded"
+        triggers={{ fetchStatus: 'loading' }}
         filteredTransactions={[]}
         addFilterByPeriod={jest.fn()}
       />
@@ -32,6 +46,8 @@ describe('HealthReimbursements', () => {
         filteredTransactions={pending}
         t={key => key}
         addFilterByPeriod={jest.fn()}
+        brands={[]}
+        triggers={{ fetchStatus: 'loaded' }}
       />
     )
 
@@ -49,19 +65,23 @@ describe('HealthReimbursements', () => {
         filteredTransactions={reimbursed}
         t={key => key}
         addFilterByPeriod={jest.fn()}
+        brands={[]}
+        triggers={{ fetchStatus: 'loaded' }}
       />
     )
 
     expect(root.find(TransactionsWithSelection).length).toBe(1)
   })
 
-  it('should show a button to open the store if there is no reimbursed transactions', () => {
+  it('should show a button to open the store if there is no reimbursed transactions and no health brand with trigger', () => {
     const root = shallow(
       <DumbHealthReimbursements
         fetchStatus="loaded"
         filteredTransactions={[]}
         t={key => key}
         addFilterByPeriod={jest.fn()}
+        brands={[]}
+        triggers={{ fetchStatus: 'loaded' }}
       />
     )
 

--- a/src/ducks/transactions/TransactionActionsProvider.jsx
+++ b/src/ducks/transactions/TransactionActionsProvider.jsx
@@ -5,7 +5,7 @@ import { DumbTransactionActionsProvider } from 'ducks/transactions/TransactionAc
 
 const TransactionActionsProvider = compose(
   withAppsUrls,
-  withBrands
+  withBrands()
 )(DumbTransactionActionsProvider)
 
 export default TransactionActionsProvider


### PR DESCRIPTION
Previously we showed a link to the store when there was no reimbursed transactions. Now, we show it if there is neither reimbursed transaction nor health brand triggers.