### PR TITLE
Compute additional income using all income subcategories except activity income

### DIFF
--- a/src/targets/services/stats.js
+++ b/src/targets/services/stats.js
@@ -82,51 +82,44 @@ const main = async () => {
       const accountStats = statsByAccountId[accountId] || {}
       const transactionsByCategory = groupBy(transactions, getCategoryId)
 
+      const getTransactionsByCategoryName = categoryName => {
+        const categoryId = getCategoryIdFromName(categoryName)
+        return transactionsByCategory[categoryId] || []
+      }
+
       accountStats.periodStart = period.start
       accountStats.periodEnd = period.end
 
       accountStats.income = getMeanOnPeriod(
-        transactionsByCategory[getCategoryIdFromName('activityIncome')],
+        getTransactionsByCategoryName('activityIncome'),
         period
       )
 
       accountStats.additionalIncome = getMeanOnPeriod(
         [
-          ...(transactionsByCategory[
-            getCategoryIdFromName('replacementIncome')
-          ] || []),
-          ...(transactionsByCategory[getCategoryIdFromName('interests')] || []),
-          ...(transactionsByCategory[getCategoryIdFromName('dividends')] || []),
-          ...(transactionsByCategory[
-            getCategoryIdFromName('donationsReceived')
-          ] || []),
-          ...(transactionsByCategory[getCategoryIdFromName('allocations')] ||
-            []),
-          ...(transactionsByCategory[getCategoryIdFromName('rentalIncome')] ||
-            []),
-          ...(transactionsByCategory[
-            getCategoryIdFromName('additionalIncome')
-          ] || []),
-          ...(transactionsByCategory[getCategoryIdFromName('incomeCat')] || [])
+          ...getTransactionsByCategoryName('replacementIncome'),
+          ...getTransactionsByCategoryName('interests'),
+          ...getTransactionsByCategoryName('dividends'),
+          ...getTransactionsByCategoryName('donationsReceived'),
+          ...getTransactionsByCategoryName('allocations'),
+          ...getTransactionsByCategoryName('rentalIncome'),
+          ...getTransactionsByCategoryName('additionalIncome'),
+          ...getTransactionsByCategoryName('incomeCat')
         ],
         period
       )
 
       accountStats.mortgage = getMeanOnPeriod(
-        transactionsByCategory[getCategoryIdFromName('realEstateLoan')],
+        getTransactionsByCategoryName('realEstateLoan'),
         period
       )
 
       accountStats.loans = getMeanOnPeriod(
         [
-          ...(transactionsByCategory[getCategoryIdFromName('realEstateLoan')] ||
-            []),
-          ...(transactionsByCategory[getCategoryIdFromName('consumerLoan')] ||
-            []),
-          ...(transactionsByCategory[getCategoryIdFromName('studentLoan')] ||
-            []),
-          ...(transactionsByCategory[getCategoryIdFromName('vehiculeLoan')] ||
-            [])
+          ...getTransactionsByCategoryName('realEstateLoan'),
+          ...getTransactionsByCategoryName('consumerLoan'),
+          ...getTransactionsByCategoryName('studentLoan'),
+          ...getTransactionsByCategoryName('vehiculeLoan')
         ],
         period
       )

--- a/src/targets/services/stats.js
+++ b/src/targets/services/stats.js
@@ -91,7 +91,24 @@ const main = async () => {
       )
 
       accountStats.additionalIncome = getMeanOnPeriod(
-        transactionsByCategory[getCategoryIdFromName('additionalIncome')],
+        [
+          ...(transactionsByCategory[
+            getCategoryIdFromName('replacementIncome')
+          ] || []),
+          ...(transactionsByCategory[getCategoryIdFromName('interests')] || []),
+          ...(transactionsByCategory[getCategoryIdFromName('dividends')] || []),
+          ...(transactionsByCategory[
+            getCategoryIdFromName('donationsReceived')
+          ] || []),
+          ...(transactionsByCategory[getCategoryIdFromName('allocations')] ||
+            []),
+          ...(transactionsByCategory[getCategoryIdFromName('rentalIncome')] ||
+            []),
+          ...(transactionsByCategory[
+            getCategoryIdFromName('additionalIncome')
+          ] || []),
+          ...(transactionsByCategory[getCategoryIdFromName('incomeCat')] || [])
+        ],
         period
       )
 


### PR DESCRIPTION
We previously used only the additional income subcategory, but we actually want to include all incomes except activity incomes in this sum.