### PR TITLE
feat: Delayed render for snappier user XP

### DIFF
--- a/scripts/import_mobile_keys
+++ b/scripts/import_mobile_keys
@@ -30,6 +30,7 @@ function cp_from_keepass {
 
 check_dir
 
+mkdir -p src/targets/mobile/keys/{android,ios}
 cp_from_keepass Gangsters/cozy-banks/keys/android/cozy-banks-release-key.jks ./src/targets/mobile/keys/android/cozy-banks-release-key.jks
 cp_from_keepass Gangsters/cozy-banks/keys/android/key.json ./src/targets/mobile/keys/android/key.json
 extract_from_keepass Gangsters/cozy-banks/keys/android/google-services.json ./src/targets/mobile/keys/android/google-services.json

--- a/src/components/Delayed.jsx
+++ b/src/components/Delayed.jsx
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react'
+
+const useDelay = delay => {
+  // ok is true when delay has elapsed
+  const [ok, setOK] = useState(false)
+  // Pass empty dep list to useEffect to have a behavior similar to
+  // componentDid{Mount,Unmount}
+  // https://fr.reactjs.org/docs/hooks-effect.html#tip-optimizing-performance-by-skipping-effects
+  useEffect(() => {
+    function setOKToTrue() {
+      setOK(true)
+    }
+    let timeout = setTimeout(setOKToTrue, delay)
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [])
+  return ok
+}
+
+const Delayed = ({ fallback, children, delay }) => {
+  const ok = useDelay(delay)
+  if (ok) {
+    return children
+  } else {
+    return fallback
+  }
+}
+
+export default Delayed

--- a/src/components/Delayed.jsx
+++ b/src/components/Delayed.jsx
@@ -18,6 +18,12 @@ const useDelay = delay => {
   return ok
 }
 
+/**
+ * Delays rendering of its children
+ * @param  {Element} options.fallback - Simple component used while delay has not elapsed
+ * @param  {Element} options.children - Will be rendered after <delay>ms have passed
+ * @param  {Number} options.delay    - Delay to render children in ms
+ */
 const Delayed = ({ fallback, children, delay }) => {
   const ok = useDelay(delay)
   if (ok) {

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -24,9 +24,12 @@ import { getCategoryIdFromName } from 'ducks/categories/categoriesMap'
 import { getDate, getDisplayDate } from 'ducks/transactions/helpers'
 import { getCategoryId } from 'ducks/categories/helpers'
 
+import { queryConnect } from 'cozy-client'
+
 import Loading from 'components/Loading'
+import Delayed from 'components/Delayed'
 import { TransactionsWithSelection } from 'ducks/transactions/Transactions.jsx'
-import TransactionHeader from 'ducks/transactions/TransactionHeader'
+
 import {
   ACCOUNT_DOCTYPE,
   accountsConn,
@@ -35,7 +38,7 @@ import {
   transactionsConn
 } from 'doctypes'
 
-import { queryConnect } from 'cozy-client'
+import TransactionHeader from 'ducks/transactions/TransactionHeader'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
 import { findNearestMonth } from 'ducks/transactions/helpers'
 import {
@@ -45,39 +48,12 @@ import {
 } from 'ducks/balance/helpers'
 import BarTheme from 'ducks/bar/BarTheme'
 import TransactionActionsProvider from 'ducks/transactions/TransactionActionsProvider'
-import { useState, useEffect } from 'react'
 
 const { BarRight } = cozy.bar
 
 const STEP_INFINITE_SCROLL = 30
 const SCROLL_THRESOLD_TO_ACTIVATE_TOP_INFINITE_SCROLL = 150
 const getMonth = date => date.slice(0, 7)
-
-const useDelay = delay => {
-  let timeout
-  const [ok, setOK] = useState(false)
-  useEffect(() => {
-    function setOKToTrue() {
-      setOK(true)
-    }
-    if (!timeout) {
-      timeout = setTimeout(setOKToTrue, delay)
-    }
-    return () => {
-      clearTimeout(timeout)
-    }
-  })
-  return ok
-}
-
-const Delayed = ({ fallback, children, delay }) => {
-  const ok = useDelay(delay)
-  if (ok) {
-    return children
-  } else {
-    return fallback
-  }
-}
 
 const FakeTransactions = () => {
   return <Padded>{null}</Padded>

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -45,12 +45,43 @@ import {
 } from 'ducks/balance/helpers'
 import BarTheme from 'ducks/bar/BarTheme'
 import TransactionActionsProvider from 'ducks/transactions/TransactionActionsProvider'
+import { useState, useEffect } from 'react'
 
 const { BarRight } = cozy.bar
 
 const STEP_INFINITE_SCROLL = 30
 const SCROLL_THRESOLD_TO_ACTIVATE_TOP_INFINITE_SCROLL = 150
 const getMonth = date => date.slice(0, 7)
+
+const useDelay = delay => {
+  let timeout
+  const [ok, setOK] = useState(false)
+  useEffect(() => {
+    function setOKToTrue() {
+      setOK(true)
+    }
+    if (!timeout) {
+      timeout = setTimeout(setOKToTrue, delay)
+    }
+    return () => {
+      clearTimeout(timeout)
+    }
+  })
+  return ok
+}
+
+const Delayed = ({ fallback, children, delay }) => {
+  const ok = useDelay(delay)
+  if (ok) {
+    return children
+  } else {
+    return fallback
+  }
+}
+
+const FakeTransactions = () => {
+  return <Padded>{null}</Padded>
+}
 
 class TransactionsPage extends Component {
   constructor(props) {
@@ -223,18 +254,20 @@ class TransactionsPage extends Component {
     }
 
     return (
-      <TransactionsWithSelection
-        limitMin={limitMin}
-        limitMax={limitMax}
-        onReachTop={this.handleDecreaseLimitMin}
-        onReachBottom={this.handleIncreaseLimitMax}
-        infiniteScrollTop={infiniteScrollTop}
-        onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
-        onScroll={this.checkToActivateTopInfiniteScroll}
-        transactions={transactions}
-        filteringOnAccount={this.getFilteringOnAccount()}
-        manualLoadMore={isMobileApp()}
-      />
+      <Delayed delay={0} fallback={<FakeTransactions />}>
+        <TransactionsWithSelection
+          limitMin={limitMin}
+          limitMax={limitMax}
+          onReachTop={this.handleDecreaseLimitMin}
+          onReachBottom={this.handleIncreaseLimitMax}
+          infiniteScrollTop={infiniteScrollTop}
+          onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
+          onScroll={this.checkToActivateTopInfiniteScroll}
+          transactions={transactions}
+          filteringOnAccount={this.getFilteringOnAccount()}
+          manualLoadMore={isMobileApp()}
+        />
+      </Delayed>
     )
   }
 


### PR DESCRIPTION
We delay the rendering of transactions for the transactions page to be shown right away (initially only with the header) after user click.

Visible on http://testbanksadddelaytransactionspage.cozy.works/