### PR TITLE
fix: Import cozy-ui icon sprite at higher level in components hierarchy

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -6,6 +6,7 @@ import React from 'react'
 import { CozyProvider } from 'cozy-client'
 import { Provider } from 'react-redux'
 import flag from 'cozy-flags'
+import { Sprite as IconSprite } from 'cozy-ui/react/Icon'
 
 const AppContainer = ({ store, lang, history, client }) => {
   const AppRoute = require('components/AppRoute').default
@@ -14,15 +15,18 @@ const AppContainer = ({ store, lang, history, client }) => {
       ? require('ducks/mobile/MobileRouter').default
       : require('react-router').Router
   return (
-    <Provider store={store}>
-      <CozyProvider client={client}>
-        <I18n lang={lang} dictRequire={lang => require(`locales/${lang}`)}>
-          <MuiCozyTheme>
-            <Router history={history} routes={AppRoute()} />
-          </MuiCozyTheme>
-        </I18n>
-      </CozyProvider>
-    </Provider>
+    <>
+      <IconSprite />
+      <Provider store={store}>
+        <CozyProvider client={client}>
+          <I18n lang={lang} dictRequire={lang => require(`locales/${lang}`)}>
+            <MuiCozyTheme>
+              <Router history={history} routes={AppRoute()} />
+            </MuiCozyTheme>
+          </I18n>
+        </CozyProvider>
+      </Provider>
+    </>
   )
 }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -5,7 +5,6 @@ import 'react-hint/css/index.css'
 import Alerter from 'cozy-ui/react/Alerter'
 import { Layout, Main, Content } from 'cozy-ui/react/Layout'
 import Sidebar from 'cozy-ui/react/Sidebar'
-import { Sprite as IconSprite } from 'cozy-ui/react/Icon'
 import Nav from 'ducks/commons/Nav'
 import { Warnings } from 'ducks/warnings'
 import flag, { FlagSwitcher } from 'cozy-flags'
@@ -49,7 +48,6 @@ const App = props => {
       <ReactHint />
 
       <Warnings />
-      <IconSprite />
       <Alerter />
     </Layout>
   )


### PR DESCRIPTION
This makes the icons available everywhere in the app, including on the
mobile app's welcome screen.