### PR TITLE
Fixes in services

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,7 +242,8 @@
     ],
     "transform": {
       "^.+\\.jsx?$": "babel-jest",
-      "\\.(hbs|css)$": "<rootDir>/test/readFile.js"
+      "\\.css$": "<rootDir>/test/readFile.js",
+      "\\.hbs$": "<rootDir>/test/readFileESM.js"
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(cozy-ui|cozy-client))"

--- a/src/ducks/notifications/html/templates/index.js
+++ b/src/ducks/notifications/html/templates/index.js
@@ -88,25 +88,27 @@ layouts.register(Handlebars)
 
 const partials = {
   'bank-layout': Handlebars.compile(
-    require('ducks/notifications/html/templates/bank-layout.hbs')
+    require('ducks/notifications/html/templates/bank-layout.hbs').default
   ),
   'cozy-layout': Handlebars.compile(
-    require('ducks/notifications/html/templates/cozy-layout.hbs')
+    require('ducks/notifications/html/templates/cozy-layout.hbs').default
   ),
   'balance-lower': Handlebars.compile(
-    require('ducks/notifications/html/templates/balance-lower.hbs')
+    require('ducks/notifications/html/templates/balance-lower.hbs').default
   ),
   'transaction-greater': Handlebars.compile(
     require('ducks/notifications/html/templates/transaction-greater.hbs')
+      .default
   ),
   'health-bill-linked': Handlebars.compile(
-    require('ducks/notifications/html/templates/health-bill-linked.hbs')
+    require('ducks/notifications/html/templates/health-bill-linked.hbs').default
   ),
   'late-health-reimbursement': Handlebars.compile(
     require('ducks/notifications/html/templates/late-health-reimbursement.hbs')
+      .default
   ),
   'delayed-debit': Handlebars.compile(
-    require('ducks/notifications/html/templates/delayed-debit.hbs')
+    require('ducks/notifications/html/templates/delayed-debit.hbs').default
   )
 }
 

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -60,9 +60,10 @@ const doBillsMatching = async setting => {
           billsChanges.documents.length
         } new bills since last execution. Trying to find transactions for them`
       )
+
+      const result = await matchFromBills(billsChanges.documents)
+      logResult(result)
     }
-    const result = await matchFromBills(billsChanges.documents)
-    logResult(result)
   } catch (e) {
     log('error', `[matching service] ${e}`)
   }

--- a/test/readFileESM.js
+++ b/test/readFileESM.js
@@ -1,0 +1,5 @@
+module.exports = {
+  process: function(fileContent) {
+    return `module.exports = { default: \`${fileContent}\` }`
+  }
+}


### PR DESCRIPTION
There were two problems:

* We recently update raw-loader from v1 to v3. But since v2 it uses ES modules, so we had to reflect that when using it to import handlebars templates
* `matchFromBills` could be executed with an empty array, which is useless