### PR TITLE
Make doc publishable on docs.cozy.io

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,13 +1,13 @@
 # Demo
 
-## Fake connectors success state in Collect
+## Fake connectors success state in Cozy Home
 
-On demo instances, we use fixtures, not real data. But we need to show some connectors
-successfully connected in Collect. Here is how to do that :
+On demo instances, we use fixtures, not real data. But we need to show some
+connectors successfully connected in Collect. Here is how to do that :
 
 * Install a connector via the Store
 * Configure an account that doesn't exist on this service
-* In collect, the connector shows an error, it's normal for the moment
+* In the Home, the connector shows an error, it's normal for the moment
 * Connect to CouchDB of the environment the instance lives on
 * Find the latest job for the connector and update its `state` to `done` and remove its `error` property
 * Find the trigger for the connector and update its `arguments` to a yearly CRON. For example `0 0 0 15 1 *` will run this trigger once every january 15th

--- a/toc.yml
+++ b/toc.yml
@@ -1,0 +1,10 @@
+- README: ./README.md
+- Develop: ./docs/dev.md
+- "Bank account types": ./docs/account-types.md
+- "Matching algorithm": ./docs/bills-matching.md
+- "Brands dictionary": ./docs/brand-dictionary.md
+- "Demo tricks": ./docs/demo.md
+- Notifications: ./docs/notifications.md
+- "Override Cordova project config.xml": ./docs/override-cordova-config.md
+- Services: ./docs/services.md
+- Tracking: ./docs/tracking.md


### PR DESCRIPTION
We want to add our documentation to docs.cozy.io. This PR prepares this by reworking the development guide and adding a TOC file.

Some parts of our documentation looks old. We must update it, but doing it in one-shot can be hard. I propose we open small PRs from time to time to enhance it.