### PR TITLE
refactor(categories): Use cozy-doctypes BankTransaction::getCategoryId

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "cozy-client": "6.55.0",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "1.7.3",
-    "cozy-doctypes": "1.56.2",
+    "cozy-doctypes": "1.62.0",
     "cozy-flags": "1.9.0",
     "cozy-interapp": "0.4.5",
     "cozy-konnector-libs": "4.17.1",

--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -2,6 +2,7 @@ import flag from 'cozy-flags'
 import parentCategory, { categoriesStyle } from 'ducks/categories/categoriesMap'
 import categoryNames from 'ducks/categories/tree'
 import { getCurrencySymbol } from 'utils/currencySymbol'
+import { BankTransaction } from 'cozy-doctypes'
 
 const getParent = parentCategory.get.bind(parentCategory)
 
@@ -19,46 +20,15 @@ const makeSubcategory = catId => ({
   transactions: []
 })
 
-export const LOCAL_MODEL_USAGE_THRESHOLD = 0.8
-export const GLOBAL_MODEL_USAGE_THRESHOLD = 0.15
-
 /**
  * Return the category id of the transaction
  * @param {Object} transaction
  * @return {String|null} A category id or null if the transaction has not been categorized yet
  */
 export const getCategoryId = transaction => {
-  if (transaction.manualCategoryId) {
-    return transaction.manualCategoryId
-  }
-
   const localModelOverride = flag('local-model-override')
 
-  if (
-    localModelOverride &&
-    transaction.localCategoryId &&
-    transaction.localCategoryProba &&
-    transaction.localCategoryProba > LOCAL_MODEL_USAGE_THRESHOLD
-  ) {
-    return transaction.localCategoryId
-  }
-
-  if (
-    transaction.cozyCategoryId &&
-    transaction.cozyCategoryProba &&
-    transaction.cozyCategoryProba > GLOBAL_MODEL_USAGE_THRESHOLD
-  ) {
-    return transaction.cozyCategoryId
-  }
-
-  // If the cozy categorization models have not been applied, we return null
-  // so the transaction is considered as « categorization in progress ».
-  // Otherwize we just use the automatic categorization from the vendor
-  if (!transaction.localCategoryId && !transaction.cozyCategoryId) {
-    return null
-  }
-
-  return transaction.automaticCategoryId
+  return BankTransaction.getCategoryId(transaction, { localModelOverride })
 }
 
 export const getParentCategory = transaction => {

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -1,13 +1,6 @@
 jest.mock('cozy-flags')
 
-import flag from 'cozy-flags'
-import {
-  getCategoryId,
-  isAwaitingCategorization,
-  transactionsByCategory,
-  LOCAL_MODEL_USAGE_THRESHOLD,
-  GLOBAL_MODEL_USAGE_THRESHOLD
-} from './helpers'
+import { isAwaitingCategorization, transactionsByCategory } from './helpers'
 
 describe('transactionsByCategory', () => {
   const byCategory = transactionsByCategory([
@@ -25,76 +18,6 @@ describe('transactionsByCategory', () => {
   expect(byCategory.incomeCat.subcategories['200110'].name).toBe(
     'activityIncome'
   )
-})
-
-describe('getCategoryId', () => {
-  beforeEach(() => {
-    flag.mockReturnValue(true)
-  })
-
-  it("Should return the manualCategoryId if there's one", () => {
-    const transaction = {
-      manualCategoryId: '200110',
-      automaticCategoryId: '200120',
-      localCategoryId: '200130',
-      localCategoryProba: LOCAL_MODEL_USAGE_THRESHOLD + 0.01
-    }
-
-    expect(getCategoryId(transaction)).toBe(transaction.manualCategoryId)
-  })
-
-  it('Should return the automaticCategoryId if the localCategoryProba is lower than the threshold', () => {
-    const transaction = {
-      automaticCategoryId: '200120',
-      localCategoryId: '200130',
-      localCategoryProba: LOCAL_MODEL_USAGE_THRESHOLD - 0.01
-    }
-
-    expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
-  })
-
-  it("Should return the automaticCategoryId if there's no manualCategoryId, and localCategory/cozyCategory are not usable", () => {
-    const transaction = {
-      automaticCategoryId: '200120',
-      localCategoryId: '200130',
-      localCategoryPrba: LOCAL_MODEL_USAGE_THRESHOLD - 0.01,
-      cozyCategoryId: '200140',
-      cozyCategoryProba: GLOBAL_MODEL_USAGE_THRESHOLD - 0.01
-    }
-
-    expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
-  })
-
-  it('Should use local model properties according to "use-local-model" flag', () => {
-    const transaction = {
-      automaticCategoryId: '200120',
-      localCategoryId: '200130',
-      localCategoryProba: LOCAL_MODEL_USAGE_THRESHOLD + 0.01
-    }
-
-    expect(getCategoryId(transaction)).toBe(transaction.localCategoryId)
-
-    flag.mockReturnValueOnce(false)
-    expect(getCategoryId(transaction)).toBe(transaction.automaticCategoryId)
-  })
-
-  it('should return the cozyCategoryId if there is one with a high probability, but no localCategoryId', () => {
-    const transaction = {
-      automaticCategoryId: '200120',
-      cozyCategoryId: '200130',
-      cozyCategoryProba: GLOBAL_MODEL_USAGE_THRESHOLD + 0.01
-    }
-
-    expect(getCategoryId(transaction)).toBe(transaction.cozyCategoryId)
-  })
-
-  it('should return null if there is only automaticCategoryId', () => {
-    const transaction = {
-      automaticCategoryId: '200120'
-    }
-
-    expect(getCategoryId(transaction)).toBeNull()
-  })
 })
 
 describe('isAwaitingCategorization', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4424,13 +4424,14 @@ cozy-doctypes@1.39.0:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-doctypes@1.56.2:
-  version "1.56.2"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.56.2.tgz#f2036aa5b1715375e0c02ff59c50d1a7a4152aba"
-  integrity sha512-Zqhpdp370scOUV9Xwxyglic8Aw/IBFOcI3WR2zzWDcIRpoNzborPBWwcNeUAV6AQEGM+HnVkKWzZR7aauap2WQ==
+cozy-doctypes@1.62.0:
+  version "1.62.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.62.0.tgz#0b3e48d1b4347e0dc247c878c1ee7f2612317955"
+  integrity sha512-P3aq+oi7tOqT3/Nx2M1fm/BqK/ZMQad017lY6RihCa1ddK2RJ/vgHHQHvVcge1+OXtGfgXAkSHhDoa5ndTLsog==
   dependencies:
     "@babel/runtime" "7.3.1"
-    cozy-logger "^1.4.0"
+    cozy-logger "^1.5.0"
+    date-fns "1.30.1"
     es6-promise-pool "2.5.0"
     lodash "4.17.15"
     prop-types "^15.7.2"
@@ -4527,11 +4528,19 @@ cozy-logger@1.3.1, cozy-logger@^1.3.1:
   dependencies:
     json-stringify-safe "5.0.1"
 
-cozy-logger@1.4.0, cozy-logger@^1.4.0:
+cozy-logger@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.4.0.tgz#0b3ccce97654aa2257aaf1d606d7e0c950655acf"
   integrity sha512-MMUVPytfgTLK3lxRD26X1Ty6s2969g55G+CIe3UM9rULnLLLGmFQh5A/QmjmQuIDg+jQfvO67U6PuloPFVTjcQ==
   dependencies:
+    json-stringify-safe "5.0.1"
+
+cozy-logger@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-logger/-/cozy-logger-1.5.0.tgz#76c619f8371354b627600db1006bd5e118263370"
+  integrity sha512-ekgFSGbJepAmppZ5Kd/osthdKnneLPDsI5ouAj/me6sOUcklwPhhlaKdMw68FP9oFcfE4+ZGnMM70ep4CwZSKA==
+  dependencies:
+    chalk "^2.4.2"
     json-stringify-safe "5.0.1"
 
 cozy-pouch-link@6.49.1:


### PR DESCRIPTION
I extracted `getCategoryId` logic in cozy-doctypes because we needed it in cozy-procedures (see https://github.com/cozy/cozy-libs/pull/701). In this PR I refactor `getCategoryId` so it only gets the `local-model-override` flag and pass it to `BankTrasaction::getCategoryId`.