### PR TITLE
Use bills matchingCriterias names in Linker options

### DIFF
--- a/docs/bills-matching.md
+++ b/docs/bills-matching.md
@@ -29,10 +29,10 @@ parameters:
 
 The options object can contain the following properties:
 
-* `minAmountDelta`: defaults to `0.001`
-* `maxAmountDelta`: defaults to `0.001`
-* `pastWindow`: defaults to 15 (days)
-* `futureWindow`: defaults to 29 (days)
+* `amountLowerDelta`: defaults to `0.001`
+* `amountUpperDelta`: defaults to `0.001`
+* `dateLowerDelta`: defaults to 15 (days)
+* `dateUpperDelta`: defaults to 29 (days)
 
 These options will determine the default date and amount windows in which a
 transaction should be to match with a bill.
@@ -63,8 +63,8 @@ the ones that fits in the amount and date windows of the bill.
 The date window is `[bill date - dateLowerDelta; bill date + dateUpperDelta]`. Where:
 
 * `bill date` is `bill.date` if we are looking for a credit; `bill.originalDate` with a fallback on `bill.date` if we are looking for a debit
-* `dateLowerDelta` is `bill.matchingCriterias.dateLowerDelta` if it exists, `options.pastWindow` otherwise
-* `dateUpperDelta` is `bill.matchingCriterias.dateUpperDelta` if it exists, `options.futureWindow` otherwise
+* `dateLowerDelta` is `bill.matchingCriterias.dateLowerDelta` if it exists, `options.dateLowerDelta` otherwise
+* `dateUpperDelta` is `bill.matchingCriterias.dateUpperDelta` if it exists, `options.dateUpperDelta` otherwise
 
 The amount window is `[bill amount - amountLowerDelta; bill amount + amountUpperDelta]`. Where:
 

--- a/scripts/visualizer/index.html
+++ b/scripts/visualizer/index.html
@@ -7,9 +7,10 @@
     <p>Find links between bills and banking</p>
     <form id='form'>
       Identifiers: <input type='text' name='identifiers' value="Harmonie" /><br/>
-      minDateDelta: <input type='text' name='minDateDelta' value='15' /><br/>
-      maxDateDelta: <input type='text' name='maxDateDelta' value='29' /><br/>
-      amountDelta: <input type='text' name='amountDelta' value='0.001' /><br/>
+      minDateDelta: <input type='text' name='dateLowerDelta' value='15' /><br/>
+      maxDateDelta: <input type='text' name='dateUpperDelta' value='29' /><br/>
+      amountLowerDelta: <input type='text' name='amountLowerDelta' value='0.001' /><br/>
+      amountUpperDelta: <input type='text' name='amountUpperDelta' value='0.001' /><br/>
       Allow uncategorized : <input type='checkbox' name='allowUncategorized' /><br/>
       <button type='submit'>Find links</button>
     </form>

--- a/scripts/visualizer/src/server/index.js
+++ b/scripts/visualizer/src/server/index.js
@@ -56,9 +56,10 @@ const commaSeparatedArray = x => x.split(/\s*,\s*/)
 
 const parseOptions = parser({
   allowUncategorized: htmlFormBoolean,
-  minDateDelta: float,
-  maxDateDelta: float,
-  amountDelta: float,
+  dateLowerDelta: float,
+  dateUpperDelta: float,
+  amountLowerDelta: float,
+  amountUpperDelta: float,
   identifiers: commaSeparatedArray
 })
 

--- a/src/ducks/billsMatching/Linker/Linker.js
+++ b/src/ducks/billsMatching/Linker/Linker.js
@@ -6,6 +6,7 @@ const {
   findCreditOperation
 } = require('./billsToOperation')
 const defaults = require('lodash/defaults')
+const defaultTo = require('lodash/defaultTo')
 const groupBy = require('lodash/groupBy')
 const flatten = require('lodash/flatten')
 const sumBy = require('lodash/sumBy')
@@ -266,10 +267,22 @@ class Linker {
     // TODO Use the same names as the bills matchingCriterias
     defaults(options, { amountDelta: DEFAULT_AMOUNT_DELTA })
     defaults(options, {
-      amountLowerDelta: options.amountDelta,
-      amountUpperDelta: options.amountDelta,
-      dateLowerDelta: DEFAULT_DATE_LOWER_DELTA,
-      dateUpperDelta: DEFAULT_DATE_UPPER_DELTA
+      amountLowerDelta: defaultTo(
+        options.amountLowerDelta,
+        DEFAULT_AMOUNT_DELTA
+      ),
+      amountUpperDelta: defaultTo(
+        options.amountUpperDelta,
+        DEFAULT_AMOUNT_DELTA
+      ),
+      dateLowerDelta: defaultTo(
+        options.dateLowerDelta,
+        DEFAULT_DATE_LOWER_DELTA
+      ),
+      dateUpperDelta: defaultTo(
+        options.dateUpperDelta,
+        DEFAULT_DATE_UPPER_DELTA
+      )
     })
 
     return options

--- a/src/ducks/billsMatching/Linker/Linker.js
+++ b/src/ducks/billsMatching/Linker/Linker.js
@@ -19,8 +19,8 @@ const { cozyClient } = require('cozy-konnector-libs')
 
 const DOCTYPE_OPERATIONS = 'io.cozy.bank.operations'
 const DEFAULT_AMOUNT_DELTA = 0.001
-export const DEFAULT_PAST_WINDOW = 15
-export const DEFAULT_FUTURE_WINDOW = 29
+export const DEFAULT_DATE_LOWER_DELTA = 15
+export const DEFAULT_DATE_UPPER_DELTA = 29
 
 Transaction.registerClient(cozyClient)
 
@@ -255,10 +255,10 @@ class Linker {
    * Get defaulted options
    *
    * @param {Object} [opts={}]
-   * @param {number} [opts.minAmountDelta=0.001]
-   * @param {number} [opts.maxAmountDelta=0.001]
-   * @param {number} [opts.pastWindow=15]
-   * @param {number} [opts.futureWindow=29]
+   * @param {number} [opts.amountLowerDelta=0.001]
+   * @param {number} [opts.amountUpperDelta=0.001]
+   * @param {number} [opts.dateLowerDelta=15]
+   * @param {number} [opts.dateUpperDelta=29]
    */
   getOptions(opts = {}) {
     const options = { ...opts }
@@ -266,10 +266,10 @@ class Linker {
     // TODO Use the same names as the bills matchingCriterias
     defaults(options, { amountDelta: DEFAULT_AMOUNT_DELTA })
     defaults(options, {
-      minAmountDelta: options.amountDelta,
-      maxAmountDelta: options.amountDelta,
-      pastWindow: DEFAULT_PAST_WINDOW,
-      futureWindow: DEFAULT_FUTURE_WINDOW
+      amountLowerDelta: options.amountDelta,
+      amountUpperDelta: options.amountDelta,
+      dateLowerDelta: DEFAULT_DATE_LOWER_DELTA,
+      dateUpperDelta: DEFAULT_DATE_UPPER_DELTA
     })
 
     return options
@@ -353,10 +353,10 @@ class Linker {
    * @param {Object[]} bills - The array of io.cozy.bills to match
    * @param {Object[]} operations - The array of io.cozy.bank.operations to match
    * @param {Object} options - The options to apply to the matching algorithm
-   * @param {number} options.minAmountDelta - Lower delta for amount window
-   * @param {number} options.maxAmountDelta - Upper delta for amount window
-   * @param {number} options.pastWindow - Lower delta for date window
-   * @param {number} options.futureWindow - Upper delta for date window
+   * @param {number} options.amountLowerDelta - Lower delta for amount window
+   * @param {number} options.amountUpperDelta - Upper delta for amount window
+   * @param {number} options.dateLowerDelta - Lower delta for date window
+   * @param {number} options.dateUpperDelta - Upper delta for date window
    *
    * @returns {Object} An object that contains matchings for each bill
    *
@@ -607,8 +607,8 @@ class Linker {
     const defaultCriterias = {
       amountLowerDelta: DEFAULT_AMOUNT_DELTA,
       amountUpperDelta: DEFAULT_AMOUNT_DELTA,
-      dateLowerDelta: DEFAULT_PAST_WINDOW,
-      dateUpperDelta: DEFAULT_FUTURE_WINDOW
+      dateLowerDelta: DEFAULT_DATE_LOWER_DELTA,
+      dateUpperDelta: DEFAULT_DATE_UPPER_DELTA
     }
 
     const matchingCriterias = bills.reduce((criterias, bill) => {

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -23,21 +23,21 @@ const getIdentifiers = options => options.identifiers
 const getDateRangeFromBill = (bill, options) => {
   const date = getOperationDateFromBill(bill, options)
 
-  const pastWindow = get(
+  const lowerDelta = get(
     bill,
     'matchingCriterias.dateLowerDelta',
-    options.pastWindow
+    options.dateLowerDelta
   )
 
-  const futureWindow = get(
+  const upperDelta = get(
     bill,
     'matchingCriterias.dateUpperDelta',
-    options.futureWindow
+    options.dateUpperDelta
   )
 
   return {
-    minDate: subDays(date, pastWindow),
-    maxDate: addDays(date, futureWindow)
+    minDate: subDays(date, lowerDelta),
+    maxDate: addDays(date, upperDelta)
   }
 }
 
@@ -47,13 +47,13 @@ const getAmountRangeFromBill = (bill, options) => {
   const lowerDelta = get(
     bill,
     'matchingCriterias.amountLowerDelta',
-    options.minAmountDelta
+    options.amountLowerDelta
   )
 
   const upperDelta = get(
     bill,
     'matchingCriterias.amountUpperDelta',
-    options.maxAmountDelta
+    options.amountUpperDelta
   )
 
   return {

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -52,11 +52,11 @@ describe('getterHelper', () => {
   })
 
   describe('getDateRangeFromBill', () => {
-    const pastWindow = 1
-    const futureWindow = 1
+    const dateLowerDelta = 1
+    const dateUpperDelta = 1
     const date = '2018-01-08'
     const originalDate = '2018-01-03'
-    const options = { pastWindow, futureWindow }
+    const options = { dateLowerDelta, dateUpperDelta }
     const creditOptions = { ...options, credit: true }
 
     const matchingCriterias = {
@@ -89,9 +89,9 @@ describe('getterHelper', () => {
   })
 
   describe('getAmountRangeFromBill', () => {
-    const minAmountDelta = 1
-    const maxAmountDelta = 1
-    const options = { minAmountDelta, maxAmountDelta }
+    const amountLowerDelta = 1
+    const amountUpperDelta = 1
+    const options = { amountLowerDelta, amountUpperDelta }
     const creditOptions = { ...options, credit: true }
     const amount = 7.5
     const originalAmount = 25

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
@@ -241,10 +241,10 @@ describe('operations filters', () => {
     ]
 
     const defaultOptions = {
-      minAmountDelta: 1,
-      maxAmountDelta: 1,
-      pastWindow: 1,
-      futureWindow: 1
+      amountLowerDelta: 1,
+      amountUpperDelta: 1,
+      dateLowerDelta: 1,
+      dateUpperDelta: 1
     }
 
     describe('health bill', () => {

--- a/src/ducks/billsMatching/matchFromBills.js
+++ b/src/ducks/billsMatching/matchFromBills.js
@@ -1,5 +1,8 @@
 import Linker from './Linker/Linker'
-import { DEFAULT_PAST_WINDOW, DEFAULT_FUTURE_WINDOW } from './Linker/Linker'
+import {
+  DEFAULT_DATE_LOWER_DELTA,
+  DEFAULT_DATE_UPPER_DELTA
+} from './Linker/Linker'
 import { format as formatDate } from 'date-fns'
 import { Transaction } from 'models'
 import { getDateRangeFromBill } from './Linker/billsToOperation/helpers'
@@ -8,8 +11,8 @@ const DATE_FORMAT = 'YYYY-MM-DD'
 
 export default async function matchFromBills(bills) {
   const options = {
-    pastWindow: DEFAULT_PAST_WINDOW,
-    futureWindow: DEFAULT_FUTURE_WINDOW
+    dateLowerDelta: DEFAULT_DATE_LOWER_DELTA,
+    dateUpperDelta: DEFAULT_DATE_UPPER_DELTA
   }
 
   const dateRange = bills.reduce((range, bill) => {


### PR DESCRIPTION
We had some inconsistency between the Linker's options names and the bills matchingCriterias properties names. This fixes it so the Linker code is more understandable.

Related to #1525 