### PR TITLE
feat(settings): Delete accounts stats when an account is deleted

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -37,10 +37,23 @@ const removeAccountFromGroups = async account => {
   }
 }
 
+export const removeStats = async (client, account) => {
+  const statsResponse = await client.query(
+    client.find('io.cozy.bank.accounts.stats', {
+      'relationships.account.data._id': account._id
+    })
+  )
+
+  for (const accountStats of statsResponse.data) {
+    await client.destroy(accountStats)
+  }
+}
+
 export const DESTROY_ACCOUNT = 'DESTROY_ACCOUNT'
 export const destroyReferences = async (client, account) => {
   await deleteOrphanOperations(client, account)
   await removeAccountFromGroups(account)
+  await removeStats(client, account)
 }
 
 CozyClient.registerHook(ACCOUNT_DOCTYPE, 'before:destroy', destroyReferences)

--- a/src/actions/accounts.spec.js
+++ b/src/actions/accounts.spec.js
@@ -1,0 +1,31 @@
+import { removeStats } from './accounts'
+import CozyClient from 'cozy-client'
+
+jest.mock('cozy-client')
+
+const client = new CozyClient()
+
+describe('removeStats', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should remove the stats doc corresponding to the account if it exists', async () => {
+    const account = { _id: 'account' }
+    const stats = { _id: 'stats' }
+    client.query.mockResolvedValueOnce({ data: [stats] })
+
+    await removeStats(client, account)
+
+    expect(client.destroy).toHaveBeenCalledWith(stats)
+  })
+
+  it('should do nothing if no stats doc corresponding to the account exist', async () => {
+    const account = { _id: 'account' }
+    client.query.mockResolvedValueOnce({ data: [] })
+
+    await removeStats(client, account)
+
+    expect(client.destroy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
When an account is deleted, we want to also delete its correspondig `io.cozy.bank.accounts.stats` document if it exists.