### PR TITLE
Fix in AttachedDocsAction

### DIFF
--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -9,6 +9,7 @@ import FileOpener from 'ducks/transactions/FileOpener'
 import FileIcon from 'ducks/transactions/actions/AttachedDocsAction/FileIcon'
 import { Figure } from 'components/Figure'
 import { AugmentedModalOpener } from 'components/AugmentedModal'
+import { getBrands } from 'ducks/brandDictionary'
 
 export class DumbBillChip extends React.PureComponent {
   static propTypes = {
@@ -48,6 +49,13 @@ export class DumbBillChip extends React.PureComponent {
 
     const Wrapper = isVentePrivee ? AugmentedModalOpener : FileOpener
 
+    // Bill's vendor can be a slug. We get the brand from our dictionary to be
+    // sure that we show the brand name and not a konnector slug
+    const [brand] = getBrands(
+      brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
+    )
+    const vendorName = brand && brand.name
+
     return (
       <Wrapper fileId={invoiceId} key={invoiceId}>
         <Chip component="button" size="small" variant="outlined">
@@ -57,8 +65,8 @@ export class DumbBillChip extends React.PureComponent {
           />
           {bill.isRefund ? (
             <>
-              {bill.vendor && (
-                <span className="u-valid u-mr-half">{bill.vendor}</span>
+              {vendorName && (
+                <span className="u-valid u-mr-half">{vendorName}</span>
               )}
               <Figure total={bill.amount} coloredPositive signed symbol="€" />
             </>

--- a/src/ducks/transactions/actions/AttachedDocsAction/index.js
+++ b/src/ducks/transactions/actions/AttachedDocsAction/index.js
@@ -9,27 +9,16 @@ import {
 import BillChip from 'ducks/transactions/actions/AttachedDocsAction/BillChip'
 import { TransactionModalRow } from 'ducks/transactions/TransactionModal'
 import iconAttachment from 'assets/icons/icon-attachment.svg'
+import { uniqBy } from 'lodash'
 
 class AttachedDocsAction extends React.PureComponent {
   renderTransactionRow() {
-    return (
-      <>
-        {this.renderTransactionRowBills()}
-        {this.renderTransactionRowReimbursements()}
-      </>
-    )
-  }
-
-  renderTransactionRowBills() {
     const { transaction } = this.props
-    const bills = getBills(transaction)
 
-    return bills.map(bill => <BillChip bill={bill} key={bill._id} />)
-  }
-
-  renderTransactionRowReimbursements() {
-    const { transaction } = this.props
-    const bills = getReimbursementsBills(transaction)
+    const bills = uniqBy([
+      ...getBills(transaction),
+      ...getReimbursementsBills(transaction)
+    ])
 
     return bills.map(bill => <BillChip bill={bill} key={bill._id} />)
   }


### PR DESCRIPTION
We had two problems :

* If the transaction has the same bill attached in `bills` and in `reimbursements` (which occurs in our matching algorithm), then each bill was shown two times. To avoid that, we `uniqBy` on the bills ids
* We shown `bill.vendor` in the bill chip, but sometimes this is a real name, sometimes this is a slug. To avoid showing a slug, we search the brand in our dictionnary and we get its name from here