### PR TITLE
Tweak renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,9 @@
           "cozy-flags",
           "cozy-interapp",
           "cozy-logger",
-          "cozy-realtime"
+          "cozy-realtime",
+          "cozy-app-publish",
+          "cozy-notifications"
       ],
       "groupName": "cozy-libs packages"
     },
@@ -28,6 +30,22 @@
           "cozy-konnector-libs"
       ],
       "groupName": "cozy-konnectors packages"
+    },
+    {
+      "packagePatterns": [
+        "eslint",
+        "eslint-loader",
+        "babel-preset-cozy-app",
+        "stylint",
+        "style-loader",
+        "lint-staged",
+        "postcss",
+        "webpack-bundle-analyzer"
+      ],
+      "minor": {
+        "automerge": true
+      },
+      "groupName": "tooling packages"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "extends": [
     "cozy"
   ],
+  "masterIssue": true,
   "packageRules": [
     {
       "packagePatterns": [


### PR DESCRIPTION
- Group tooling packages + automerge
- Create master issue to have one place where we see renovate updates (less
noise in PRs and we will be able to close PRs that we will not merge soon)