### PR TITLE
AccountSwitch translation fix

### DIFF
--- a/scripts/ci/mattermost_comment.sh
+++ b/scripts/ci/mattermost_comment.sh
@@ -11,4 +11,4 @@ else
   FROM="master"
 fi
 
-curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"gangsters-release\"}" $MATTERMOST_HOOK_URL
+curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"gangsters\"}" $MATTERMOST_HOOK_URL

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -151,40 +151,6 @@ AccountSwitchSelect.defaultProps = {
   color: 'default'
 }
 
-const AccountSwitchMobile = ({
-  filteredAccounts,
-  filteringDoc,
-  onClick,
-  color
-}) => (
-  <AccountSwitchSelect
-    filteringAccounts={filteredAccounts}
-    filteringDoc={filteringDoc}
-    onClick={onClick}
-    color={color}
-  />
-)
-
-AccountSwitchMobile.propTypes = {
-  filteringDoc: PropTypes.object,
-  onClick: PropTypes.func.isRequired,
-  filteredAccounts: PropTypes.array.isRequired
-}
-
-const AccountSwitchTablet = ({ filteringDoc, onClick }) => (
-  <button
-    className={cx(styles['account-switch-button-mobile'], {
-      [styles['active']]: filteringDoc
-    })}
-    onClick={onClick}
-  />
-)
-
-AccountSwitchTablet.propTypes = {
-  filteringDoc: PropTypes.object,
-  onClick: PropTypes.func.isRequired
-}
-
 const AccountSwitchMenu = translate()(
   ({
     accounts,

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -118,29 +118,29 @@ const getFilteringDocLabel = (filteringDoc, t, accounts) => {
   }
 }
 
-const AccountSwitchSelect = translate()(
-  ({ accounts, filteringDoc, onClick, t, color }) => (
-    <div
-      className={cx(
-        styles.AccountSwitch__Select,
-        styles[`AccountSwitchColor_${color}`]
-      )}
-      onClick={onClick}
-    >
-      {flag('account-switch.display-icon') &&
-      filteringDoc._type === ACCOUNT_DOCTYPE ? (
-        <span className="u-mr-1">
-          <AccountIcon account={filteringDoc} />
-        </span>
-      ) : null}
-      <Title className={styles.AccountSwitch__SelectText} color={color}>
-        {filteringDoc
-          ? getFilteringDocLabel(filteringDoc, t, accounts)
-          : t('AccountSwitch.all_accounts')}
-      </Title>
-      <DownArrow color={color} />
-    </div>
-  )
+// t is passed from above and not through translate() since AccountSwitchSelect can be
+// rendered in the Bar and in this case it has a different context
+const AccountSwitchSelect = ({ accounts, filteringDoc, onClick, t, color }) => (
+  <div
+    className={cx(
+      styles.AccountSwitch__Select,
+      styles[`AccountSwitchColor_${color}`]
+    )}
+    onClick={onClick}
+  >
+    {flag('account-switch.display-icon') &&
+    filteringDoc._type === ACCOUNT_DOCTYPE ? (
+      <span className="u-mr-1">
+        <AccountIcon account={filteringDoc} />
+      </span>
+    ) : null}
+    <Title className={styles.AccountSwitch__SelectText} color={color}>
+      {filteringDoc
+        ? getFilteringDocLabel(filteringDoc, t, accounts)
+        : t('AccountSwitch.all_accounts')}
+    </Title>
+    <DownArrow color={color} />
+  </div>
 )
 
 AccountSwitchSelect.propTypes = {


### PR DESCRIPTION
Recently, AccountSwitch was wrapped into translate() (by me :/) which
was a bad idea since it need to be passed t directly to work when
rendered inside the Bar.