### PR TITLE
Chart and categories improvements

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -27,6 +27,8 @@ const tooltipDimensions = {
   fontSize: 11
 }
 
+const getDataByDate = memoize(data => keyBy(data, i => i.x.getTime()))
+
 class LineChart extends Component {
   constructor(props) {
     super(props)
@@ -37,18 +39,16 @@ class LineChart extends Component {
     this.dragging = false
 
     const { data } = props
-    const dataByDate = this.getDataByDate(data)
+    const dataByDate = getDataByDate(data)
     const itemKey = max(Object.keys(dataByDate))
 
     this.state = { itemKey }
   }
 
-  getDataByDate = memoize(data => keyBy(data, i => i.x.getTime()))
-
   getSelectedItem = () => {
     const { data } = this.props
     const { itemKey } = this.state
-    const dataByDate = this.getDataByDate(data)
+    const dataByDate = getDataByDate(data)
 
     return dataByDate[itemKey]
   }

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -12,6 +12,7 @@ import { Media, Bd, Img } from 'cozy-ui/react/Media'
 import Overlay from 'cozy-ui/react/Overlay'
 import Portal from 'cozy-ui/react/Portal'
 import flag from 'cozy-flags'
+import { createStructuredSelector } from 'reselect'
 
 import AccountSharingStatus from 'components/AccountSharingStatus'
 import AccountIcon from 'components/AccountIcon'
@@ -437,10 +438,10 @@ AccountSwitch.defaultProps = {
   color: 'default'
 }
 
-const mapStateToProps = state => ({
-  filteringDoc: getFilteringDoc(state),
-  filteredAccounts: getFilteredAccounts(state),
-  virtualGroups: getVirtualGroups(state)
+const mapStateToProps = createStructuredSelector({
+  filteringDoc: getFilteringDoc,
+  filteredAccounts: getFilteredAccounts,
+  virtualGroups: getVirtualGroups
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -437,18 +437,11 @@ AccountSwitch.defaultProps = {
   color: 'default'
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const enhancedState = {
-    ...state,
-    accounts: ownProps.accounts,
-    groups: ownProps.groups
-  }
-  return {
-    virtualGroups: getVirtualGroups(state),
-    filteringDoc: getFilteringDoc(state),
-    filteredAccounts: getFilteredAccounts(enhancedState)
-  }
-}
+const mapStateToProps = state => ({
+  filteringDoc: getFilteringDoc(state),
+  filteredAccounts: getFilteredAccounts(state),
+  virtualGroups: getVirtualGroups(state)
+})
 
 const mapDispatchToProps = dispatch => ({
   resetFilterByDoc: () => dispatch(resetFilterByDoc()),

--- a/src/ducks/apps/withAppsUrls.jsx
+++ b/src/ducks/apps/withAppsUrls.jsx
@@ -12,19 +12,14 @@ const withAppsUrls = Wrapped => {
     }
   }
 
-  function mapStateToProps(state, ownProps) {
-    const enhancedState = {
-      ...state,
-      apps: ownProps.apps
-    }
-
+  function mapStateToProps(state) {
     return {
       urls: {
-        MAIF: getAppUrlById(enhancedState, 'io.cozy.apps/maif'),
-        HEALTH: getAppUrlById(enhancedState, 'io.cozy.apps/sante'),
-        EDF: getAppUrlById(enhancedState, 'io.cozy.apps/edf'),
-        COLLECT: getAppUrlById(enhancedState, 'io.cozy.apps/collect'),
-        HOME: getAppUrlById(enhancedState, 'io.cozy.apps/home')
+        MAIF: getAppUrlById(state, 'io.cozy.apps/maif'),
+        HEALTH: getAppUrlById(state, 'io.cozy.apps/sante'),
+        EDF: getAppUrlById(state, 'io.cozy.apps/edf'),
+        COLLECT: getAppUrlById(state, 'io.cozy.apps/collect'),
+        HOME: getAppUrlById(state, 'io.cozy.apps/home')
       }
     }
   }

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -38,6 +38,7 @@ import { getPanelsState } from 'ducks/balance/helpers'
 import BarTheme from 'ducks/bar/BarTheme'
 import { filterByAccounts } from 'ducks/filters'
 import CozyRealtime from 'cozy-realtime'
+import { createStructuredSelector } from 'reselect'
 
 const syncPouchImmediately = async client => {
   const pouchLink = client.links.find(link => link.pouches)
@@ -443,10 +444,12 @@ export default compose(
     triggers: triggersConn,
     transactions: transactionsConn
   }),
-  connect(state => ({
-    virtualAccounts: getVirtualAccounts(state),
-    virtualGroups: getVirtualGroups(state)
-  })),
+  connect(
+    createStructuredSelector({
+      virtualAccounts: getVirtualAccounts,
+      virtualGroups: getVirtualGroups
+    })
+  ),
   withClient,
   withMutations()
 )(Balance)

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -443,18 +443,10 @@ export default compose(
     triggers: triggersConn,
     transactions: transactionsConn
   }),
-  connect((state, ownProps) => {
-    const enhancedState = {
-      ...state,
-      accounts: ownProps.accounts,
-      groups: ownProps.groups,
-      transactions: ownProps.transactions
-    }
-    return {
-      virtualAccounts: getVirtualAccounts(enhancedState),
-      virtualGroups: getVirtualGroups(enhancedState)
-    }
-  }),
+  connect(state => ({
+    virtualAccounts: getVirtualAccounts(state),
+    virtualGroups: getVirtualGroups(state)
+  })),
   withClient,
   withMutations()
 )(Balance)

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -83,7 +83,6 @@ class Balance extends PureComponent {
       groups,
       accounts,
       settings: settingsCollection,
-      transactions,
       virtualGroups
     } = props
 
@@ -91,8 +90,7 @@ class Balance extends PureComponent {
       (isCollectionLoading(groups) && !hasBeenLoaded(groups)) ||
       (isCollectionLoading(accounts) && !hasBeenLoaded(accounts)) ||
       (isCollectionLoading(settingsCollection) &&
-        !hasBeenLoaded(settingsCollection)) ||
-      (isCollectionLoading(transactions) && !hasBeenLoaded(transactions))
+        !hasBeenLoaded(settingsCollection))
 
     if (isLoading) {
       return null
@@ -317,7 +315,6 @@ class Balance extends PureComponent {
       groups: groupsCollection,
       settings: settingsCollection,
       triggers: triggersCollection,
-      transactions: transactionsCollection,
       virtualGroups
     } = this.props
 
@@ -326,7 +323,6 @@ class Balance extends PureComponent {
       accountsCollection,
       groupsCollection,
       triggersCollection,
-      transactionsCollection,
       settingsCollection
     ]
 
@@ -336,7 +332,7 @@ class Balance extends PureComponent {
       return (
         <Fragment>
           <BarTheme theme="primary" />
-          <BalanceHeader transactionsCollection={transactionsCollection} />
+          <BalanceHeader />
           <Loading />
         </Fragment>
       )
@@ -409,7 +405,6 @@ class Balance extends PureComponent {
           accountsBalance={accountsBalance}
           accounts={checkedAccounts}
           subtitleParams={subtitleParams}
-          transactionsCollection={transactionsCollection}
         />
         <Padded
           className={cx({

--- a/src/ducks/balance/components/BalanceHeader.jsx
+++ b/src/ducks/balance/components/BalanceHeader.jsx
@@ -2,6 +2,7 @@ import React, { memo } from 'react'
 import { flowRight as compose } from 'lodash'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 
+import { transactionsConn } from 'doctypes'
 import { Padded } from 'components/Spacing'
 import Header from 'components/Header'
 import { PageTitle } from 'components/Title'
@@ -9,6 +10,7 @@ import KonnectorUpdateInfo from 'components/KonnectorUpdateInfo'
 import History from 'ducks/balance/History'
 import HeaderTitle from 'ducks/balance/components/HeaderTitle'
 import Delayed from 'components/Delayed'
+import { queryConnect } from 'cozy-client'
 
 import styles from 'ducks/balance/components/BalanceHeader.styl'
 
@@ -19,7 +21,7 @@ const BalanceHeader = ({
   accounts,
   subtitleParams,
   onClickBalance,
-  transactionsCollection
+  transactions
 }) => {
   const titlePaddedClass = isMobile ? 'u-p-0' : 'u-pb-0'
   const titleColor = isMobile ? 'primary' : 'default'
@@ -41,7 +43,7 @@ const BalanceHeader = ({
       />
       {accounts && (
         <Delayed delay={1000}>
-          <History accounts={accounts} transactions={transactionsCollection} />
+          <History accounts={accounts} transactions={transactions} />
         </Delayed>
       )}
       <KonnectorUpdateInfo />
@@ -54,5 +56,8 @@ export const DumbBalanceHeader = BalanceHeader
 export default compose(
   withBreakpoints(),
   translate(),
-  memo
+  memo,
+  queryConnect({
+    transactions: transactionsConn
+  })
 )(BalanceHeader)

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -132,16 +132,8 @@ const mapDispatchToProps = dispatch => ({
   resetFilterByDoc: () => dispatch(resetFilterByDoc())
 })
 
-const mapStateToProps = (state, ownProps) => {
-  const { transactions, accounts, groups } = ownProps
-  const enhancedState = {
-    ...state,
-    transactions,
-    accounts,
-    groups
-  }
-
-  const filteredTransactions = getFilteredTransactions(enhancedState)
+const mapStateToProps = state => {
+  const filteredTransactions = getFilteredTransactions(state)
   return {
     categories: computeCategorieData(
       transactionsByCategory(filteredTransactions)

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -4,13 +4,8 @@ import { connect } from 'react-redux'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 import Loading from 'components/Loading'
 import { Padded } from 'components/Spacing'
-import {
-  getFilteredTransactions,
-  resetFilterByDoc,
-  getFilteringDoc
-} from 'ducks/filters'
+import { resetFilterByDoc, getFilteringDoc } from 'ducks/filters'
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
-import { transactionsByCategory, computeCategorieData } from './helpers'
 import Categories from 'ducks/categories/Categories'
 import { flowRight as compose, sortBy, some, includes } from 'lodash'
 import CategoriesHeader from 'ducks/categories/CategoriesHeader'
@@ -24,6 +19,7 @@ import {
 } from 'doctypes'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
 import BarTheme from 'ducks/bar/BarTheme'
+import { getCategoriesData } from 'ducks/categories/selectors'
 
 class CategoriesPage extends Component {
   componentDidMount() {
@@ -133,11 +129,8 @@ const mapDispatchToProps = dispatch => ({
 })
 
 const mapStateToProps = state => {
-  const filteredTransactions = getFilteredTransactions(state)
   return {
-    categories: computeCategorieData(
-      transactionsByCategory(filteredTransactions)
-    ),
+    categories: getCategoriesData(state),
     filteringDoc: getFilteringDoc(state)
   }
 }

--- a/src/ducks/categories/helpers.spec.js
+++ b/src/ducks/categories/helpers.spec.js
@@ -1,9 +1,21 @@
 jest.mock('cozy-flags')
 
-import { isAwaitingCategorization, transactionsByCategory } from './helpers'
+import { isAwaitingCategorization, getTransactionsByCategory } from './helpers'
 
-describe('transactionsByCategory', () => {
-  const byCategory = transactionsByCategory([
+describe('isAwaitingCategorization', () => {
+  it('should return true if the transaction is awaiting cozy categorization', () => {
+    const transaction = { _id: 't1', automaticCategoryId: '400110' }
+    expect(isAwaitingCategorization(transaction)).toBe(true)
+  })
+
+  it('should return false if the transaction have a cozy categorization', () => {
+    const transaction = { _id: 't1', cozyCategoryId: '400110' }
+    expect(isAwaitingCategorization(transaction)).toBe(false)
+  })
+})
+
+describe('getTransactionsByCategory', () => {
+  const byCategory = getTransactionsByCategory([
     {
       manualCategoryId: '200110',
       automaticCategoryId: '200120',
@@ -18,16 +30,4 @@ describe('transactionsByCategory', () => {
   expect(byCategory.incomeCat.subcategories['200110'].name).toBe(
     'activityIncome'
   )
-})
-
-describe('isAwaitingCategorization', () => {
-  it('should return true if the transaction is awaiting cozy categorization', () => {
-    const transaction = { _id: 't1', automaticCategoryId: '400110' }
-    expect(isAwaitingCategorization(transaction)).toBe(true)
-  })
-
-  it('should return false if the transaction have a cozy categorization', () => {
-    const transaction = { _id: 't1', cozyCategoryId: '400110' }
-    expect(isAwaitingCategorization(transaction)).toBe(false)
-  })
 })

--- a/src/ducks/categories/selectors.js
+++ b/src/ducks/categories/selectors.js
@@ -1,0 +1,75 @@
+import { getFilteredTransactions } from 'ducks/filters'
+import { createSelector } from 'reselect'
+import { getCurrencySymbol } from 'utils/currencySymbol'
+import { getTransactionsByCategory as getTransactionsByCategoryRaw } from './helpers'
+
+// This function builds a map of categories and sub-categories, each containing
+// a list of related transactions, a name and a color
+export const getTransactionsByCategory = createSelector(
+  [getFilteredTransactions],
+  getTransactionsByCategoryRaw
+)
+
+// Very specific to this component: takes the transactions by category as returned by the
+// `transactionsByCategory` function, and turns it into a flat array, while computing derived
+// data such as totals and currencies.
+// The result is used pretty much as is down the chain by other components, so changing property
+// names here should be done with care.
+export const getCategoriesData = createSelector(
+  [getTransactionsByCategory],
+  transactionsByCategory => {
+    return Object.values(transactionsByCategory).map(category => {
+      let subcategories = Object.values(category.subcategories).map(
+        subcategory => {
+          const debit = subcategory.transactions.reduce(
+            (total, op) => (op.amount < 0 ? total + op.amount : total),
+            0
+          )
+          const credit = subcategory.transactions.reduce(
+            (total, op) => (op.amount > 0 ? total + op.amount : total),
+            0
+          )
+
+          return {
+            id: subcategory.id,
+            name: subcategory.name,
+            amount: credit + debit,
+            debit: debit,
+            credit: credit,
+            percentage: 0,
+            currency:
+              subcategory.transactions.length > 0
+                ? getCurrencySymbol(subcategory.transactions[0].currency)
+                : '',
+            transactionsNumber: subcategory.transactions.length
+          }
+        }
+      )
+
+      const debit = category.transactions.reduce(
+        (total, op) => (op.amount < 0 ? total + op.amount : total),
+        0
+      )
+      const credit = category.transactions.reduce(
+        (total, op) => (op.amount > 0 ? total + op.amount : total),
+        0
+      )
+
+      return {
+        id: category.id,
+        name: category.name,
+        color: category.color,
+        amount: credit + debit,
+        debit: debit,
+        credit: credit,
+        percentage: 0,
+        currency:
+          category.transactions.length > 0
+            ? getCurrencySymbol(category.transactions[0].currency)
+            : '',
+        transactionsNumber: category.transactions.length,
+        subcategories: subcategories
+      }
+    })
+  }
+)

--- a/src/ducks/chart/selectors.js
+++ b/src/ducks/chart/selectors.js
@@ -5,18 +5,9 @@ import {
 } from 'ducks/balance/helpers'
 import { getCategoryId } from 'ducks/categories/helpers'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
-import { subMonths } from 'date-fns'
 
-export const getBalanceHistory = (accounts, transactions) => {
-  const today = new Date()
-  const twoMonthsBefore = subMonths(today, 2)
-
-  const balanceHistories = getBalanceHistories(
-    accounts,
-    transactions,
-    today,
-    twoMonthsBefore
-  )
+const getBalanceHistory = (accounts, transactions, to, from) => {
+  const balanceHistories = getBalanceHistories(accounts, transactions, to, from)
   const balanceHistory = sumBalanceHistories(Object.values(balanceHistories))
 
   return balanceHistory
@@ -25,8 +16,10 @@ export const getBalanceHistory = (accounts, transactions) => {
 export const getChartData = (
   accountsCol,
   transactionsCol,
-  transactions,
-  filteredAccounts
+  filteredTransactions,
+  filteredAccounts,
+  to,
+  from
 ) => {
   const isLoading =
     (isCollectionLoading(transactionsCol) && !hasBeenLoaded(transactionsCol)) ||
@@ -36,9 +29,13 @@ export const getChartData = (
     return null
   }
 
-  const history = getBalanceHistory(filteredAccounts, transactions)
+  const history = getBalanceHistory(
+    filteredAccounts,
+    filteredTransactions,
+    to,
+    from
+  )
   const data = balanceHistoryToChartData(history)
-
   return data
 }
 

--- a/src/ducks/chart/selectors.js
+++ b/src/ducks/chart/selectors.js
@@ -1,0 +1,54 @@
+import {
+  getBalanceHistories,
+  sumBalanceHistories,
+  balanceHistoryToChartData
+} from 'ducks/balance/helpers'
+import { getCategoryId } from 'ducks/categories/helpers'
+import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
+import { subMonths } from 'date-fns'
+
+export const getBalanceHistory = (accounts, transactions) => {
+  const today = new Date()
+  const twoMonthsBefore = subMonths(today, 2)
+
+  const balanceHistories = getBalanceHistories(
+    accounts,
+    transactions,
+    today,
+    twoMonthsBefore
+  )
+  const balanceHistory = sumBalanceHistories(Object.values(balanceHistories))
+
+  return balanceHistory
+}
+
+export const getChartData = (
+  accountsCol,
+  transactionsCol,
+  transactions,
+  filteredAccounts
+) => {
+  const isLoading =
+    (isCollectionLoading(transactionsCol) && !hasBeenLoaded(transactionsCol)) ||
+    (isCollectionLoading(accountsCol) && !hasBeenLoaded(accountsCol))
+
+  if (isLoading) {
+    return null
+  }
+
+  const history = getBalanceHistory(filteredAccounts, transactions)
+  const data = balanceHistoryToChartData(history)
+
+  return data
+}
+
+export const getChartTransactions = (filteredTransactions, categoryId) => {
+  if (!categoryId) {
+    return filteredTransactions
+  }
+
+  // TODO should be done via selectors
+  return filteredTransactions.filter(
+    transaction => getCategoryId(transaction) === categoryId
+  )
+}

--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -6,12 +6,12 @@ let client
 const lib =
   __TARGET__ === 'mobile' ? require('./mobile/mobile') : require('./web')
 
-export const getClient = state => {
+export const getClient = () => {
   if (client) {
     return client
   }
 
-  client = lib.getClient(state)
+  client = lib.getClient()
 
   const intents = new Intents({ client })
   client.intents = intents

--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -6,12 +6,12 @@ let client
 const lib =
   __TARGET__ === 'mobile' ? require('./mobile/mobile') : require('./web')
 
-export const getClient = (state, getStore) => {
+export const getClient = state => {
   if (client) {
     return client
   }
 
-  client = lib.getClient(state, getStore)
+  client = lib.getClient(state)
 
   const intents = new Intents({ client })
   client.intents = intents

--- a/src/ducks/client/mobile/mobile.js
+++ b/src/ducks/client/mobile/mobile.js
@@ -12,7 +12,6 @@ import { clientPlugin as sentryPlugin } from 'lib/sentry'
 
 import { SOFTWARE_ID } from 'ducks/mobile/constants'
 import { getRedirectUri } from 'ducks/client/mobile/redirect'
-import { resetFilterByDoc } from 'ducks/filters'
 
 export const getScope = m => {
   if (m.permissions === undefined) {
@@ -76,17 +75,12 @@ const registerPlugin = (client, plugin) => {
   plugin(client)
 }
 
-const registerPluginsAndHandlers = (client, getStore) => {
+const registerPluginsAndHandlers = client => {
   registerPlugin(client, pushPlugin)
   registerPlugin(client, sentryPlugin)
-
-  client.on('logout', () => {
-    const store = getStore()
-    store.dispatch(resetFilterByDoc())
-  })
 }
 
-export const getClient = (state, getStore) => {
+export const getClient = state => {
   const manifestOptions = getManifestOptions(manifest)
   const appSlug = manifest.slug
 
@@ -113,6 +107,6 @@ export const getClient = (state, getStore) => {
   }
 
   client = new CozyClient(merge(manifestOptions, banksOptions))
-  registerPluginsAndHandlers(client, getStore)
+  registerPluginsAndHandlers(client)
   return client
 }

--- a/src/ducks/client/mobile/mobile.js
+++ b/src/ducks/client/mobile/mobile.js
@@ -80,7 +80,7 @@ const registerPluginsAndHandlers = client => {
   registerPlugin(client, sentryPlugin)
 }
 
-export const getClient = state => {
+export const getClient = () => {
   const manifestOptions = getManifestOptions(manifest)
   const appSlug = manifest.slug
 

--- a/src/ducks/reimbursements/HealthReimbursements.jsx
+++ b/src/ducks/reimbursements/HealthReimbursements.jsx
@@ -143,13 +143,9 @@ export class DumbHealthReimbursements extends Component {
   }
 }
 
-function mapStateToProps(state, ownProps) {
-  const enhancedState = {
-    ...state,
-    transactions: ownProps.transactions
-  }
+function mapStateToProps(state) {
   return {
-    filteredTransactions: getHealthExpensesByPeriod(enhancedState)
+    filteredTransactions: getHealthExpensesByPeriod(state)
   }
 }
 

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -5,6 +5,8 @@ import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
+import { subMonths } from 'date-fns'
+
 import { isMobileApp } from 'cozy-device-helper'
 import { translate, withBreakpoints } from 'cozy-ui/react'
 
@@ -241,11 +243,17 @@ class TransactionsPage extends Component {
     if (this.state.fetching) {
       return null
     }
+
+    const today = new Date()
+    const twoMonthsBefore = subMonths(today, 2)
+
     return getChartData(
       this.props.accounts,
       this.props.transactions,
       this.getTransactions(),
-      this.props.filteredAccounts
+      this.props.filteredAccounts,
+      today,
+      twoMonthsBefore
     )
   }
 

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -56,9 +56,7 @@ const STEP_INFINITE_SCROLL = 30
 const SCROLL_THRESOLD_TO_ACTIVATE_TOP_INFINITE_SCROLL = 150
 const getMonth = date => date.slice(0, 7)
 
-const FakeTransactions = () => {
-  return <Padded>{null}</Padded>
-}
+const FakeTransactions = () => <Padded>{null}</Padded>
 
 class TransactionsPage extends Component {
   constructor(props) {
@@ -335,21 +333,14 @@ export const TransactionsPageBar = ({ accounts, theme }) => (
 const onSubcategory = ownProps => ownProps.router.params.subcategoryName
 
 const mapStateToProps = (state, ownProps) => {
-  const enhancedState = {
-    ...state,
-    accounts: ownProps.accounts,
-    groups: ownProps.groups,
-    transactions: ownProps.transactions
-  }
-
   const filteredTransactions = onSubcategory(ownProps)
-    ? getFilteredTransactions(enhancedState)
-    : getTransactionsFilteredByAccount(enhancedState)
+    ? getFilteredTransactions(state)
+    : getTransactionsFilteredByAccount(state)
 
   return {
-    accountIds: getFilteredAccountIds(enhancedState),
+    accountIds: getFilteredAccountIds(state),
     filteringDoc: getFilteringDoc(state),
-    filteredAccounts: getFilteredAccounts(enhancedState),
+    filteredAccounts: getFilteredAccounts(state),
     filteredTransactions: filteredTransactions
   }
 }

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -72,7 +72,6 @@ class TransactionsPage extends Component {
     )
 
     this.state = {
-      fetching: false,
       limitMin: 0,
       limitMax: STEP_INFINITE_SCROLL,
       infiniteScrollTop: false
@@ -240,10 +239,6 @@ class TransactionsPage extends Component {
   }
 
   getChartData() {
-    if (this.state.fetching) {
-      return null
-    }
-
     const today = new Date()
     const twoMonthsBefore = subMonths(today, 2)
 
@@ -266,8 +261,7 @@ class TransactionsPage extends Component {
     } = this.props
 
     const isFetching =
-      (isCollectionLoading(transactions) && !hasBeenLoaded(transactions)) ||
-      this.state.fetching
+      isCollectionLoading(transactions) && !hasBeenLoaded(transactions)
     const areAccountsLoading =
       isCollectionLoading(accounts) && !hasBeenLoaded(accounts)
     const filteredTransactions = this.getTransactions()

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -80,6 +80,8 @@ const setupApp = async persistedState => {
   store = configureStore(client, persistedState)
   client.registerPlugin(StoreClientPlugin, { store })
 
+  client.setStore(store)
+
   persistState(store)
 
   if (__TARGET__ !== 'mobile') {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -23,6 +23,7 @@ import { checkToRefreshToken } from 'utils/token'
 import Alerter from 'cozy-ui/react/Alerter'
 import flag from 'cozy-flags'
 import { makeItShine } from 'utils/display.debug'
+import { resetFilterByDoc } from 'ducks/filters'
 
 const D3_LOCALES_MAP = {
   fr: require('d3-time-format/locale/fr-FR.json'),
@@ -48,6 +49,21 @@ const initRender = () => {
   )
 }
 
+/** Used to cleanup redux store when client disconnects */
+class StoreClientPlugin {
+  constructor(client, { store }) {
+    this.client = client
+    this.store = store
+    client.on('logout', this.handleLogout.bind(this))
+  }
+
+  handleLogout() {
+    this.store.dispatch(resetFilterByDoc())
+  }
+}
+
+StoreClientPlugin.pluginName = 'store'
+
 const setupApp = async persistedState => {
   const root = document.querySelector('[role=application]')
   const data = root.dataset
@@ -60,8 +76,9 @@ const setupApp = async persistedState => {
 
   history = setupHistory()
 
-  client = await getClient(persistedState, () => store)
+  client = await getClient(persistedState)
   store = configureStore(client, persistedState)
+  client.registerPlugin(StoreClientPlugin, { store })
 
   persistState(store)
 
@@ -81,8 +98,8 @@ const setupApp = async persistedState => {
       }
     })
     const openUniversalLink = (/*eventData*/) => {
-      /* 
-      banks just need to be waked up by an universal link. 
+      /*
+      banks just need to be waked up by an universal link.
       We currently do not manage any path
     */
     }

--- a/src/store/configureStore.js
+++ b/src/store/configureStore.js
@@ -34,7 +34,8 @@ const configureStore = (cozyClient, persistedState) => {
 
   const store = createStore(
     combineReducers({
-      filters
+      filters,
+      cozy: cozyClient.reducer()
     }),
     persistedState,
     composeEnhancers(applyMiddleware.apply(null, middlewares))


### PR DESCRIPTION
- [ ] ⚠️ Change base branch to master when auto-group is merged

Features and refactors are mangled in this PR, I think it is helpful to have
both to understand the need for the refactors, but I can split this PR if
it is deemed necessary.

## Features

- In transaction page, history chart now updates based on month, this will
surely need more work to be perfect but it is usable right now

- In category page, go to the first month with data if current month does
not have any data

## Refactors

- Extract data mangling from the components
- Put cozy-client's store inside our own store to have easy access to cozy-client's
  queries in our selectors without using the `enhancedState` semi-hack

fix #1131 

<details>
<summary>Changes:</summary>

c8298177 (Patrick Browne, 4 hours ago)
   feat: Chart corresponds to selected month

a8d0a64d (Patrick Browne, 9 hours ago)
   feat: Set filter to month having transactions when opening Categories

09e35cd4 (Patrick Browne, 5 hours ago)
   refactor: Remove unused state variable

71f749bf (Patrick Browne, 5 hours ago)
   refactor: Extract getDataByDate

45fb3f28 (Patrick Browne, 5 hours ago)
   refactor: Chart selectors accept to/from parameters

   Enables the user of the selectors to choose from which date to which date
   they need chart data

f8665dd7 (Patrick Browne, 9 hours ago)
   refactor: Extract data selectors

   First step before using selectors directly inside mapStateToProps End goal
   is

   - remove data mangling from rendering
   - have memoization on the selectors
   - be able to have the chart reflect the month currently selected

7f21b120 (Patrick Browne, 10 hours ago)
   refactor: Use selectors to compute categories data

c0e36b5a (Patrick Browne, 10 hours ago)
   refactor: Use createStructuredSelector

   Promotes consistency and doing the work inside selectors

b3b43ef3 (Patrick Browne, 4 hours ago)
   feat: Use directly the cozy store in selectors

06917c0e (Patrick Browne, 29 hours ago)
   feat: Integrate cozy store into our own redux store

   This will enable us to use cozy-client selectors in our selectors

635e8aa5 (Patrick Browne, 30 hours ago)
   feat: Let Balance render even if transactions are not yet loaded

   Balance does not need the transactions. The consequence is that Balance
   loads faster the first time, the history might show a spinner now

493b5866 (Patrick Browne, 24 hours ago)
   refactor: Detangle client/store

   the client instantiation needed a store, now with a plugin, it is more 
   decoupled
</summary>