### PR TITLE
fix(stats): No need to subtract a month to compute mean on period

### DIFF
--- a/src/ducks/stats/services.js
+++ b/src/ducks/stats/services.js
@@ -28,9 +28,7 @@ export const getMeanOnPeriod = (transactions, period) => {
   const end = moment(period.end)
   const start = moment(period.start)
 
-  // We need to remove one month since the period ends on the first day of the
-  // current month, not on the last day of the previous month
-  const nbMonths = end.diff(start, 'months') - 1
+  const nbMonths = end.diff(start, 'months')
 
   const total = Math.abs(sumBy(transactions, transaction => transaction.amount))
   const mean = total / nbMonths

--- a/src/ducks/stats/services.spec.js
+++ b/src/ducks/stats/services.spec.js
@@ -28,7 +28,7 @@ describe('getPeriod', () => {
 describe('fetchTransactionsForPeriod', () => {
   it('should fetch transactions for the given period', async () => {
     const period = {
-      start: moment('2019-03-01'),
+      start: moment('2019-04-01'),
       end: moment('2019-07-01')
     }
 
@@ -45,7 +45,7 @@ describe('fetchTransactionsForPeriod', () => {
 
 describe('getMeanOnPeriod', () => {
   const period = {
-    start: moment('2019-03-01'),
+    start: moment('2019-04-01'),
     end: moment('2019-07-01')
   }
 


### PR DESCRIPTION
Periods used in tests were wrong and led me to wrongly subtract 1 to the number of months in `getMeanOnPeriod` function. Actually after correcting the period in tests, we don't need to subtract anything.