### PR TITLE
fix: Do not use minified bar

### DIFF
--- a/config/webpack.target.mobile.js
+++ b/config/webpack.target.mobile.js
@@ -43,7 +43,7 @@ module.exports = {
       pouchdbFind: 'pouchdb-find',
       pouchdbAdapterCordovaSqlite: 'pouchdb-adapter-cordova-sqlite',
       'cozy.client': 'cozy-client-js/dist/cozy-client.js',
-      'cozy.bar': `cozy-bar/dist/cozy-bar.mobile${production ? '.min' : ''}.js`
+      'cozy.bar': `cozy-bar/dist/cozy-bar.mobile.js`
     }),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, `../src/index.ejs`),


### PR DESCRIPTION
When using the minified bar, after building banks production,
the bar code is minified two times and what seems like a minification bug happens.

The bug happens in the react-select code : https://github.com/JedWatson/react-select/blob/c22a4b20aef2161ebaa3a0373de7e0e179e73693/packages/react-select/src/components/Menu.js#L250

`alignToControl` is inlined by the minification, and `placement ? placementToCSSProp[placement] : "bottom"` gets simplified into `"bottom"` which forces the react-select menu to always come on top.

---

in bar.min.js

```js
menu: function(e) {
    var t, n = e.placement,
        r = e.theme,
        o = r.borderRadius,
        a = r.spacing,
        i = r.colors;
    return F(t = {}, function(e) {
        return e ? {
            bottom: "top",
            top: "bottom"
        } [e] : "bottom"
    }(n), "100%"), F(t, "backgroundColor", i.neutral0), F(t, "borderRadius", o), F(t, "boxShadow", "0 0 0 1px hsla(0, 0%, 0%, 0.1), 0 4px 11px hsla(0, 0%, 0%, 0.1)"), F(t, "marginBottom", a.menuGutter), F(t, "marginTop", a.menuGutter), F(t, "position", "absolute"), F(t, "width", "100%"), F(t, "zIndex", 1), t
},
```

in banks.min.js

```js
menu: function(e) {
    e.placement;
    var t, n = e.theme,
        r = n.borderRadius,
        o = n.spacing,
        i = n.colors;
    return I(t = {}, "bottom", "100%"), I(t, "backgroundColor", i.neutral0), I(t, "borderRadius", r), I(t, "boxShadow", "0 0 0 1px hsla(0, 0%, 0%, 0.1), 0 4px 11px hsla(0, 0%, 0%, 0.1)"), I(t, "marginBottom", o.menuGutter), I(t, "marginTop", o.menuGutter), I(t, "position", "absolute"), I(t, "width", "100%"), I(t, "zIndex", 1), t
},

```