### PR TITLE
Handle matching criterias in combined bills

### DIFF
--- a/src/ducks/billsMatching/Linker/Linker.spec.js
+++ b/src/ducks/billsMatching/Linker/Linker.spec.js
@@ -542,5 +542,64 @@ describe('linker', () => {
         expect(combinedBill.originalDate).toBe('2018-03-10T00:00:00Z')
       })
     })
+
+    describe('mergeMatchingCriterias', () => {
+      it('should merge criterias', () => {
+        const bills = [
+          {
+            matchingCriterias: {
+              labelRegex: '\\binulogic\\b',
+              amountLowerDelta: 2,
+              amountUpperDelta: 2,
+              dateLowerDelta: 30,
+              dateUpperDelta: 30
+            }
+          },
+          {
+            matchingCriterias: {
+              labelRegex: '(impot|impots)',
+              amountLowerDelta: 10,
+              amountUpperDelta: 10,
+              dateLowerDelta: 20,
+              dateUpperDelta: 20
+            }
+          }
+        ]
+
+        const criterias = linker.mergeMatchingCriterias(bills)
+        const regex = new RegExp(criterias.labelRegex, 'i')
+
+        expect(criterias.labelRegex).toBe('(\\binulogic\\b|(impot|impots))')
+
+        expect('INULOGIC 22-08-2019'.match(regex)).toBeTruthy()
+        expect('IMPOT blablabla'.match(regex)).toBeTruthy()
+        expect('IMPOTS blablabla'.match(regex)).toBeTruthy()
+        expect('INULOGIC IMPOT IMPOTS'.match(regex)).toBeTruthy()
+        expect(criterias.amountLowerDelta).toBe(10)
+        expect(criterias.amountUpperDelta).toBe(10)
+        expect(criterias.dateLowerDelta).toBe(30)
+        expect(criterias.dateUpperDelta).toBe(30)
+      })
+
+      it('should use defaults if needed', () => {
+        const bills = [
+          {
+            matchingCriterias: {
+              amountLowerDelta: 2,
+              dateLowerDelta: 10
+            }
+          },
+          {}
+        ]
+
+        const criterias = linker.mergeMatchingCriterias(bills)
+
+        expect(criterias.labelRegex).not.toBeDefined()
+        expect(criterias.amountLowerDelta).toBe(2)
+        expect(criterias.amountUpperDelta).toBe(0.001)
+        expect(criterias.dateLowerDelta).toBe(15)
+        expect(criterias.dateUpperDelta).toBe(29)
+      })
+    })
   })
 })

--- a/test/fixtures/matching-service/cases/22-combined-health-bills.json
+++ b/test/fixtures/matching-service/cases/22-combined-health-bills.json
@@ -1,0 +1,51 @@
+{
+  "description": "health bills on the same date should combine",
+  "bills": [
+    {
+      "_id": "b1",
+      "amount": 10,
+      "groupAmount": 20,
+      "originalDate": "2018-07-19T00:00:00.000Z",
+      "date": "2018-07-25T00:00:00.000Z",
+      "isRefund": true,
+      "vendor": "Ameli",
+      "type": "health_costs"
+    },
+    {
+      "_id": "b2",
+      "amount": 10,
+      "groupAmount": 20,
+      "originalDate": "2018-07-19T00:00:00.000Z",
+      "date": "2018-07-25T00:00:00.000Z",
+      "isRefund": true,
+      "vendor": "Ameli",
+      "type": "health_costs"
+    }
+  ],
+  "operations": [
+    {
+      "_id": "op1",
+      "date": "2018-07-19T12:00:00.000Z",
+      "label": "Ophtalmo",
+      "amount": -20,
+      "manualCategoryId": "400610"
+    },
+    {
+      "_id": "reimbur",
+      "date": "2018-07-20T12:00:00.000Z",
+      "label": "CPAM",
+      "amount": 20,
+      "manualCategoryId": "400610"
+    }
+  ],
+  "expectedResult": {
+    "b1": {
+      "debitOperation": "op1",
+      "creditOperation": "reimbur"
+    },
+    "b2": {
+      "debitOperation": "op1",
+      "creditOperation": "reimbur"
+    }
+  }
+}

--- a/test/fixtures/matching-service/cases/23-combined-health-bills-with-criterias.json
+++ b/test/fixtures/matching-service/cases/23-combined-health-bills-with-criterias.json
@@ -1,0 +1,63 @@
+{
+  "description": "combined bills should have their matching criterias merged",
+  "bills": [
+    {
+      "_id": "b1",
+      "amount": 10,
+      "groupAmount": 20,
+      "originalDate": "2018-07-19T00:00:00.000Z",
+      "date": "2018-07-25T00:00:00.000Z",
+      "isRefund": true,
+      "vendor": "Ameli",
+      "type": "health_costs",
+      "matchingCriterias": {
+        "amountLowerDelta": 0.1,
+        "amountUpperDelta": 0.1,
+        "dateLowerDelta": 20,
+        "dateUpperDelta": 20
+      }
+    },
+    {
+      "_id": "b2",
+      "amount": 10,
+      "groupAmount": 20,
+      "originalDate": "2018-07-19T00:00:00.000Z",
+      "date": "2018-07-25T00:00:00.000Z",
+      "isRefund": true,
+      "vendor": "Ameli",
+      "type": "health_costs",
+      "matchingCriterias": {
+        "amountLowerDelta": 0.2,
+        "amountUpperDelta": 0.2,
+        "dateLowerDelta": 40,
+        "dateUpperDelta": 40
+      }
+    }
+  ],
+  "operations": [
+    {
+      "_id": "op1",
+      "date": "2018-06-19T12:00:00.000Z",
+      "label": "Ophtalmo",
+      "amount": -20.2,
+      "manualCategoryId": "400610"
+    },
+    {
+      "_id": "reimbur",
+      "date": "2018-07-20T12:00:00.000Z",
+      "label": "CPAM",
+      "amount": 20,
+      "manualCategoryId": "400610"
+    }
+  ],
+  "expectedResult": {
+    "b1": {
+      "debitOperation": "op1",
+      "creditOperation": "reimbur"
+    },
+    "b2": {
+      "debitOperation": "op1",
+      "creditOperation": "reimbur"
+    }
+  }
+}


### PR DESCRIPTION
This was the last missing piece in https://github.com/cozy/cozy-banks/pull/1465. Now we also handle matching criterias when we try to combine bills by making the union of the different matching criterias. At the moment, we can't find a real application to this, but it ensures that the matching doesn't crash if it happens.