### PR TITLE
Handle bills matching criterias in matching algorithm

### DIFF
--- a/src/ducks/billsMatching/Linker/Linker.spec.js
+++ b/src/ducks/billsMatching/Linker/Linker.spec.js
@@ -327,7 +327,8 @@ describe('linker', () => {
     const testCases = require('../../../../test/fixtures/matching-service/cases')
 
     for (const testCase of testCases) {
-      test(testCase.description, async () => {
+      const fn = testCase.focus ? fit : it
+      fn(testCase.description, async () => {
         const { bills, operations, expectedResult } = testCase
         const result = await linker.linkBillsToOperations(bills, operations)
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/findNeighboringOperations.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/findNeighboringOperations.js
@@ -20,8 +20,8 @@ const createAmountSelector = (bill, options) => {
   const { minAmount, maxAmount } = getAmountRangeFromBill(bill, options)
 
   return {
-    $gt: minAmount,
-    $lt: maxAmount
+    $gte: minAmount,
+    $lte: maxAmount
   }
 }
 
@@ -67,6 +67,10 @@ const findByMangoQuerySimple = (docs, query) => {
         return val > selValue
       } else if ($operator == '$lt') {
         return val < selValue
+      } else if ($operator == '$gte') {
+        return val >= selValue
+      } else if ($operator == '$lte') {
+        return val <= selValue
       } else {
         throw new Error(`Unknown operator ${$operator}`)
       }

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -21,9 +21,22 @@ const getIdentifiers = options => options.identifiers
 
 const getDateRangeFromBill = (bill, options) => {
   const date = getOperationDateFromBill(bill, options)
+
+  const pastWindow = get(
+    bill,
+    'matchingCriterias.dateLowerDelta',
+    options.pastWindow
+  )
+
+  const futureWindow = get(
+    bill,
+    'matchingCriterias.dateUpperDelta',
+    options.futureWindow
+  )
+
   return {
-    minDate: subDays(date, options.pastWindow),
-    maxDate: addDays(date, options.futureWindow)
+    minDate: subDays(date, pastWindow),
+    maxDate: addDays(date, futureWindow)
   }
 }
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -1,4 +1,5 @@
 const sortBy = require('lodash/sortBy')
+const get = require('lodash/get')
 const addDays = require('date-fns/add_days')
 const subDays = require('date-fns/sub_days')
 const differenceInDays = require('date-fns/difference_in_days')
@@ -29,9 +30,21 @@ const getDateRangeFromBill = (bill, options) => {
 const getAmountRangeFromBill = (bill, options) => {
   const amount = getOperationAmountFromBill(bill, options)
 
+  const lowerDelta = get(
+    bill,
+    'matchingCriterias.amountLowerDelta',
+    options.minAmountDelta
+  )
+
+  const upperDelta = get(
+    bill,
+    'matchingCriterias.amountUpperDelta',
+    options.maxAmountDelta
+  )
+
   return {
-    minAmount: amount - options.minAmountDelta,
-    maxAmount: amount + options.maxAmountDelta
+    minAmount: amount - lowerDelta,
+    maxAmount: amount + upperDelta
   }
 }
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -3,6 +3,7 @@ const get = require('lodash/get')
 const addDays = require('date-fns/add_days')
 const subDays = require('date-fns/sub_days')
 const differenceInDays = require('date-fns/difference_in_days')
+const { getBrands } = require('ducks/brandDictionary')
 
 const getOperationAmountFromBill = (bill, options) => {
   const searchingCredit = options && options.credit
@@ -93,6 +94,19 @@ const sortedOperations = (bill, operations) => {
   return sortBy(operations, buildSortFunction(bill))
 }
 
+const getBillRegexp = bill => {
+  let regexpStr = bill.matchingCriterias && bill.matchingCriterias.labelRegex
+
+  if (!regexpStr) {
+    const [brand] = getBrands(
+      brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
+    )
+    regexpStr = brand ? brand.regexp : `\\b${bill.vendor}\\b`
+  }
+
+  return new RegExp(regexpStr, 'i')
+}
+
 module.exports = {
   getOperationAmountFromBill,
   getOperationDateFromBill,
@@ -100,5 +114,6 @@ module.exports = {
   getDateRangeFromBill,
   getAmountRangeFromBill,
   getTotalReimbursements,
-  sortedOperations
+  sortedOperations,
+  getBillRegexp
 }

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -97,11 +97,15 @@ const sortedOperations = (bill, operations) => {
 const getBillRegexp = bill => {
   let regexpStr = bill.matchingCriterias && bill.matchingCriterias.labelRegex
 
-  if (!regexpStr) {
+  if (!regexpStr && bill.vendor) {
     const [brand] = getBrands(
       brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
     )
     regexpStr = brand ? brand.regexp : `\\b${bill.vendor}\\b`
+  }
+
+  if (!regexpStr) {
+    return null
   }
 
   return new RegExp(regexpStr, 'i')

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -52,21 +52,35 @@ describe('getterHelper', () => {
     const futureWindow = 1
     const date = '2018-01-08'
     const originalDate = '2018-01-03'
-
-    const bill = { date, originalDate }
     const options = { pastWindow, futureWindow }
     const creditOptions = { ...options, credit: true }
 
+    const matchingCriterias = {
+      dateLowerDelta: 2,
+      dateUpperDelta: 2
+    }
+
+    const bill1 = { date, originalDate }
+    const bill2 = { ...bill1, matchingCriterias }
+
     it('should find debit date range', () => {
-      const { minDate, maxDate } = getDateRangeFromBill(bill, options)
-      expect(minDate).toEqual(new Date('2018-01-02'))
-      expect(maxDate).toEqual(new Date('2018-01-04'))
+      const bill1Range = getDateRangeFromBill(bill1, options)
+      expect(bill1Range.minDate).toEqual(new Date('2018-01-02'))
+      expect(bill1Range.maxDate).toEqual(new Date('2018-01-04'))
+
+      const bill2Range = getDateRangeFromBill(bill2, options)
+      expect(bill2Range.minDate).toEqual(new Date('2018-01-01'))
+      expect(bill2Range.maxDate).toEqual(new Date('2018-01-05'))
     })
 
     it('should find credit date range', () => {
-      const { minDate, maxDate } = getDateRangeFromBill(bill, creditOptions)
-      expect(minDate).toEqual(new Date('2018-01-07'))
-      expect(maxDate).toEqual(new Date('2018-01-09'))
+      const bill1Range = getDateRangeFromBill(bill1, creditOptions)
+      expect(bill1Range.minDate).toEqual(new Date('2018-01-07'))
+      expect(bill1Range.maxDate).toEqual(new Date('2018-01-09'))
+
+      const bill2Range = getDateRangeFromBill(bill2, creditOptions)
+      expect(bill2Range.minDate).toEqual(new Date('2018-01-06'))
+      expect(bill2Range.maxDate).toEqual(new Date('2018-01-10'))
     })
   })
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -5,8 +5,12 @@ import {
   getDateRangeFromBill,
   getAmountRangeFromBill,
   getTotalReimbursements,
-  sortedOperations
+  sortedOperations,
+  getBillRegexp
 } from './helpers'
+import { getBrands } from '../../../brandDictionary'
+
+jest.mock('../../../brandDictionary')
 
 const OK = 'ok'
 
@@ -194,6 +198,35 @@ describe('getterHelper', () => {
         { id: 3, date: new Date(2017, 0, 19), amount: -13 }
       ]
       expect(sortedOperations(bill, operations)[0]).toEqual(operations[1])
+    })
+  })
+
+  describe('getBillRegexp', () => {
+    it('should return the regexp from matching criterias if it exists', () => {
+      const bill = {
+        matchingCriterias: { labelRegex: '\\bCOZY CLOUD\\b' },
+        vendor: 'Payfit'
+      }
+
+      const regexp = getBillRegexp(bill)
+
+      expect(regexp.toString()).toBe('/\\bCOZY CLOUD\\b/i')
+    })
+
+    it('should return the brand regexp if it exists', () => {
+      getBrands.mockReturnValueOnce([{ regexp: '\\bPAYFIT\\b' }])
+      const bill = { vendor: 'Payfit' }
+      const regexp = getBillRegexp(bill)
+
+      expect(regexp.toString()).toBe('/\\bPAYFIT\\b/i')
+    })
+
+    it("should build a regexp from the bill's vendor if nothing else exists", () => {
+      getBrands.mockReturnValueOnce([])
+      const bill = { vendor: 'Payfit' }
+      const regexp = getBillRegexp(bill)
+
+      expect(regexp.toString()).toBe('/\\bPayfit\\b/i')
     })
   })
 })

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -228,5 +228,12 @@ describe('getterHelper', () => {
 
       expect(regexp.toString()).toBe('/\\bPayfit\\b/i')
     })
+
+    it('should return null if the bill has no labelRegex and no vendor', () => {
+      const bill = {}
+      const regexp = getBillRegexp(bill)
+
+      expect(regexp).toBe(null)
+    })
   })
 })

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -73,42 +73,59 @@ describe('getterHelper', () => {
   describe('getAmountRangeFromBill', () => {
     const minAmountDelta = 1
     const maxAmountDelta = 1
+    const options = { minAmountDelta, maxAmountDelta }
+    const creditOptions = { ...options, credit: true }
     const amount = 7.5
     const originalAmount = 25
 
+    const matchingCriterias = {
+      amountLowerDelta: 2,
+      amountUpperDelta: 2
+    }
+
     const bill1 = { amount }
     const bill2 = { amount, originalAmount }
-    const options = { minAmountDelta, maxAmountDelta }
-    const creditOptions = { ...options, credit: true }
+    const bill3 = { amount, matchingCriterias }
+    const bill4 = { ...bill2, matchingCriterias }
 
     it('should find debit amount range (negative)', () => {
-      const { minAmount, maxAmount } = getAmountRangeFromBill(bill1, options)
-      expect(minAmount).toEqual(-8.5)
-      expect(maxAmount).toEqual(-6.5)
+      const bill1Range = getAmountRangeFromBill(bill1, options)
+      expect(bill1Range.minAmount).toEqual(-8.5)
+      expect(bill1Range.maxAmount).toEqual(-6.5)
+
+      const bill3Range = getAmountRangeFromBill(bill3, options)
+      expect(bill3Range.minAmount).toEqual(-9.5)
+      expect(bill3Range.maxAmount).toEqual(-5.5)
     })
 
     it('should find debit amount range of bill with originalAmount (negative)', () => {
-      const { minAmount, maxAmount } = getAmountRangeFromBill(bill2, options)
-      expect(minAmount).toEqual(-26)
-      expect(maxAmount).toEqual(-24)
+      const bill2Range = getAmountRangeFromBill(bill2, options)
+      expect(bill2Range.minAmount).toEqual(-26)
+      expect(bill2Range.maxAmount).toEqual(-24)
+
+      const bill4Range = getAmountRangeFromBill(bill4, options)
+      expect(bill4Range.minAmount).toEqual(-27)
+      expect(bill4Range.maxAmount).toEqual(-23)
     })
 
     it('sould find credit amount range (positive)', () => {
-      const { minAmount, maxAmount } = getAmountRangeFromBill(
-        bill1,
-        creditOptions
-      )
-      expect(minAmount).toEqual(6.5)
-      expect(maxAmount).toEqual(8.5)
+      const bill1Range = getAmountRangeFromBill(bill1, creditOptions)
+      expect(bill1Range.minAmount).toEqual(6.5)
+      expect(bill1Range.maxAmount).toEqual(8.5)
+
+      const bill3Range = getAmountRangeFromBill(bill3, creditOptions)
+      expect(bill3Range.minAmount).toEqual(5.5)
+      expect(bill3Range.maxAmount).toEqual(9.5)
     })
 
     it('should find credit amount range of bill with originalAmount (positive)', () => {
-      const { minAmount, maxAmount } = getAmountRangeFromBill(
-        bill2,
-        creditOptions
-      )
-      expect(minAmount).toEqual(6.5)
-      expect(maxAmount).toEqual(8.5)
+      const bill2Range = getAmountRangeFromBill(bill2, creditOptions)
+      expect(bill2Range.minAmount).toEqual(6.5)
+      expect(bill2Range.maxAmount).toEqual(8.5)
+
+      const bill4Range = getAmountRangeFromBill(bill4, creditOptions)
+      expect(bill4Range.minAmount).toEqual(5.5)
+      expect(bill4Range.maxAmount).toEqual(9.5)
     })
   })
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
@@ -1,11 +1,14 @@
 const includes = require('lodash/includes')
 const sumBy = require('lodash/sumBy')
 const isWithinRange = require('date-fns/is_within_range')
-const { getBrands } = require('ducks/brandDictionary')
 const { log } = require('../../utils')
 const { getCategoryId } = require('../../../categories/helpers')
 
-const { getDateRangeFromBill, getAmountRangeFromBill } = require('./helpers')
+const {
+  getDateRangeFromBill,
+  getAmountRangeFromBill,
+  getBillRegexp
+} = require('./helpers')
 
 // constants
 
@@ -47,10 +50,7 @@ const isHealthBill = bill => {
 
 // filters
 const filterByBrand = bill => {
-  const [brand] = getBrands(
-    brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
-  )
-  const regexp = new RegExp(brand ? brand.regexp : `\\b${bill.vendor}\\b`, 'i')
+  const regexp = getBillRegexp(bill)
 
   const brandFilter = operation => {
     const label = operation.label.toLowerCase()

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
@@ -53,6 +53,10 @@ const filterByBrand = bill => {
   const regexp = getBillRegexp(bill)
 
   const brandFilter = operation => {
+    if (!regexp) {
+      return false
+    }
+
     const label = operation.label.toLowerCase()
     return label.match(regexp)
   }

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
@@ -26,6 +26,15 @@ describe('operations filters', () => {
       expect(fByBrand({ label: 'tartanpion 17/09' })).toBeTruthy()
       expect(fByBrand({ label: 'Rien à voir' })).toBeFalsy()
     })
+
+    it('should use the regexp from the bill if it has one', () => {
+      const bill = { matchingCriterias: { labelRegex: 'Bidule' } }
+      const fByBrand = filterByBrand(bill)
+
+      expect(fByBrand({ label: 'Chez Bidule !!!' })).toBe(true)
+      expect(fByBrand({ label: 'bidule 20/08' })).toBe(true)
+      expect(fByBrand({ label: 'Ca match paaaas du tout' })).toBe(false)
+    })
   })
 
   test('filtering by date period', () => {

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
@@ -35,6 +35,13 @@ describe('operations filters', () => {
       expect(fByBrand({ label: 'bidule 20/08' })).toBe(true)
       expect(fByBrand({ label: 'Ca match paaaas du tout' })).toBe(false)
     })
+
+    it('should return false if the bill has no vendor and no regex', () => {
+      const bill = {}
+      const fByBrand = filterByBrand(bill)
+
+      expect(fByBrand({ label: 'Something' })).toBe(false)
+    })
   })
 
   test('filtering by date period', () => {

--- a/src/ducks/billsMatching/matchFromBills.spec.js
+++ b/src/ducks/billsMatching/matchFromBills.spec.js
@@ -1,0 +1,26 @@
+import matchFromBills from './matchFromBills'
+import { Transaction } from 'models'
+
+jest.mock('./Linker/Linker')
+
+const bills = [
+  { originalDate: '2019-07-01', date: '2019-07-05' },
+  { date: '2019-07-19' },
+  { date: '2019-08-01' },
+  { date: '2019-08-20' }
+]
+
+beforeEach(() => {
+  jest.spyOn(Transaction, 'queryAll').mockImplementation(() => {})
+})
+
+it('should fetch the potentials bills', async () => {
+  await matchFromBills(bills)
+
+  expect(Transaction.queryAll).toHaveBeenCalledWith({
+    date: {
+      $gt: '2019-06-16',
+      $lt: '2019-09-18'
+    }
+  })
+})

--- a/src/ducks/billsMatching/matchFromBills.spec.js
+++ b/src/ducks/billsMatching/matchFromBills.spec.js
@@ -5,7 +5,13 @@ jest.mock('./Linker/Linker')
 
 const bills = [
   { originalDate: '2019-07-01', date: '2019-07-05' },
-  { date: '2019-07-19' },
+  {
+    date: '2019-07-19',
+    matchingCriterias: {
+      dateLowerDelta: 60,
+      dateUpperDelta: 30
+    }
+  },
   { date: '2019-08-01' },
   { date: '2019-08-20' }
 ]
@@ -19,7 +25,7 @@ it('should fetch the potentials bills', async () => {
 
   expect(Transaction.queryAll).toHaveBeenCalledWith({
     date: {
-      $gt: '2019-06-16',
+      $gt: '2019-05-20',
       $lt: '2019-09-18'
     }
   })

--- a/src/ducks/billsMatching/matchFromTransactions.js
+++ b/src/ducks/billsMatching/matchFromTransactions.js
@@ -1,13 +1,12 @@
 import { max, min } from 'lodash'
-import { DEFAULT_FUTURE_WINDOW, DEFAULT_PAST_WINDOW } from './Linker/Linker'
-import { format as formatDate, addDays, subDays } from 'date-fns'
+import { format as formatDate, addYears, subYears } from 'date-fns'
 import { Bill } from 'models'
 import Linker from './Linker/Linker'
 
 export default async function matchFromTransactions(transactions) {
   const transactionsDates = transactions.map(transaction => transaction.date)
-  const dateMin = subDays(min(transactionsDates), DEFAULT_FUTURE_WINDOW)
-  const dateMax = addDays(max(transactionsDates), DEFAULT_PAST_WINDOW)
+  const dateMin = subYears(min(transactionsDates), 1)
+  const dateMax = addYears(max(transactionsDates), 1)
 
   const selector = {
     date: {

--- a/src/ducks/billsMatching/matchFromTransactions.spec.js
+++ b/src/ducks/billsMatching/matchFromTransactions.spec.js
@@ -1,0 +1,25 @@
+import matchFromTransactions from './matchFromTransactions'
+import { Bill } from 'models'
+
+jest.mock('./Linker/Linker')
+
+const transactions = [
+  { date: '2019-07-01' },
+  { date: '2019-07-20' },
+  { date: '2019-08-21' }
+]
+
+beforeEach(() => {
+  jest.spyOn(Bill, 'queryAll').mockImplementation(() => {})
+})
+
+it('should fetch the potentials bills', async () => {
+  await matchFromTransactions(transactions)
+
+  expect(Bill.queryAll).toHaveBeenCalledWith({
+    date: {
+      $gt: '2019-06-02',
+      $lt: '2019-09-05'
+    }
+  })
+})

--- a/src/ducks/billsMatching/matchFromTransactions.spec.js
+++ b/src/ducks/billsMatching/matchFromTransactions.spec.js
@@ -18,8 +18,8 @@ it('should fetch the potentials bills', async () => {
 
   expect(Bill.queryAll).toHaveBeenCalledWith({
     date: {
-      $gt: '2019-06-02',
-      $lt: '2019-09-05'
+      $gt: '2018-07-01',
+      $lt: '2020-08-21'
     }
   })
 })

--- a/test/fixtures/matching-service/cases/18.js
+++ b/test/fixtures/matching-service/cases/18.js
@@ -1,0 +1,30 @@
+module.exports = {
+  description: 'bill with own label regex',
+  bills: [
+    {
+      _id: 'b1',
+      amount: 2000,
+      date: '2019-07-31T00:00:00.000Z',
+      vendor: 'Payfit',
+      isRefund: true,
+      matchingCriterias: {
+        labelRegex: '\\bCOZY CLOUD\\b'
+      }
+    }
+  ],
+  operations: [
+    {
+      _id: 'salary',
+      date: '2019-07-30T12:00:00.000Z',
+      label: '3019287s DE: COZY CLOUD MOTIF: 07/2019',
+      amount: 2000,
+      manualCategoryId: '200110'
+    }
+  ],
+  expectedResult: {
+    b1: {
+      debitOperation: undefined,
+      creditOperation: 'salary'
+    }
+  }
+}

--- a/test/fixtures/matching-service/cases/19.js
+++ b/test/fixtures/matching-service/cases/19.js
@@ -1,0 +1,47 @@
+module.exports = {
+  description: 'bill with own date deltas',
+  bills: [
+    {
+      _id: 'b1',
+      amount: 30,
+      date: '2019-07-31T00:00:00.000Z',
+      vendor: 'sosh',
+      matchingCriterias: {
+        dateLowerDelta: 30
+      }
+    },
+    {
+      _id: 'b2',
+      amount: 50,
+      date: '2019-08-01T00:00:00.000Z',
+      vendor: 'sfr',
+      matchingCriterias: {
+        dateUpperDelta: 40
+      }
+    }
+  ],
+  operations: [
+    {
+      _id: 'op1',
+      date: '2019-07-01T12:00:00.000Z',
+      label: 'SOSH',
+      amount: -30
+    },
+    {
+      _id: 'op2',
+      date: '2019-09-01T12:00:00.000Z',
+      label: 'SFR',
+      amount: -50
+    }
+  ],
+  expectedResult: {
+    b1: {
+      debitOperation: 'op1',
+      creditOperation: undefined
+    },
+    b2: {
+      debitOperation: 'op2',
+      creditOperation: undefined
+    }
+  }
+}

--- a/test/fixtures/matching-service/cases/20.js
+++ b/test/fixtures/matching-service/cases/20.js
@@ -1,0 +1,28 @@
+module.exports = {
+  description: 'bill with own amount deltas',
+  bills: [
+    {
+      _id: 'b1',
+      amount: 30,
+      date: '2019-07-31T00:00:00.000Z',
+      vendor: 'pouet',
+      matchingCriterias: {
+        amountLowerDelta: 2
+      }
+    }
+  ],
+  operations: [
+    {
+      _id: 'op1',
+      date: '2019-07-31T12:00:00.000Z',
+      label: 'pouet',
+      amount: -32
+    }
+  ],
+  expectedResult: {
+    b1: {
+      debitOperation: 'op1',
+      creditOperation: undefined
+    }
+  }
+}

--- a/test/fixtures/matching-service/cases/21.js
+++ b/test/fixtures/matching-service/cases/21.js
@@ -1,0 +1,24 @@
+module.exports = {
+  description: 'bill without vendor',
+  bills: [
+    {
+      _id: 'b1',
+      amount: 30,
+      date: '2019-07-31T00:00:00.000Z'
+    }
+  ],
+  operations: [
+    {
+      _id: 'op1',
+      date: '2019-07-31T12:00:00.000Z',
+      label: 'Anything',
+      amount: -30
+    }
+  ],
+  expectedResult: {
+    b1: {
+      debitOperation: undefined,
+      creditOperation: undefined
+    }
+  }
+}


### PR DESCRIPTION
The `io.cozy.bills` documents can now carry some matching criterias (see https://github.com/cozy/cozy-doctypes/blob/master/docs/io.cozy.bills.md#optional-attributes-but-some-are-important-depending-the-context). This PR updates the matching algorithm so these criterias are taken into account if they exist. If a bill doesn't have its own matching criterias, the previous defaults criterias apply.

This PR misses the combined bills with criterias case. I'm going to handle it in its own PR so this one is not delayed in its entirety.