### PR TITLE
fix(stats): Export getCategoryIdFromName from categories helpers

### DIFF
--- a/src/ducks/categories/helpers.js
+++ b/src/ducks/categories/helpers.js
@@ -143,3 +143,5 @@ export const getGlobalCurrency = categories => {
 
   return currency
 }
+
+export { getCategoryIdFromName } from 'ducks/categories/categoriesMap'


### PR DESCRIPTION
The import was changed in https://github.com/cozy/cozy-banks/pull/1605/commits/3fbe228fc1a0f96423a434a41770ff0600386871 but I didn't catch this while reviewing.

Maybe your intent was to move the `getCategoryIdFromName` from `ducks/categories/categoriesMap` to `ducks/categories/helpers` @ptbrowne?