### PR TITLE
feat(AttachedDocsActions): Show reimbursements vendors

### DIFF
--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -56,7 +56,12 @@ export class DumbBillChip extends React.PureComponent {
             className="u-flex-shrink-0"
           />
           {bill.isRefund ? (
-            <Figure total={bill.amount} coloredPositive signed symbol="€" />
+            <>
+              {bill.vendor && (
+                <span className="u-valid u-mr-half">{bill.vendor}</span>
+              )}
+              <Figure total={bill.amount} coloredPositive signed symbol="€" />
+            </>
           ) : (
             t('Transactions.actions.attachedDocs.bill')
           )}


### PR DESCRIPTION
We now show the vendor name of each reimbursement bill on the `AttachedDocsAction` (if the bill has a vendor).

![image](https://user-images.githubusercontent.com/1606068/60521667-f26b2f80-9ce7-11e9-9200-d080cc68e9a6.png)

![image](https://user-images.githubusercontent.com/1606068/60521735-0ca50d80-9ce8-11e9-8dcf-ab0fb6323740.png)
