### PR TITLE
fix: Don't put accountType: null on a group that did not have a…

### DIFF
--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -104,6 +104,20 @@ export const translateAndSortGroups = (groups, translate) => {
   ])
 }
 
+export const renamedGroup = (group, label) => {
+  const updatedGroup = {
+    ...group,
+    label
+  }
+
+  if (group.accountType) {
+    // As soon as the account is renamed it loses its accountType
+    updatedGroup.accountType = null
+  }
+
+  return updatedGroup
+}
+
 // For automatically created groups, the `accountType` attribute is present.
 export const isFormerAutoGroup = group => group.accountType === null
 export const isAutoGroup = group => group.accountType !== undefined

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -1,7 +1,8 @@
 import {
   buildAutoGroups,
   getGroupLabel,
-  translateAndSortGroups
+  translateAndSortGroups,
+  renamedGroup
 } from './helpers'
 import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
@@ -156,5 +157,26 @@ describe('translateAndSortGroups', () => {
     ]
 
     expect(setup(groups)).toEqual(expected)
+  })
+})
+
+describe('when the given group has an accountType', () => {
+  it('should not set accountType to null', () => {
+    const group = { accountType: 'checkings' }
+
+    expect(renamedGroup(group, 'My super group')).toEqual({
+      label: 'My super group',
+      accountType: null
+    })
+  })
+})
+
+describe('when the given group does not have an accountType', () => {
+  it('should not set accountType to null', () => {
+    const group = { label: 'My group' }
+
+    expect(renamedGroup(group, 'My super group')).toEqual({
+      label: 'My super group'
+    })
   })
 })

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -15,7 +15,7 @@ import { PageTitle } from 'components/Title'
 import { Padded } from 'components/Spacing'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { logException } from 'lib/sentry'
-import { getGroupLabel } from 'ducks/groups/helpers'
+import { getGroupLabel, renamedGroup } from 'ducks/groups/helpers'
 
 import styles from 'ducks/settings/GroupsSettings.styl'
 import btnStyles from 'styles/buttons.styl'
@@ -91,23 +91,20 @@ class _AccountsList extends PureComponent {
 
 const AccountsList = translate()(_AccountsList)
 
-class DumbGroupSettings extends Component {
+export class DumbGroupSettings extends Component {
   state = { modifying: false, saving: false }
-  rename = () => {
-    const { group } = this.props
+  handleRename = () => {
     const label = this.inputRef.value
+    this.rename(label)
+  }
+
+  rename(label) {
     this.setState({ saving: true })
-    this.updateOrCreate(
-      {
-        ...group,
-        label,
-        // As soon as the account is renamed it loses its accountType
-        accountType: null
-      },
-      () => {
-        this.setState({ saving: false, modifying: false })
-      }
-    )
+    const { group } = this.props
+    const updatedGroup = renamedGroup(group, label)
+    return this.updateOrCreate(updatedGroup, () => {
+      this.setState({ saving: false, modifying: false })
+    })
   }
 
   async updateOrCreate(group, cb) {
@@ -198,7 +195,7 @@ class DumbGroupSettings extends Component {
                 className={styles['save-button']}
                 disabled={saving}
                 theme="regular"
-                onClick={this.rename}
+                onClick={this.handleRename}
                 label={t('Groups.save')}
                 busy={saving}
               />

--- a/src/ducks/settings/GroupSettings.spec.js
+++ b/src/ducks/settings/GroupSettings.spec.js
@@ -1,12 +1,67 @@
 import React from 'react'
-import { AccountLine } from './GroupSettings'
+import {
+  DumbGroupSettings as GroupSettings,
+  AccountLine
+} from './GroupSettings'
 import Toggle from 'cozy-ui/react/Toggle'
 import { mount } from 'enzyme'
 import AppLike from 'test/AppLike'
 import fixtures from 'test/fixtures'
-import { keyBy } from 'lodash'
+import { keyBy, omit } from 'lodash'
+
+jest.mock('components/BackButton', () => () => null)
 
 describe('GroupSettings', () => {
+  const setup = ({ group }) => {
+    const account = fixtures['io.cozy.bank.accounts'][0]
+    const router = {
+      push: jest.fn()
+    }
+    const saveDocument = jest.fn().mockResolvedValue({ data: { id: '1234' } })
+    const root = mount(
+      <AppLike>
+        <GroupSettings
+          account={account}
+          group={group}
+          router={router}
+          saveDocument={saveDocument}
+          breakpoints={{ isMobile: false }}
+          t={x => x}
+        />
+      </AppLike>
+    )
+    const instance = root.find(GroupSettings).instance()
+    return { router, saveDocument, root, instance }
+  }
+
+  it('should rename new group', async () => {
+    const group = omit(fixtures['io.cozy.bank.groups'][0], ['_id', 'id'])
+    const { router, saveDocument, instance } = setup({ group })
+    await instance.rename('Renamed group')
+    expect(saveDocument).toHaveBeenCalledWith({
+      accounts: ['compteisa1', 'comptelou1', 'comptecla1', 'comptegene1'],
+      label: 'Renamed group'
+    })
+    expect(router.push).toHaveBeenCalledWith('/settings/groups/1234')
+  })
+
+  it('should rename autogroup', async () => {
+    const group = {
+      ...fixtures['io.cozy.bank.groups'][0],
+      accountType: 'checkings'
+    }
+    const { router, saveDocument, instance } = setup({ group })
+    await instance.rename('Renamed group')
+    expect(saveDocument).toHaveBeenCalledWith({
+      _id: 'f1d11eb324b64d604cbeee734e77de66',
+      accountType: null,
+      accounts: ['compteisa1', 'comptelou1', 'comptecla1', 'comptegene1'],
+      id: 'f1d11eb324b64d604cbeee734e77de66',
+      label: 'Renamed group'
+    })
+    expect(router.push).not.toHaveBeenCalled()
+  })
+
   it('Should call existsById with an id when rendering an account line', () => {
     const group = fixtures['io.cozy.bank.groups'][0]
     const accountsById = keyBy(fixtures['io.cozy.bank.accounts'], '_id')


### PR DESCRIPTION
- Otherwise virtualGroups would disappear when creating a group
- Added tests