### PR TITLE
fix(Nav): Balances tab is highlighted by default

### DIFF
--- a/src/ducks/commons/Nav.jsx
+++ b/src/ducks/commons/Nav.jsx
@@ -78,7 +78,7 @@ export const Nav = ({ t }) => {
     <UINav>
       <NavItems
         items={[
-          { to: 'balance', icon: wallet, label: t('Nav.my-accounts') },
+          { to: 'balances', icon: wallet, label: t('Nav.my-accounts') },
           { to: 'categories', icon: graph, label: t('Nav.categorisation') },
           flag('transfers')
             ? {


### PR DESCRIPTION
When opening the app, no tab was highlighted. The reason was just a typo on the `to` props for the balances nav item.