### PR TITLE
Display connection problems in Banks

### DIFF
--- a/src/components/Carrousel.jsx
+++ b/src/components/Carrousel.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+import compose from 'lodash/flowRight'
+import SwipeableViews from 'react-swipeable-views'
+import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
+import { withBreakpoints } from 'cozy-ui/transpiled/react'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import range from 'lodash/range'
+
+const hidden = {
+  visibility: 'hidden'
+}
+
+class Carrousel extends React.PureComponent {
+  constructor(props, context) {
+    super(props, context)
+    this.state = { currentIndex: 0 }
+    this.handleChange = this.handleChange.bind(this)
+    this.handlePrev = this.handlePrev.bind(this)
+    this.handleNext = this.handleNext.bind(this)
+  }
+
+  handleChange(i) {
+    this.setState({ currentIndex: i })
+  }
+
+  handlePrev() {
+    this.setState({ currentIndex: Math.max(0, this.state.currentIndex - 1) })
+  }
+
+  handleNext() {
+    this.setState({
+      currentIndex: Math.min(
+        this.props.children.length - 1,
+        this.state.currentIndex + 1
+      )
+    })
+  }
+
+  render() {
+    const { currentIndex } = this.state
+    const {
+      children,
+      className,
+      breakpoints: { isMobile }
+    } = this.props
+    return (
+      <Media className={className}>
+        <Img
+          style={currentIndex === 0 ? hidden : null}
+          className="u-c-pointer u-slateGrey"
+          onClick={this.handlePrev}
+        >
+          <Icon className={isMobile ? 'u-mh-half' : 'u-mh-1'} icon="left" />
+        </Img>
+        <Bd>
+          <SwipeableViews animateHeight disabled index={currentIndex}>
+            {React.Children.map(children, (child, i) => {
+              return React.cloneElement(child, { active: i === currentIndex })
+            })}
+          </SwipeableViews>
+          <div className="u-ta-center u-slateGrey u-c-pointer">
+            {range(children.length).map((x, i) => (
+              <span key={i} onClick={this.handleChange.bind(this, i)}>
+                {i === currentIndex ? '●' : '○'}
+              </span>
+            ))}
+          </div>
+        </Bd>
+        <Img
+          style={currentIndex === children.length - 1 ? hidden : null}
+          className="u-c-pointer u-slateGrey"
+          onClick={this.handleNext}
+        >
+          <Icon className={isMobile ? 'u-mh-half' : 'u-mh-1'} icon="right" />
+        </Img>
+      </Media>
+    )
+  }
+}
+
+export default compose(
+  withBreakpoints(),
+  React.memo
+)(Carrousel)

--- a/src/components/ErrorCard/index.jsx
+++ b/src/components/ErrorCard/index.jsx
@@ -13,18 +13,23 @@ const ErrorCard = ({
   content,
   buttonLabel,
   buttonHref,
-  buttonIcon
+  buttonIcon,
+  style
 }) => {
   return (
-    <div className={styles.ErrorCard}>
+    <div className={styles.ErrorCard} style={style}>
       <SubTitle className="u-monza">{title}</SubTitle>
-      <Text
-        tag="p"
-        className={cx('u-mt-half', styles.ErrorCard__text)}
-        dangerouslySetInnerHTML={{
-          __html: content
-        }}
-      />
+      {typeof content === 'string' ? (
+        <Text
+          tag="p"
+          className={cx('u-mt-half', styles.ErrorCard__text)}
+          dangerouslySetInnerHTML={{
+            __html: content
+          }}
+        />
+      ) : (
+        content
+      )}
       <ButtonLink
         theme="secondary"
         extension={breakpoints.isMobile ? 'full' : 'narrow'}

--- a/src/components/ErrorCard/index.jsx
+++ b/src/components/ErrorCard/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import compose from 'lodash/flowRight'
+import styles from './styles.styl'
+import { withBreakpoints } from 'cozy-ui/react'
+import Text, { SubTitle } from 'cozy-ui/react/Text'
+import { ButtonLink } from 'cozy-ui/react/Button'
+import cx from 'classnames'
+
+// TODO Move ErrorCard to cozy-ui
+const ErrorCard = ({
+  breakpoints,
+  title,
+  content,
+  buttonLabel,
+  buttonHref,
+  buttonIcon
+}) => {
+  return (
+    <div className={styles.ErrorCard}>
+      <SubTitle className="u-monza">{title}</SubTitle>
+      <Text
+        tag="p"
+        className={cx('u-mt-half', styles.ErrorCard__text)}
+        dangerouslySetInnerHTML={{
+          __html: content
+        }}
+      />
+      <ButtonLink
+        theme="secondary"
+        extension={breakpoints.isMobile ? 'full' : 'narrow'}
+        className="u-mh-0"
+        label={buttonLabel}
+        icon={buttonIcon}
+        href={buttonHref}
+      />
+    </div>
+  )
+}
+
+export default compose(
+  withBreakpoints(),
+  React.memo
+)(ErrorCard)

--- a/src/components/ErrorCard/styles.styl
+++ b/src/components/ErrorCard/styles.styl
@@ -1,0 +1,15 @@
+@require 'settings/breakpoints'
+
+.ErrorCard
+    padding 1.5rem
+    background-color var(--chablis)
+    border-radius 6px
+    text-align left
+
+    +small-screen()
+        padding 1rem
+
+.ErrorCard__text a
+    font-weight bold
+    text-decoration none
+    color var(--primaryColor)

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -1,17 +1,16 @@
 import React from 'react'
 import styles from 'components/KonnectorUpdateInfo/styles.styl'
-import { translate, withBreakpoints } from 'cozy-ui/react'
-import Text, { SubTitle } from 'cozy-ui/react/Text'
+import { translate } from 'cozy-ui/react'
 import Icon from 'cozy-ui/react/Icon'
-import { ButtonLink } from 'cozy-ui/react/Button'
 import { withClient } from 'cozy-client'
 import { flowRight as compose } from 'lodash'
-import { Intents } from 'cozy-interapp'
 import { queryConnect } from 'cozy-client'
 import { KONNECTOR_DOCTYPE } from 'doctypes'
 import { isCollectionLoading } from 'ducks/client/utils'
 import { Padded } from 'components/Spacing'
 import CozyClient from 'cozy-client'
+import ErrorCard from 'components/ErrorCard'
+import { useRedirectionURL } from 'components/effects'
 
 // Utilities on konnectors
 const konnectors = {
@@ -20,85 +19,44 @@ const konnectors = {
   }
 }
 
-class KonnectorUpdateInfo extends React.PureComponent {
-  intents = new Intents({ client: this.props.client })
+const openWithIcon = <Icon icon="openwith" />
 
-  state = {
-    url: null
+const APP_DOCTYPE = 'io.cozy.apps'
+const redirectionOptions = {
+  type: 'konnector',
+  category: 'banking',
+  pendingUpdate: true
+}
+
+const KonnectorUpdateInfo = ({ t, outdatedKonnectors, client }) => {
+  const url = useRedirectionURL(client, APP_DOCTYPE, redirectionOptions)
+
+  if (!url || isCollectionLoading(outdatedKonnectors)) {
+    return null
   }
 
-  async componentDidMount() {
-    try {
-      const url = await this.intents.getRedirectionURL('io.cozy.apps', {
-        type: 'konnector',
-        category: 'banking',
-        pendingUpdate: true
-      })
-
-      if (this.unmounted) {
-        return
-      }
-
-      this.setState({ url })
-    } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('Error while retrieving redirection URL', err)
-    }
+  if (outdatedKonnectors.hasMore) {
+    outdatedKonnectors.fetchMore()
   }
 
-  componentWillUnmount() {
-    this.unmounted = true
+  const bankingKonnectors = outdatedKonnectors.data.filter(
+    konnectors.hasCategory('banking')
+  )
+  if (bankingKonnectors.length === 0) {
+    return null
   }
 
-  render() {
-    const { url } = this.state
-
-    if (!url) {
-      return null
-    }
-
-    const { t, breakpoints, outdatedKonnectors } = this.props
-
-    if (isCollectionLoading(outdatedKonnectors)) {
-      return null
-    }
-
-    if (outdatedKonnectors.hasMore) {
-      outdatedKonnectors.fetchMore()
-    }
-
-    const bankingKonnectors = outdatedKonnectors.data.filter(
-      konnectors.hasCategory('banking')
-    )
-    if (bankingKonnectors.length === 0) {
-      return null
-    }
-
-    return (
-      <Padded className={styles.KonnectorUpdateInfo}>
-        <div className={styles.KonnectorUpdateInfo__inner}>
-          <SubTitle className="u-monza">
-            {t('KonnectorUpdateInfo.title')}
-          </SubTitle>
-          <Text
-            tag="p"
-            className="u-mt-half"
-            dangerouslySetInnerHTML={{
-              __html: t('KonnectorUpdateInfo.content')
-            }}
-          />
-          <ButtonLink
-            icon={<Icon icon="openwith" />}
-            label={t('KonnectorUpdateInfo.cta')}
-            theme="secondary"
-            href={url}
-            extension={breakpoints.isMobile ? 'full' : 'narrow'}
-            className="u-mh-0"
-          />
-        </div>
-      </Padded>
-    )
-  }
+  return (
+    <Padded className={styles.KonnectorUpdateInfo}>
+      <ErrorCard
+        title={t('KonnectorUpdateInfo.title')}
+        content={t('KonnectorUpdateInfo.content')}
+        buttonHref={url}
+        buttonLabel={t('KonnectorUpdateInfo.cta')}
+        buttonIcon={openWithIcon}
+      />
+    </Padded>
+  )
 }
 
 const outdatedKonnectors = {
@@ -113,7 +71,6 @@ const outdatedKonnectors = {
 export default compose(
   translate(),
   withClient,
-  withBreakpoints(),
   queryConnect({
     outdatedKonnectors
   })

--- a/src/components/KonnectorUpdateInfo/styles.styl
+++ b/src/components/KonnectorUpdateInfo/styles.styl
@@ -7,16 +7,3 @@
         padding-left 0.5rem
         padding-right 0.5rem
 
-.KonnectorUpdateInfo__inner
-    padding 1.5rem
-    background-color var(--chablis)
-    border-radius 6px
-    text-align left
-
-    +small-screen()
-        padding 1rem
-
-.KonnectorUpdateInfo__message a
-    font-weight bold
-    text-decoration none
-    color var(--primaryColor)

--- a/src/components/effects.js
+++ b/src/components/effects.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react'
+import { Intents } from 'cozy-interapp'
+
+export const useRedirectionURL = (client, doctype, options) => {
+  const [fetched, setFetched] = useState(null)
+  useEffect(() => {
+    const fetch = async () => {
+      const intents = new Intents({ client: client })
+      const fetchedRes = await intents.getRedirectionURL(doctype, options)
+      setFetched(fetchedRes)
+    }
+    fetch()
+  }, [client.uri, doctype, options])
+  return fetched
+}

--- a/src/components/effects.js
+++ b/src/components/effects.js
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react'
 import { Intents } from 'cozy-interapp'
 
 export const useRedirectionURL = (client, doctype, options) => {
-  const [fetched, setFetched] = useState(null)
+  const [redirectionURL, setRedirectionURL] = useState(null)
   useEffect(() => {
     const fetch = async () => {
       const intents = new Intents({ client: client })
-      const fetchedRes = await intents.getRedirectionURL(doctype, options)
-      setFetched(fetchedRes)
+      const redirectionURL = await intents.getRedirectionURL(doctype, options)
+      setRedirectionURL(redirectionURL)
     }
     fetch()
   }, [client.uri, doctype, options])
-  return fetched
+  return redirectionURL
 }

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -353,11 +353,14 @@ class Balance extends PureComponent {
       flag('no-account') ||
       flag('account-loading')
     ) {
-      let konnectorInfos = triggers.filter(isBankTrigger).map(t => ({
-        konnector: get(t, 'attributes.message.konnector'),
-        account: get(t, 'attributes.message.account'),
-        status: get(t, 'attributes.current_state.status')
-      }))
+      let konnectorInfos = triggers
+        .map(x => x.attributes)
+        .filter(isBankTrigger)
+        .map(t => ({
+          konnector: get(t, 'message.konnector'),
+          account: get(t, 'message.account'),
+          status: get(t, 'current_state.status')
+        }))
 
       if (flag('account-loading')) {
         // eslint-disable-next-line no-console

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -59,19 +59,16 @@
     .AccountRow__figure
         color var(--pomegranate)
 
-.AccountRow__updatedAt
+.AccountRow__subText
     font-size 0.75rem
     color var(--coolGrey)
     line-height 1.5
-
-.AccountRow__updatedAt--old
-    color var(--pomegranate)
 
 .AccountRow__updatedAtIcon
     vertical-align top
     margin-right 0.25rem
 
-.AccountRow__labelUpdatedAtWrapper
+.AccountRow__labelWrapper
     flex 1
     overflow hidden
 

--- a/src/ducks/transactions/TransactionPageErrors.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.jsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import compose from 'lodash/flowRight'
+import sortBy from 'lodash/sortBy'
+import get from 'lodash/get'
+import keyBy from 'lodash/keyBy'
+import mapValues from 'lodash/mapValues'
+
+import CozyClient, { queryConnect } from 'cozy-client'
+
+import { triggersConn } from 'doctypes'
+import { isErrored, isBankTrigger } from 'utils/triggers'
+import Carrousel from 'components/Carrousel'
+import TriggerErrorCard from 'ducks/transactions/TriggerErrorCard'
+
+const getCreatedByApp = acc => get(acc, 'cozyMetadata.createdByApp')
+
+/**
+ * Returns
+ * - failed triggers corresponding to the given accounts.
+ * - a mapping from konnector to institutionLabel (caissedepargne1 -> Caisse d'Epargne)
+ *
+ * Extracted from TransactionPageErrors because it should be closer to the redux store.
+ */
+export const getDerivedData = ({ triggerCol, accounts }) => {
+  const konnectorToAccounts = keyBy(accounts, getCreatedByApp)
+  const konnectorToInstitutionLabel = mapValues(
+    konnectorToAccounts,
+    acc => acc && acc.institutionLabel
+  )
+  const triggers = triggerCol.data
+  const failedTriggers = sortBy(
+    triggers
+      .filter(isBankTrigger)
+      .filter(isErrored)
+      .filter(tr => konnectorToAccounts[tr.message.konnector]),
+    tr => tr.message.konnector
+  )
+  return { failedTriggers, konnectorToInstitutionLabel }
+}
+
+/**
+ * Shows connection errors for the currently filtered bank accounts.
+ * If there is more than 1 error, a carrousel wraps the errors.
+ */
+const TransactionPageErrors = props => {
+  const { failedTriggers, konnectorToInstitutionLabel } = getDerivedData(props)
+  const count = failedTriggers.length
+  const Wrapper = count > 1 ? Carrousel : React.Fragment
+  const wrapperProps = count > 1 ? { className: 'u-bg-chablis' } : null
+  return (
+    <Wrapper {...wrapperProps}>
+      {failedTriggers.map((trigger, i) => (
+        <TriggerErrorCard
+          bankName={konnectorToInstitutionLabel[trigger.message.konnector]}
+          key={trigger._id}
+          index={i}
+          count={count}
+          trigger={trigger}
+        />
+      ))}
+    </Wrapper>
+  )
+}
+
+TransactionPageErrors.propTypes = {
+  triggerCol: PropTypes.object.isRequired,
+  accounts: PropTypes.array.isRequired
+}
+
+export const DumbTransactionPageErrors = TransactionPageErrors
+
+export default compose(
+  queryConnect({
+    triggerCol: {
+      ...triggersConn,
+      fetchPolicy: CozyClient.fetchPolicies.noFetch
+    }
+  }),
+  React.memo
+)(TransactionPageErrors)

--- a/src/ducks/transactions/TransactionPageErrors.spec.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.spec.jsx
@@ -1,0 +1,54 @@
+/* global shallow */
+
+import React from 'react'
+import {
+  DumbTransactionPageErrors as TransactionPageErrors,
+  getDerivedData
+} from './TransactionPageErrors'
+import fixtures from 'test/fixtures'
+import TriggerErrorCard from 'ducks/transactions/TriggerErrorCard'
+import Carrousel from 'components/Carrousel'
+
+const DEFAULT_TRIGGERS = fixtures['io.cozy.triggers']
+const DEFAULT_ACCOUNTS = fixtures['io.cozy.bank.accounts']
+
+describe('get derived data', () => {
+  it('should work', () => {
+    const data = getDerivedData({
+      accounts: DEFAULT_ACCOUNTS,
+      triggerCol: { data: DEFAULT_TRIGGERS }
+    })
+    expect(data.failedTriggers.length).toBe(1)
+  })
+})
+
+describe('transaction page errors', () => {
+  const setup = ({
+    triggers = DEFAULT_TRIGGERS,
+    accounts = DEFAULT_ACCOUNTS
+  } = {}) => {
+    const instance = shallow(
+      <TransactionPageErrors
+        accounts={accounts}
+        triggerCol={{ data: triggers }}
+      />
+    )
+    return {
+      instance
+    }
+  }
+
+  it('should only show errors for currently filtered accounts', () => {
+    const { instance } = setup()
+    expect(instance.find(TriggerErrorCard).length).toBe(1)
+    expect(instance.find(Carrousel).length).toBe(0)
+  })
+
+  it('should wrap in a carousel if there is more than 1 error', () => {
+    const { instance } = setup({
+      triggers: [...DEFAULT_TRIGGERS, ...DEFAULT_TRIGGERS]
+    })
+    expect(instance.find(Carrousel).length).toBe(1)
+    expect(instance.find(TriggerErrorCard).length).toBe(2)
+  })
+})

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -39,6 +39,7 @@ import {
 } from 'doctypes'
 
 import TransactionHeader from 'ducks/transactions/TransactionHeader'
+import TransactionPageErrors from 'ducks/transactions/TransactionPageErrors'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
 import { findNearestMonth } from 'ducks/transactions/helpers'
 import {
@@ -311,6 +312,7 @@ class TransactionsPage extends Component {
           chartData={chartData}
           showBackButton={this.props.showBackButton}
         />
+        <TransactionPageErrors accounts={filteredAccounts} />
         {isMobile && !areAccountsLoading && !isOnSubcategory && (
           <TransactionsPageBar accounts={filteredAccounts} theme={theme} />
         )}

--- a/src/ducks/transactions/TriggerErrorCard.jsx
+++ b/src/ducks/transactions/TriggerErrorCard.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import ErrorCard from 'components/ErrorCard'
+import { useRedirectionURL } from 'components/effects'
+import { translate } from 'cozy-ui/transpiled/react'
+import compose from 'lodash/flowRight'
+import { withClient } from 'cozy-client'
+
+const noBorderStyle = { borderRadius: 0 }
+
+const TriggerErrorCard = ({ t, trigger, index, count, client, bankName }) => {
+  const url = useRedirectionURL(client, 'io.cozy.accounts', {
+    account: trigger.message.account,
+    konnector: trigger.message.konnector
+  })
+  return (
+    <ErrorCard
+      style={noBorderStyle}
+      title={
+        t('Transactions.trigger-error.title') +
+        (count > 1 ? ` (${index + 1}/${count})` : '')
+      }
+      content={t('Transactions.trigger-error.description', { bankName })}
+      buttonLabel={t('Transactions.trigger-error.cta')}
+      buttonHref={url}
+      buttonTarget="_blank"
+    />
+  )
+}
+
+export default compose(
+  withClient,
+  translate()
+)(TriggerErrorCard)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -78,7 +78,8 @@
     "importing_accounts": "Importing accounts",
     "importing_accounts_error": "Failed to import",
     "in_progress": "In progress",
-    "error": "Click to restart"
+    "error": "Click to restart",
+    "trigger-problem": "Problem with the connection"
   },
   "SelectDates": {
     "all_year": "All year",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -288,6 +288,11 @@
     "no-movements": "No movements to display",
     "total": "Total",
     "transactions": "Transactions",
+    "trigger-error": {
+      "title": "Connection unavailable",
+      "description": "Your banking data is no longer up-to-date because we cannot retrieve your data from %{bankName}.",
+      "cta": "Verify the connection"
+    },
     "will-be-debited-on": "Will be debited on %{date}",
     "debit": "Debit",
     "credit": "Credit",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -98,7 +98,8 @@
     "importing_accounts": "Importation des comptes",
     "importing_accounts_error": "Échec de l'import",
     "in_progress": "En cours",
-    "error": "Cliquez pour relancer"
+    "error": "Cliquez pour relancer",
+    "trigger-problem": "Problème avec la connexion"
   },
 
   "Transactions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -105,6 +105,11 @@
     "title": "Mouvements",
     "no-movements": "Pas de mouvements à afficher",
     "total": "Total",
+    "trigger-error": {
+      "title": "Connexion impossible",
+      "description": "Vos données bancaires ne sont plus à jour car nous ne parvenons plus à vous connecter à %{bankName}.",
+      "cta": "Régler la connexion"
+    },
     "transactions": "Opérations",
     "will-be-debited-on": "Sera débitée le %{date}",
     "debit": "Débit",

--- a/src/utils/triggers.js
+++ b/src/utils/triggers.js
@@ -29,7 +29,9 @@ const bankingSlug = [
   'lcl-linxo',
   'monabanq96',
   'cdngroup109',
-  'societegenerale'
+  'revolut',
+  'societegenerale',
+  'n26'
 ]
 
 export const getKonnectorFromTrigger = trigger => {
@@ -46,6 +48,10 @@ export const getKonnectorFromTrigger = trigger => {
   }
 }
 
+export const isErrored = trigger => {
+  return trigger.current_state.status === 'errored'
+}
+
 export const isBankTrigger = trigger =>
-  get(trigger, 'attributes.worker') === 'konnector' &&
-  includes(bankingSlug, get(trigger, 'attributes.message.konnector'))
+  get(trigger, 'worker') === 'konnector' &&
+  includes(bankingSlug, get(trigger, 'message.konnector'))

--- a/src/utils/triggers.spec.js
+++ b/src/utils/triggers.spec.js
@@ -53,16 +53,12 @@ describe('isBankTrigger', () => {
   const triggerWithUnknownBank = merge({}, trigger, {
     attributes: { message: { konnector: 'unknownBank' } }
   })
-  const triggerWithoutAttributes = {}
-  const triggerNull = null
   const triggerWithoutMessage = { attributes: {} }
 
   it('should return if is bank trigger', () => {
-    expect(isBankTrigger(trigger)).toBe(true)
-    expect(isBankTrigger(triggerNotKonnector)).toBe(false)
-    expect(isBankTrigger(triggerWithUnknownBank)).toBe(false)
-    expect(isBankTrigger(triggerWithoutAttributes)).toBe(false)
-    expect(isBankTrigger(triggerNull)).toBe(false)
-    expect(isBankTrigger(triggerWithoutMessage)).toBe(false)
+    expect(isBankTrigger(trigger.attributes)).toBe(true)
+    expect(isBankTrigger(triggerNotKonnector.attributes)).toBe(false)
+    expect(isBankTrigger(triggerWithUnknownBank.attributes)).toBe(false)
+    expect(isBankTrigger(triggerWithoutMessage.attributes)).toBe(false)
   })
 })

--- a/test/fixtures/triggers.json
+++ b/test/fixtures/triggers.json
@@ -1,0 +1,32 @@
+[
+  {
+    "message": {
+      "konnector": "revolut"
+    },
+    "attributes": {
+      "current_state": {
+        "status": "errored"
+      }
+    }
+  },
+  {
+    "message": {
+      "konnector": "boursorama81"
+    },
+    "attributes": {
+      "current_state": {
+        "status": "done"
+      }
+    }
+  },
+  {
+    "message": {
+      "konnector": "caissedepargne1"
+    },
+    "attributes": {
+      "current_state": {
+        "status": "done"
+      }
+    }
+  }
+]

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -28,7 +28,10 @@
       "number": "{{int 1000000 9999999}}",
       "balance": 1421.22,
       "description": "Premier compte sans connaitre l id pour generer le doc",
-      "type": "Savings"
+      "type": "Savings",
+      "cozyMetadata": {
+        "createdByApp": "caissedepargne1"
+      }
     },
     {
       "_id": "comptecla1",
@@ -38,6 +41,9 @@
       "balance": 4135.62,
       "shared": "true",
       "type": "Checkings",
+      "cozyMetadata": {
+        "createdByApp": "boursorama83"
+      },
       "recipients": [
         {
           "status": "pending",
@@ -54,7 +60,10 @@
       "institutionLabel": "BNPP",
       "number": "{{int 1000000 9999999}}",
       "balance": 3974.25,
-      "type": "Checkings"
+      "type": "Checkings",
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
     },
     {
       "_id": "compteisa3",
@@ -62,7 +71,10 @@
       "institutionLabel": "La Banque Postale",
       "number": "{{int 1000000 9999999}}",
       "balance": 11635.12,
-      "type": "Savings"
+      "type": "Savings",
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
     },
     {
       "_id": "comptegene1",
@@ -80,7 +92,10 @@
             "type": "io.cozy.mocks.recipients"
           }
         }
-      ]
+      ],
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
     },
     {
       "_id": "comptelou1",
@@ -98,7 +113,10 @@
             "type": "io.cozy.mocks.recipients"
           }
         }
-      ]
+      ],
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
     },
     {
       "_id": "compteisa2",
@@ -107,7 +125,10 @@
       "number": "{{int 1000000 9999999}}",
       "balance": 0,
       "type": "CreditCard",
-      "comingBalance": -1000
+      "comingBalance": -1000,
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
     }
   ],
   "io.cozy.bank.groups": [
@@ -1546,6 +1567,48 @@
       "originalOperation": "io.cozy.bank.operations:paiementdocteur",
       "isRefund": true,
       "invoice": "io.cozy.files:{{reference 'io.cozy.files' 1 '_id' }}"
+    }
+  ],
+  "io.cozy.triggers": [
+    {
+      "message": {
+        "konnector": "revolut",
+        "account": "account-revolut"
+      },
+      "worker": "konnector",
+      "current_state": {
+        "status": "errored"
+      }
+    },
+    {
+      "message": {
+        "konnector": "boursorama83",
+        "account": "account-boursorama"
+      },
+      "worker": "konnector",
+      "current_state": {
+        "status": "errored"
+      }
+    },
+    {
+      "message": {
+        "konnector": "bnpparibas82",
+        "account": "account-bnp"
+      },
+      "worker": "konnector",
+      "current_state": {
+        "status": "done"
+      }
+    },
+    {
+      "message": {
+        "konnector": "caissedepargne1",
+        "account": "account-caissedepargne"
+      },
+      "worker": "konnector",
+      "current_state": {
+        "status": "done"
+      }
     }
   ]
 }


### PR DESCRIPTION
When one of the connection has a problem, we tell the user inside Banks so that they can fix that in the Home.

- Display connection status in Balance page
- Display more information and a button to the Home in Transaction page
  - The connection problem banner is displayed in function of the account filter; if we are seeing a revolut account, we will not have a banner signalling the the caisse d'epargne account has a problem
  - Since it is possible that groups contain one or more accounts with problems, we can display more than 1 error at a time. To reduce visual clutter, we display the errors in a carrousel.

<img width="504" alt="image" src="https://user-images.githubusercontent.com/465582/65059650-aa6ab900-d976-11e9-9a25-7128fc0d51c6.png">

<img width="871" alt="image" src="https://user-images.githubusercontent.com/465582/65059668-b2c2f400-d976-11e9-8577-f553060976b5.png">
