### PR TITLE
Use COZY_TIME_LIMIT env variable in categorization service instead of hard coded time

### DIFF
--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -30,7 +30,7 @@ export const fetchTransactionsToCategorize = () => {
 /**
  * Fetch transactions to categorize and chunk them
  *
- * @return {Object[][]} The chunks to categorize
+ * @return {io.cozy.bank.operations[][]} The chunks to categorize
  */
 export const fetchChunksToCategorize = async () => {
   const toCategorize = await fetchTransactionsToCategorize()
@@ -44,7 +44,7 @@ export const fetchChunksToCategorize = async () => {
  * Apply global and local categorization models to a chunk
  *
  * @param {Object} categorizer - A categorizer (see https://docs.cozy.io/en/cozy-konnector-libs/api/#categorization)
- * @param {Object[]} chunk - An array of io.cozy.bank.operations to categorize
+ * @param {io.cozy.bank.operations[]} chunk - Operations to categorize
  *
  * @return {Number} the time taken to categorize the chunk
  */

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -12,7 +12,7 @@ BankTransaction.registerClient(cozyClient)
 // Each chunk will contain 100 transactions
 export const CHUNK_SIZE = 100
 
-const MAX_EXECUTION_TIME = 200
+const MAX_EXECUTION_TIME = parseInt(process.env.COZY_TIME_LIMIT, 10)
 const timeStart = new Date()
 let highestTime = 0
 

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -16,12 +16,22 @@ const MAX_EXECUTION_TIME = parseInt(process.env.COZY_TIME_LIMIT, 10)
 const timeStart = new Date()
 let highestTime = 0
 
+/**
+ * Fetch all transactions marked as `toCategorize` by a banking konnector
+ *
+ * @return {Promise} Promise that resolves with an array of io.cozy.bank.operations documents
+ */
 export const fetchTransactionsToCategorize = () => {
   return BankTransaction.queryAll({
     toCategorize: true
   })
 }
 
+/**
+ * Fetch transactions to categorize and chunk them
+ *
+ * @return {Object[][]} The chunks to categorize
+ */
 export const fetchChunksToCategorize = async () => {
   const toCategorize = await fetchTransactionsToCategorize()
   const sortedToCategorize = sortBy(toCategorize, t => t.date).reverse()
@@ -30,6 +40,14 @@ export const fetchChunksToCategorize = async () => {
   return chunks
 }
 
+/**
+ * Apply global and local categorization models to a chunk
+ *
+ * @param {Object} categorizer - A categorizer (see https://docs.cozy.io/en/cozy-konnector-libs/api/#categorization)
+ * @param {Object[]} chunk - An array of io.cozy.bank.operations to categorize
+ *
+ * @return {Number} the time taken to categorize the chunk
+ */
 export const categorizeChunk = async (categorizer, chunk) => {
   const timeStart = new Date()
   const categorizedTransactions = categorizer.categorize(chunk)
@@ -45,6 +63,11 @@ export const categorizeChunk = async (categorizer, chunk) => {
   return timeElapsed
 }
 
+/**
+ * Send local categorization results to Matomo for stats
+ *
+ * @param {Object[]} transactions - An array of categorized io.cozy.bank.operations
+ */
 export const sendResultsToMatomo = transactions => {
   const tracker = getTracker(__TARGET__, { e_a: 'LocalCategorization' })
   const nbTransactionsAboveThreshold = transactions.reduce(
@@ -64,10 +87,22 @@ export const sendResultsToMatomo = transactions => {
   })
 }
 
+/**
+ * Set the highest time taken to categorize a chunk
+ * This value is used to check if there is enough time left to categorize
+ * another chunk
+ *
+ * @param {number} time - The time to compare and save if needed
+ */
 export const updateTimeTracking = time => {
   highestTime = Math.max(highestTime, time)
 }
 
+/**
+ * Tell if there is enough time left to categorize the next chunk or not
+ *
+ * @return {boolean}
+ */
 export const canCategorizeNextChunk = () => {
   const executionTime = differenceInSeconds(new Date(), timeStart)
   const nextExecutionTime = executionTime + highestTime
@@ -75,6 +110,13 @@ export const canCategorizeNextChunk = () => {
   return nextExecutionTime < MAX_EXECUTION_TIME
 }
 
+/**
+ * Ask the stack to start a banks' service
+ *
+ * @param {string} name - The name of the service to start
+ *
+ * @return {Promise}
+ */
 export const startService = name => {
   const args = {
     message: {


### PR DESCRIPTION
While doing a totally unrelated exploration on services, I found that they receive a`COZY_TIME_LIMIT` environment variable that can be used in the `categorization` service instead of the hard coded time limit we had.