### PR TITLE
feat(onOperationOrBillCreate): Get options from env and CLI

### DIFF
--- a/src/targets/services/helpers.js
+++ b/src/targets/services/helpers.js
@@ -1,0 +1,57 @@
+import last from 'lodash/last'
+import get from 'lodash/get'
+
+/**
+ * If lastSeq is 0, it's more efficient to fetch all documents.
+ */
+export const fetchChangesOrAll = async (Model, lastSeq) => {
+  if (lastSeq === '0') {
+    const documents = await Model.fetchAll()
+    // fetch last change to have the last_seq
+    const lastChanges = await Model.fetchChanges('', {
+      descending: true,
+      limit: 1
+    })
+    return { documents, newLastSeq: lastChanges.newLastSeq }
+  } else {
+    return Model.fetchChanges(lastSeq)
+  }
+}
+
+const getJobIdFromEnv = env => {
+  const cozyJobId = env.COZY_JOB_ID
+  const jobId = last(cozyJobId.split('/'))
+
+  return jobId
+}
+
+const getOptionsFromEnv = async (client, env) => {
+  const jobId = getJobIdFromEnv(env)
+  const job = await client.fetchJSON('GET', `/jobs/${jobId}`)
+
+  return get(job, 'attributes.message.arguments')
+}
+
+const getOptionsFromCLI = argv => {
+  try {
+    return JSON.parse(argv.slice(-1)[0])
+  } catch (e) {
+    return {}
+  }
+}
+
+export const getOptions = async (
+  client,
+  env = process.env,
+  argv = process.argv
+) => {
+  const optsFromEnv = await getOptionsFromEnv(client, env)
+  const optsFromCLI = getOptionsFromCLI(argv)
+
+  const options = {
+    ...optsFromEnv,
+    ...optsFromCLI
+  }
+
+  return options
+}

--- a/src/targets/services/helpers.js
+++ b/src/targets/services/helpers.js
@@ -2,16 +2,32 @@ import last from 'lodash/last'
 import get from 'lodash/get'
 
 /**
- * If lastSeq is 0, it's more efficient to fetch all documents.
+ * Returns the changes or all documents. If we want to fetch all changes, it is
+ * more efficient to fetch all the documents, because we don't have to check the
+ * whole history of each document.
+ *
+ * @param {Object} Model - A cozy-doctypes' model class
+ * @param {string} lastSeq - The lastSeq from which you want to fetch the changes. If you give '0', then all documents will be fetched
+ *
+ * @return {Object} an object containing the `documents` and the `newLastSeq`
  */
 export const fetchChangesOrAll = async (Model, lastSeq) => {
   if (lastSeq === '0') {
-    const documents = await Model.fetchAll()
-    // fetch last change to have the last_seq
+    // If we want to fetch all changes, it is more efficient to fetch all the
+    // documents. But we still need to return a `lastSeq` just as if we really
+    // fetched changes. So we fetch only the very last change to have the
+    // lastSeq.
+    // This should be done first to avoid a race condition: if we fetch all
+    // documents then fetch the last change, a document could have been created
+    // between the two, and it will not be part of the documents returned. Since
+    // the lastSeq includes it, it will not be returned next time either.
     const lastChanges = await Model.fetchChanges('', {
       descending: true,
       limit: 1
     })
+
+    const documents = await Model.fetchAll()
+
     return { documents, newLastSeq: lastChanges.newLastSeq }
   } else {
     return Model.fetchChanges(lastSeq)

--- a/src/targets/services/helpers.spec.js
+++ b/src/targets/services/helpers.spec.js
@@ -1,0 +1,82 @@
+import { getOptions } from './helpers'
+
+describe('getOptions', () => {
+  let client
+  let env
+
+  beforeEach(() => {
+    client = {
+      fetchJSON: jest.fn()
+    }
+
+    env = { COZY_JOB_ID: 'service/1/abcd' }
+  })
+
+  it('should return an empty object if no option is given', async () => {
+    client.fetchJSON.mockResolvedValueOnce({})
+    const argv = []
+
+    const options = await getOptions(client, env, argv)
+
+    expect(options).toEqual({})
+  })
+
+  it('should return the options given in the env', async () => {
+    client.fetchJSON.mockResolvedValueOnce({
+      attributes: {
+        message: {
+          arguments: {
+            billsMatching: false,
+            transactionsMatching: false
+          }
+        }
+      }
+    })
+
+    const argv = []
+    const options = await getOptions(client, env, argv)
+
+    expect(options).toEqual({
+      billsMatching: false,
+      transactionsMatching: false
+    })
+  })
+
+  it('should return the options given in the CLI', async () => {
+    client.fetchJSON.mockResolvedValueOnce({})
+    const argv = ['{"billsMatching": false, "transactionsMatching": false}']
+
+    const options = await getOptions(client, env, argv)
+
+    expect(options).toEqual({
+      billsMatching: false,
+      transactionsMatching: false
+    })
+  })
+
+  it('should merge options given in the env and in the CLI', async () => {
+    client.fetchJSON.mockResolvedValueOnce({
+      attributes: {
+        message: {
+          arguments: {
+            billsMatching: false,
+            transactionsMatching: false
+          }
+        }
+      }
+    })
+
+    const argv = [
+      '{"billsMatching": { "lastSeq": "0" }, "transactionsMatching": false}'
+    ]
+
+    const options = await getOptions(client, env, argv)
+
+    expect(options).toEqual({
+      billsMatching: {
+        lastSeq: '0'
+      },
+      transactionsMatching: false
+    })
+  })
+})

--- a/src/targets/services/helpers.spec.js
+++ b/src/targets/services/helpers.spec.js
@@ -1,4 +1,4 @@
-import { getOptions } from './helpers'
+import { getOptions, fetchChangesOrAll } from './helpers'
 
 describe('getOptions', () => {
   let client
@@ -78,5 +78,34 @@ describe('getOptions', () => {
       },
       transactionsMatching: false
     })
+  })
+})
+
+describe('fetchChangesOrAll', () => {
+  class Model {}
+  Model.fetchChanges = jest.fn().mockResolvedValue({ newLastSeq: '1234' })
+  Model.fetchAll = jest.fn()
+
+  afterEach(() => {
+    Model.fetchChanges.mockClear()
+    Model.fetchAll.mockClear()
+  })
+
+  it('should return all documents if lastSeq is "0"', async () => {
+    await fetchChangesOrAll(Model, '0')
+
+    expect(Model.fetchChanges).toHaveBeenCalledWith('', {
+      descending: true,
+      limit: 1
+    })
+
+    expect(Model.fetchAll).toHaveBeenCalled()
+  })
+
+  it('should return changes if lastSeq is not "0"', async () => {
+    await fetchChangesOrAll(Model, 'abcd')
+
+    expect(Model.fetchChanges).toHaveBeenCalledWith('abcd')
+    expect(Model.fetchAll).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
With this we can now pass arguments to the `onOperationOrBillCreate` service. For example by doing `cozy-stack --domain default.cozy.tools:8080 jobs run service --json '{"slug": "banks", "name": "onOperationOrBillCreate", "file": "onOperationOrBillCreate.js", "arguments": {"transactionsMatching": false, "billsMatching": { "lastSeq": "0"  } }}'` we can run the service and make it try to match all bills but bypass the matching from transactions.