### PR TITLE
Fix infinite spinner in ReimbursementsPage

### DIFF
--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -24,7 +24,7 @@ import withFilters from 'components/withFilters'
 import { getYear } from 'date-fns'
 import TransactionActionsProvider from 'ducks/transactions/TransactionActionsProvider'
 import withBrands from 'ducks/brandDictionary/withBrands'
-import { isCollectionLoading } from 'ducks/client/utils'
+import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
 
 const Caption = props => {
   const { className, ...rest } = props
@@ -55,14 +55,17 @@ export class DumbHealthReimbursements extends Component {
   render() {
     const {
       filteredTransactions,
-      fetchStatus,
       t,
       triggers,
+      transactions,
       brands
     } = this.props
     const reimbursementTagFlag = flag('reimbursement-tag')
 
-    if (fetchStatus !== 'loaded' || isCollectionLoading(triggers)) {
+    if (
+      (isCollectionLoading(transactions) && !hasBeenLoaded(transactions)) ||
+      (isCollectionLoading(triggers) && !hasBeenLoaded(triggers))
+    ) {
       return <Loading />
     }
 
@@ -145,9 +148,7 @@ function mapStateToProps(state, ownProps) {
     ...state,
     transactions: ownProps.transactions
   }
-
   return {
-    fetchStatus: ownProps.transactions.fetchStatus,
     filteredTransactions: getHealthExpensesByPeriod(enhancedState)
   }
 }

--- a/src/ducks/reimbursements/HealthReimbursements.spec.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.spec.jsx
@@ -12,6 +12,7 @@ describe('HealthReimbursements', () => {
       <DumbHealthReimbursements
         fetchStatus="loading"
         triggers={{ fetchStatus: 'loaded' }}
+        transactions={{ fetchStatus: 'loading' }}
         filteredTransactions={[]}
         addFilterByPeriod={jest.fn()}
       />
@@ -25,6 +26,7 @@ describe('HealthReimbursements', () => {
       <DumbHealthReimbursements
         fetchStatus="loaded"
         triggers={{ fetchStatus: 'loading' }}
+        transactions={{ fetchStatus: 'loading' }}
         filteredTransactions={[]}
         addFilterByPeriod={jest.fn()}
       />
@@ -42,7 +44,7 @@ describe('HealthReimbursements', () => {
     // fail: no `TransactionsWithSelection` exists
     const root = shallow(
       <DumbHealthReimbursements
-        fetchStatus="loaded"
+        transactions={{ fetchStatus: 'loaded' }}
         filteredTransactions={pending}
         t={key => key}
         addFilterByPeriod={jest.fn()}
@@ -61,7 +63,7 @@ describe('HealthReimbursements', () => {
 
     const root = shallow(
       <DumbHealthReimbursements
-        fetchStatus="loaded"
+        transactions={{ fetchStatus: 'loaded' }}
         filteredTransactions={reimbursed}
         t={key => key}
         addFilterByPeriod={jest.fn()}
@@ -76,7 +78,7 @@ describe('HealthReimbursements', () => {
   it('should show a button to open the store if there is no reimbursed transactions and no health brand with trigger', () => {
     const root = shallow(
       <DumbHealthReimbursements
-        fetchStatus="loaded"
+        transactions={{ fetchStatus: 'loaded' }}
         filteredTransactions={[]}
         t={key => key}
         addFilterByPeriod={jest.fn()}

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -13,7 +13,7 @@ global.cozy = {
   bar: {
     BarLeft: () => null,
     BarRight: () => null,
-    BarCenter:() => null,
+    BarCenter: () => null,
     setTheme: () => null
   }
 }


### PR DESCRIPTION
It seems there is a problem with collections' `fetchStatus`, that is made more visible when using fetch policies. See https://github.com/cozy/cozy-client/issues/526.

Checking both `fetchStatus` and `lastFetch` (with `hasBeenLoaded`) hides the
problem.