### PR TITLE
fix(History): Don't render the chart if width is undefined

### DIFF
--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -87,14 +87,20 @@ class History extends Component {
   }
 
   render() {
-    const { transactions, className } = this.props
+    const {
+      transactions,
+      className,
+      size: { width }
+    } = this.props
+
+    const hasWidth = width !== undefined
 
     const isTransactionsLoading =
       isCollectionLoading(transactions) && !hasBeenLoaded(transactions)
 
     return (
       <div className={cx(styles.History, className)}>
-        {isTransactionsLoading ? (
+        {isTransactionsLoading || !hasWidth ? (
           <Spinner size="xxlarge" color="white" />
         ) : (
           <HistoryChart {...this.getChartProps()} />


### PR DESCRIPTION
On first render the `size` prop contains an empty object. We need to
handle that case or the width passed to the `HistoryChart` component can
be `undefined`, creating a glitch on the appear animation.

Before:
![image](https://user-images.githubusercontent.com/1606068/63780379-4c533480-c8e8-11e9-8928-7bceb5748f39.png)

After:
![image](https://user-images.githubusercontent.com/1606068/63780313-32b1ed00-c8e8-11e9-8284-75be93868763.png)
