### PR TITLE
test: Fix TransactionPageErrors tests

### DIFF
--- a/src/ducks/transactions/TransactionPageErrors.spec.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.spec.jsx
@@ -8,6 +8,9 @@ import {
 import fixtures from 'test/fixtures'
 import TriggerErrorCard from 'ducks/transactions/TriggerErrorCard'
 import Carrousel from 'components/Carrousel'
+import flag from 'cozy-flags'
+
+jest.mock('cozy-flags')
 
 const DEFAULT_TRIGGERS = fixtures['io.cozy.triggers']
 const DEFAULT_ACCOUNTS = fixtures['io.cozy.bank.accounts']
@@ -37,6 +40,16 @@ describe('transaction page errors', () => {
       instance
     }
   }
+
+  beforeEach(() => {
+    flag.mockImplementation(key => {
+      if (key === 'transactions-error-banner') {
+        return true
+      }
+
+      return false
+    })
+  })
 
   it('should only show errors for currently filtered accounts', () => {
     const { instance } = setup()


### PR DESCRIPTION
Since https://github.com/cozy/cozy-banks/commit/77783752c2dcc52e2b572e0babb6da78f4baa5b3, tests were broken because the flag check that was added is falsy in test env.

It makes our build red on master and all new PRs.