### PR TITLE
fix: Actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "styleguide": "styleguidist server",
     "styleguide:build": "styleguidist build",
     "styleguide:deploy": "git-directory-deploy --directory ./docs/build/styleguide --branch master --repo docs",
+    "drop-data": "ACH drop $( cat manifest.webapp | jq '.permissions | map(.type) | map(select(contains(\"io.cozy.bank.\"))) | join(\" \")' -rc)",
     "fixtures": "ACH import test/fixtures/demo.json test/fixtures/helpers/index.js",
     "secrets:decrypt": "openssl aes-256-cbc -K $ENCRYPTED_KEY -iv $ENCRYPTED_IV -in ./scripts/encrypted.tar.gz.enc -d | tar zxv -C scripts",
     "secrets:encrypt": "tar zcvf ./scripts/decrypted.tar.gz ./scripts/decrypted && travis encrypt-file ./scripts/decrypted.tar.gz ./scripts/encrypted.tar.gz.enc -p",

--- a/src/components/withContext.jsx
+++ b/src/components/withContext.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const withContext = Context => Component => {
+  class Wrapped extends React.Component {
+    render() {
+      return (
+        <Context.Consumer>
+          {context => <Component {...context} {...this.props} />}
+        </Context.Consumer>
+      )
+    }
+  }
+  Wrapped.displayName = `withContext[${Context.name}](${Component.displayName ||
+    Component.name})`
+  return Wrapped
+}
+
+export default withContext

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import CozyClient, { queryConnect } from 'cozy-client'
 import { withBreakpoints, translate } from 'cozy-ui/react'
+import flag from 'cozy-flags'
 import Icon from 'cozy-ui/react/Icon'
 import cx from 'classnames'
 import { get, flowRight as compose } from 'lodash'
@@ -119,7 +120,7 @@ class AccountRow extends React.PureComponent {
               {account.virtual ? t(accountLabel) : accountLabel}
             </div>
             <div className={styles.AccountRow__subText}>
-              {failedTrigger ? (
+              {failedTrigger && !flag('demo') ? (
                 <FailedTriggerMessage trigger={failedTrigger} />
               ) : (
                 <UpdatedAt account={account} t={t} />

--- a/src/ducks/brandDictionary/withBrands.jsx
+++ b/src/ducks/brandDictionary/withBrands.jsx
@@ -3,36 +3,35 @@ import { queryConnect } from 'cozy-client'
 import { triggersConn } from 'doctypes'
 import { getBrands } from 'ducks/brandDictionary'
 import { includes } from 'lodash'
-import { isCollectionLoading } from 'ducks/client/utils'
-import { getKonnectorFromTrigger } from 'utils/triggers'
+import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
+import { isKonnectorTrigger, getKonnectorFromTrigger } from 'utils/triggers'
+
+const getInstalledKonnectorsSlugs = triggerCol => {
+  if (isCollectionLoading(triggerCol) && !hasBeenLoaded(triggerCol)) {
+    return []
+  }
+
+  return triggerCol.data
+    .filter(isKonnectorTrigger)
+    .map(getKonnectorFromTrigger)
+    .filter(Boolean)
+}
+
+const getInstalledBrands = triggerCol => {
+  const installedKonnectorsSlugs = getInstalledKonnectorsSlugs(triggerCol)
+  const brands = getBrands().map(brand => ({
+    ...brand,
+    hasTrigger: includes(installedKonnectorsSlugs, brand.konnectorSlug)
+  }))
+
+  return brands
+}
 
 const withBrands = (options = { queryName: 'triggers' }) => Wrapped => {
   class RawWithBrands extends Component {
-    getInstalledKonnectorsSlugs() {
-      const { triggers } = this.props
-
-      if (isCollectionLoading(triggers)) {
-        return []
-      }
-
-      return triggers.data
-        .filter(trigger => trigger.worker === 'konnector')
-        .map(getKonnectorFromTrigger)
-        .filter(Boolean)
-    }
-
-    getBrands() {
-      const installedKonnectorsSlugs = this.getInstalledKonnectorsSlugs()
-      const brands = getBrands().map(brand => ({
-        ...brand,
-        hasTrigger: includes(installedKonnectorsSlugs, brand.konnectorSlug)
-      }))
-
-      return brands
-    }
-
     render() {
-      return <Wrapped {...this.props} brands={this.getBrands()} />
+      const brands = getInstalledBrands(this.props.triggers)
+      return <Wrapped {...this.props} brands={brands} />
     }
   }
 

--- a/src/ducks/transactions/TransactionActions.jsx
+++ b/src/ducks/transactions/TransactionActions.jsx
@@ -12,6 +12,7 @@ import PropTypes from 'prop-types'
 import palette from 'cozy-ui/react/palette'
 import { findMatchingActions } from 'ducks/transactions/actions'
 import { TransactionActionsContext } from 'ducks/transactions/TransactionActionsContext'
+import withContext from 'components/withContext'
 
 // TODO delete or rename this variable (see https://gitlab.cozycloud.cc/labs/cozy-bank/merge_requests/237)
 const PRIMARY_ACTION_COLOR = palette.dodgerBlue
@@ -83,8 +84,6 @@ export const SyncTransactionActions = ({
 )
 
 class TransactionActions extends Component {
-  static contextType = TransactionActionsContext
-
   state = {
     actions: false,
     actionProps: false
@@ -96,7 +95,8 @@ class TransactionActions extends Component {
       const { bill } = this.props
       const actionProps = {
         bill,
-        ...this.context
+        brands: this.props.brands,
+        urls: this.props.urls
       }
       const actions = await findMatchingActions(transaction, actionProps)
       if (!this.unmounted) {
@@ -120,11 +120,12 @@ class TransactionActions extends Component {
   }
 
   componentDidUpdate(nextProps) {
+    const { transaction, brands, urls, bill } = this.props
     if (
-      nextProps.transaction !== this.props.transaction ||
-      nextProps.urls !== this.props.urls ||
-      nextProps.brands !== this.props.brands ||
-      nextProps.bill !== this.props.bill
+      nextProps.transaction !== transaction ||
+      nextProps.urls !== urls ||
+      nextProps.brands !== brands ||
+      nextProps.bill !== bill
     ) {
       this.findMatchingActions()
     }
@@ -149,4 +150,4 @@ TransactionActions.propTypes = {
   transaction: PropTypes.object.isRequired
 }
 
-export default TransactionActions
+export default withContext(TransactionActionsContext)(TransactionActions)

--- a/src/ducks/transactions/TransactionActions.spec.jsx
+++ b/src/ducks/transactions/TransactionActions.spec.jsx
@@ -52,7 +52,7 @@ const tests = [
   }],
   ['salaireisa1', null, 'Accéder à votre paie', 'openwith', 'url'],
   ['fnac', null, 'Accéder au site Fnac', 'openwith', 'url'],
-  ['edf', null, 'My invoices', null, 'konnector'],
+  ['edf', null, 'EDF', null, 'app'],
   ['remboursementcomplementaire', null, '1 invoice', null, 'bill', {
     brands: brands.filter(x => x.name == 'Malakoff Mederic')
   }, 'remboursementcomplementaire konnector not installed'],

--- a/src/ducks/transactions/TransactionPageErrors.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.jsx
@@ -12,6 +12,7 @@ import { triggersConn } from 'doctypes'
 import { isErrored, isBankTrigger } from 'utils/triggers'
 import Carrousel from 'components/Carrousel'
 import TriggerErrorCard from 'ducks/transactions/TriggerErrorCard'
+import flag from 'cozy-flags'
 
 const getCreatedByApp = acc => get(acc, 'cozyMetadata.createdByApp')
 
@@ -48,6 +49,11 @@ const TransactionPageErrors = props => {
   const count = failedTriggers.length
   const Wrapper = count > 1 ? Carrousel : React.Fragment
   const wrapperProps = count > 1 ? { className: 'u-bg-chablis' } : null
+
+  if (flag('demo')) {
+    return null
+  }
+
   return (
     <Wrapper {...wrapperProps}>
       {failedTriggers.map((trigger, i) => (

--- a/src/ducks/transactions/actions/index.js
+++ b/src/ducks/transactions/actions/index.js
@@ -12,25 +12,25 @@ import HealthExpenseStatusAction from 'ducks/transactions/actions/HealthExpenseS
 import ReimbursementStatusAction from 'ducks/transactions/actions/ReimbursementStatusAction'
 import AttachedDocsAction from 'ducks/transactions/actions/AttachedDocsAction'
 
-const actions = {
-  AttachedDocsAction,
-  HealthExpenseStatusAction: HealthExpenseStatusAction,
-  HealthExpenseAction: HealthExpenseAction,
-  HealthLinkAction: HealthLinkAction,
-  BillAction: BillAction,
-  KonnectorAction: KonnectorAction,
-  UrlLinkAction: UrlLinkAction,
-  AppLinkAction: AppLinkAction,
-  AttachAction: AttachAction,
-  CommentAction: CommentAction,
-  AlertAction: AlertAction,
-  ReimbursementStatusAction
-}
+const actions = [
+  ['AttachedDocsAction', AttachedDocsAction],
+  ['HealthExpenseStatusAction', HealthExpenseStatusAction],
+  ['HealthExpenseAction', HealthExpenseAction],
+  ['HealthLinkAction', HealthLinkAction],
+  ['BillAction', BillAction],
+  ['AppLinkAction', AppLinkAction],
+  ['KonnectorAction', KonnectorAction],
+  ['UrlLinkAction', UrlLinkAction],
+  ['AttachAction', AttachAction],
+  ['CommentAction', CommentAction],
+  ['AlertAction', AlertAction],
+  ['ReimbursementStatusAction', ReimbursementStatusAction]
+]
 
 export const findMatchingActions = async (transaction, actionProps) => {
   const matchingActions = []
 
-  for (const [actionName, action] of Object.entries(actions)) {
+  for (const [actionName, action] of actions) {
     try {
       const matching = await action.match(transaction, actionProps)
       if (matching) {

--- a/src/utils/triggers.js
+++ b/src/utils/triggers.js
@@ -34,6 +34,8 @@ const bankingSlug = [
   'n26'
 ]
 
+export const isKonnectorTrigger = trigger => trigger.worker === 'konnector'
+
 export const getKonnectorFromTrigger = trigger => {
   if (trigger.worker !== 'konnector') {
     return

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -1378,10 +1378,7 @@
       "manualCategoryId": "401080",
       "currency": "€",
       "date": "{{ freshDate '2018-10-20T00:00:00Z' }}",
-      "label": "EDF CLIENTS PARTICULIERS",
-      "bills": [
-        "io.cozy.bills:7a8cefd5a1ac1a5aecf862482df0225c"
-      ]
+      "label": "EDF CLIENTS PARTICULIERS"
     },
     {
       "demo": false,


### PR DESCRIPTION
findMatchingActions was not called again if context changed. I think after
the perf improvements, some re-renders of the entire list were stopped before
reaching the TransactionActions, that were not re-rendered. Hence, it needs
to re-render, and recalculate matching actions by itself.