### PR TITLE
Update stats service trigger and debounce

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -77,7 +77,7 @@
     "stats": {
       "type": "node",
       "file": "stats.js",
-      "trigger": "@event io.cozy.bank.operations:CREATED",
+      "trigger": "@event io.cozy.bank.operations:CREATED,UPDATED",
       "debounce": "3m"
     }
   },

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -78,7 +78,7 @@
       "type": "node",
       "file": "stats.js",
       "trigger": "@event io.cozy.bank.operations:CREATED,UPDATED",
-      "debounce": "3m"
+      "debounce": "1m"
     }
   },
   "notifications": {


### PR DESCRIPTION
We want the stats service to be run when a transaction is updated. This way when a user recategorizes a transaction, the stats are computed again.

Also, the service now uses a 1mn debounce.