### PR TITLE
Chore: Do not force node 10 usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "cozy-banks",
   "version": "1.3.1",
   "main": "src/main.jsx",
-  "engines": {
-    "node": "10"
-  },
   "scripts": {
     "build": "npm run build:browser && npm run build:services",
     "build:browser": "NODE_ENV=${NODE_ENV:-browser:production} npm run commons:build",


### PR DESCRIPTION
ATM, our internal jenkins can not run node 10 (so we can't deploy new version) . Let's remove this requirement ATM until our internal tools can run on node 10. (in a few days)