### PR TITLE
Force Banks in light mode

### DIFF
--- a/src/ducks/bar/statusBar.js
+++ b/src/ducks/bar/statusBar.js
@@ -28,6 +28,10 @@ export const setColor = colorHex => {
   const StatusBar = window.StatusBar
   const lum = luminosity(colorHex)
   if (lum > lumThresold) {
+    // Black text color when background is light
+    // Also see https://github.com/apache/cordova-plugin-statusbar/issues/148#issuecomment-524354985
+    // since StatusBar has a problem with ios dark mode, we had to add lines to config.xml to force
+    // light mode in Banks (by setting UIUserInterfaceStyle)
     StatusBar.styleDefault()
   } else {
     StatusBar.styleBlackTranslucent()

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -54,6 +54,9 @@
         <config-file overwrite="true" parent="GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED" platform="ios" target="*-Info.plist">
             <false />
         </config-file>
+        <config-file parent="UIUserInterfaceStyle" platform="ios" target="*-Info.plist">
+            <string>Light</string>
+        </config-file>
         <preference name="StatusBarOverlaysWebView" value="false" />
         <preference name="Suppresses3DTouchGesture" value="true" />
         <preference name="DisallowOverscroll" value="true" />
@@ -83,7 +86,6 @@
     <preference name="StatusBarBackgroundColor" value="#95999D" />
     <engine name="android" spec="7.1.4" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
-    <plugin name="cordova-plugin-statusbar" spec="2.4.2" />
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.1" />
     <plugin name="cordova-ios-plugin-no-export-compliance" spec="0.0.5" />
     <plugin name="com.lampa.startapp" spec="^0.1.4" />
@@ -107,4 +109,5 @@
     <engine name="ios" spec="4.5.5" />
     <plugin name="cordova-universal-links-plugin" spec="https://github.com/Mailbutler/cordova-universal-links-plugin" />
     <plugin name="cordova-plugin-network-information" spec="^2.0.1" />
+    <plugin name="cordova-plugin-statusbar" spec="2.4.3" />
 </widget>

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="1050100" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.5.1.0" version="1.5.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="1050200" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.5.2.2" version="1.5.2" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>


### PR DESCRIPTION
iOS introduced recently the ability to have a dark mode. In this mode,
the default style for the status bar has white text so when the background
was white, we had invisible text.

The solution is to force light mode in Banks as suggested in the thread
on StatusBar's github (linked in comment).