### PR TITLE
fix(notifications): Correctly import stylesheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,7 +243,7 @@
     ],
     "transform": {
       "^.+\\.jsx?$": "babel-jest",
-      "\\.css$": "<rootDir>/test/readFile.js",
+      "\\.css$": "<rootDir>/test/readFileESM.js",
       "\\.hbs$": "<rootDir>/test/readFileESM.js"
     },
     "transformIgnorePatterns": [

--- a/src/ducks/notifications/html/templates/index.js
+++ b/src/ducks/notifications/html/templates/index.js
@@ -19,7 +19,9 @@ const capitalizeWord = str => {
 }
 
 const embeds = {
-  'style.css': require('!!raw-loader!ducks/notifications/html/templates/style.css') // eslint-disable-line import/no-webpack-loader-syntax
+  // eslint-disable-next-line import/no-webpack-loader-syntax
+  'style.css': require('!!raw-loader!ducks/notifications/html/templates/style.css')
+    .default
 }
 
 Handlebars.registerHelper({


### PR DESCRIPTION
In https://github.com/cozy/cozy-banks/pull/1476 I forgot one place where the raw-loader is used and it introduced a regression in the notifications mails styles. Because basically no more styles from `styles.css` were imported.