### PR TITLE
chore: Upgrade cozy-doctypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "cozy-client": "6.48.0",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "1.7.2",
-    "cozy-doctypes": "1.48.0",
+    "cozy-doctypes": "1.49.2",
     "cozy-flags": "1.7.0",
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.17.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4984,10 +4984,10 @@ cozy-doctypes@1.39.0:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-doctypes@1.48.0:
-  version "1.48.0"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.48.0.tgz#1a7690b887685e9a03770e449498f7232f99e173"
-  integrity sha512-YEy+RK4909MU6vjwD+Gu37fGPNF/Rao+idD/asxqWtM9oAl8D5+wZNP3oIxlCYNSvw9rbSuy4mykbgW4VkyVhg==
+cozy-doctypes@1.49.2:
+  version "1.49.2"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.49.2.tgz#265d30a9d3e9f5ef408a5d38888b2dac3daba2d0"
+  integrity sha512-zO/+X7Wc1xHJqP3OwF5z7Low+C4m32wP0P9V/CCNKF1fYrJR4g2DF6ewGydX2yWrN+wdEmrt8cQJvz+ax3BFGA==
   dependencies:
     "@babel/runtime" "7.3.1"
     cozy-logger "1.3.1"


### PR DESCRIPTION
Since cozy-doctypes is a peerDep of cozy-procedure, we need to be up to date in banks to have access to new methods 