### PR TITLE
fix: Add cozy-logger as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "cozy-flags": "1.9.0",
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.17.1",
+    "cozy-logger": "1.4.0",
     "cozy-pouch-link": "6.49.1",
     "cozy-realtime": "3.1.0",
     "cozy-stack-client": "6.47.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4455,7 +4455,7 @@ cozy-logger@1.3.1, cozy-logger@^1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-logger@^1.4.0:
+cozy-logger@1.4.0, cozy-logger@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.4.0.tgz#0b3ccce97654aa2257aaf1d606d7e0c950655acf"
   integrity sha512-MMUVPytfgTLK3lxRD26X1Ty6s2969g55G+CIe3UM9rULnLLLGmFQh5A/QmjmQuIDg+jQfvO67U6PuloPFVTjcQ==


### PR DESCRIPTION
Since we're using cozy-logger in this code base, we should add it as a dependencies right? 