### PR TITLE
chore: Grouping related packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,33 @@
 {
   "extends": [
     "cozy"
+  ],
+  "packageRules": [
+    {
+      "packagePatterns": [
+          "cozy-authentication",
+          "cozy-doctypes",
+          "cozy-flags",
+          "cozy-interapp",
+          "cozy-logger",
+          "cozy-realtime"
+      ],
+      "groupName": "cozy-libs packages"
+    },
+    {
+      "packagePatterns": [
+          "cozy-client",
+          "cozy-pouch-link",
+          "cozy-stack-client"
+      ],
+      "groupName": "cozy-client packages"
+    },
+    {
+      "packagePatterns": [
+          "cozy-jobs-cli",
+          "cozy-konnector-libs"
+      ],
+      "groupName": "cozy-konnectors packages"
+    }
   ]
 }


### PR DESCRIPTION
I am trying to group related packages to have less noise in GitHub notification area.
If it works well for banks, we could put this into the renovate config for cozy.