### PR TITLE
feat(onOperationOrBillCreate): Find bills for all updated transactions

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -66,7 +66,7 @@
     "onOperationOrBillCreate": {
       "type": "node",
       "file": "onOperationOrBillCreate.js",
-      "trigger": "@event io.cozy.bills:CREATED",
+      "trigger": "@event io.cozy.bills:CREATED io.cozy.bank.operations:UPDATED:!=:manualCategoryId",
       "debounce": "75s"
     },
     "categorization": {

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -9,7 +9,6 @@ import matchFromBills from 'ducks/billsMatching/matchFromBills'
 import matchFromTransactions from 'ducks/billsMatching/matchFromTransactions'
 import { logResult } from 'ducks/billsMatching/utils'
 import { findAppSuggestions } from 'ducks/appSuggestions/services'
-import { isNew as isNewTransaction } from 'ducks/transactions/helpers'
 import { fetchChangesOrAll, getOptions } from './helpers'
 
 const log = logger.namespace('onOperationOrBillCreate')
@@ -63,9 +62,7 @@ const doTransactionsMatching = async (setting, options = {}) => {
       Transaction,
       transactionsLastSeq
     )
-    transactionsChanges.documents = transactionsChanges.documents.filter(
-      isNewTransaction
-    )
+
     setting.billsMatching.transactionsLastSeq = transactionsChanges.newLastSeq
 
     if (transactionsChanges.documents.length === 0) {


### PR DESCRIPTION
When a user manually categorizes a transaction, we want to apply the
matching algorithm to it. For example, if a transaction is recategorized
to health expense category, maybe we can find a related bill that didn't
match previously because the category was not good.

I see a possible problem with that though: the service will be run twice when a transaction matched with a bill, because the matching updates the transaction. I don't know how I can do better than that actually. The only solution I have in mind is to compare the document and its previous revision to see precisely what changed and skip some parts of the service if needed. But the service will still be run twice.

I think it shows that we need to split the `onOperationOrBillCreate` service into multiple ones. Any thoughts?