### PR TITLE
feat: Trying to validate bundle

### DIFF
--- a/scripts/bundle-eslintrc
+++ b/scripts/bundle-eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    es6: true
+  },
+  "parser": 'babel-eslint',
+  "plugins": ["bundle-rules"],
+  "rules": { "bundle-rules/bundle-validation": "error" }
+}

--- a/scripts/eslint-plugin-bundle-rules/index.js
+++ b/scripts/eslint-plugin-bundle-rules/index.js
@@ -1,0 +1,13 @@
+module.exports.rules = {
+  'bundle-validation': context => ({
+    ForStatement: node => {
+      if (node.init.kind == 'let') {
+        context.report(node, 'No let in initialisation of for statement')
+      }
+    },
+
+    ExperimentalSpreadProperty: node => {
+      context.report(node, 'No ExperimentalSpreadProperty')
+    }
+  })
+}

--- a/scripts/eslint-plugin-bundle-rules/package.json
+++ b/scripts/eslint-plugin-bundle-rules/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "eslint-plugin-bundle-rules",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT"
+}

--- a/scripts/validate-js-rules.json
+++ b/scripts/validate-js-rules.json
@@ -1,0 +1,10 @@
+[
+  {
+    "query": "ForStatement[init.kind=\"let\"]",
+    "help": "For statements with initializer of kind let does not work in Safari iOS 10"
+  },
+  {
+    "query": "ExperimentalSpreadProperty",
+    "help": "ExperimentalSpreadProperty does not work in older browser, use Object.assign"
+  }
+]

--- a/scripts/validate-js-rules.json
+++ b/scripts/validate-js-rules.json
@@ -6,5 +6,9 @@
   {
     "query": "ExperimentalSpreadProperty",
     "help": "ExperimentalSpreadProperty does not work in older browser, use Object.assign"
+  },
+  {
+    "query": "FunctionExpression[async=true]",
+    "help": "Does not work in older browsers"
   }
 ]

--- a/scripts/validate-js.js
+++ b/scripts/validate-js.js
@@ -1,0 +1,43 @@
+const path = require('path')
+const esquery = require('esquery')
+const fs = require('fs')
+const esprima = require('esprima')
+
+const validateAST = (ast, rules) => {
+  const query = ':matches(' + rules.map(r => r.query).join(',') + ')'
+  const results = esquery(ast, query)
+  return results
+}
+
+const validateFile = (filename, rules) => {
+  const raw = fs
+    .readFileSync(
+      filename.startsWith('/') ? filename : path.join(process.env.PWD, filename)
+    )
+    .toString()
+  const ast = esprima.parse(raw, { range: true })
+  return validateAST(ast, rules).map(result => {
+    const { range } = result
+    const source = raw.substring(range[0], range[1])
+    return {
+      ...result,
+      source
+    }
+  })
+}
+
+const main = () => {
+  const rules = JSON.parse(
+    fs.readFileSync(path.join(__dirname, 'validate-js-rules.json')).toString()
+  )
+  const results = validateFile(process.argv[2], rules)
+  for (const r of results) {
+    // eslint-disable-next-line no-console
+    console.log(`${r.range[0]}:${r.range[1]}: ${r.source}`)
+  }
+  process.exit(results.length ? 1 : 0)
+}
+
+if (require.main === module) {
+  main()
+}


### PR DESCRIPTION
It is not the first time that we have errors on old browsers (ios 10)
for syntax errors. It is costly to understand where those errors come
from when there are on the wild. IMHO it'd be better be caught as soon
as possible, for example during CI.

2 experiments here :

- Trying to validate the bundle via eslint but could not 
  - parsing error with the default parser (espree) (async function)
  - too slow with babel-eslint (10m and counting)
  - out of memory with esprima 
- Custom validation via esquery

Details in the commit messages.