### PR TITLE
chore: Remove Deezer from maintenance in banks

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -143,7 +143,6 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "deezer",
-    "maintenance": true,
     "name": "Deezer",
     "regexp": "\\\\bdeezer\\\\b",
   },
@@ -687,7 +686,6 @@ Array [
   Object {
     "isInstalled": false,
     "konnectorSlug": "deezer",
-    "maintenance": true,
     "name": "Deezer",
     "regexp": "\\\\bdeezer\\\\b",
   },

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -123,8 +123,7 @@
   {
     "name": "Deezer",
     "regexp": "\\bdeezer\\b",
-    "konnectorSlug": "deezer",
-    "maintenance": true
+    "konnectorSlug": "deezer"
   },
   {
     "name": "Deliveroo",


### PR DESCRIPTION
This PR remove Deezer from long term maintenance in banks

If possible we need to synchronise publication of :
this PR,
the same kind of change in home : https://github.com/cozy/cozy-home/pull/1352
and the registry update (easy to do when we need it)