### PR TITLE
fix: When LineChart data changes, the selected item key is the…

### DIFF
--- a/src/components/Chart/LineChart.jsx
+++ b/src/components/Chart/LineChart.jsx
@@ -58,18 +58,14 @@ class LineChart extends Component {
 
   static getDerivedStateFromProps(props, state) {
     const { data } = props
-    const { itemKey: prevItemKey } = state || {}
 
-    const dataByDate = getDataByDate(data)
-
-    // When dataByDate changes and the current selected item does not belong
-    // to the new data, we have to reset it. This happens for example when
-    // navigating from month to month
-    if (!dataByDate || !prevItemKey || !dataByDate[prevItemKey]) {
+    // If currently displayed data changes, we recompute selected itemkey
+    if (!state || state.prevData !== data) {
+      const dataByDate = getDataByDate(data)
       const itemKey = max(Object.keys(dataByDate))
-      return { itemKey }
-    } else {
-      return null
+      // Have to keep prevData in derivedState to access it in later calls
+      // of getDerivedStateFromProps. See https://github.com/facebook/react/issues/12188
+      return { prevData: data, itemKey }
     }
   }
 

--- a/src/components/Chart/LineChart.spec.jsx
+++ b/src/components/Chart/LineChart.spec.jsx
@@ -1,0 +1,42 @@
+import LineChart from './LineChart'
+
+const chartData = [
+  { x: new Date('2018-07-03'), y: 3 },
+  { x: new Date('2018-07-02'), y: 4 },
+  { x: new Date('2018-07-01'), y: 5 },
+  { x: new Date('2018-06-30'), y: 6 },
+  { x: new Date('2018-06-29'), y: 5 },
+  { x: new Date('2018-06-28'), y: 4 },
+  { x: new Date('2018-06-27'), y: 3 }
+]
+
+describe('LineChart', () => {
+  it('should recompute item key to be the max date of the data', () => {
+    const state1 = LineChart.getDerivedStateFromProps(
+      {
+        data: chartData.slice(0, 2)
+      },
+      null
+    )
+    const toISODay = ts => {
+      const date = new Date(parseInt(ts))
+      return date.toISOString().slice(0, 10)
+    }
+
+    expect(toISODay(state1.itemKey)).toBe('2018-07-03')
+    const state2 = LineChart.getDerivedStateFromProps(
+      {
+        data: chartData.slice(3, 5)
+      },
+      state1
+    )
+    expect(toISODay(state2.itemKey)).toBe('2018-06-30')
+    const state3 = LineChart.getDerivedStateFromProps(
+      {
+        data: chartData.slice(-3)
+      },
+      state2
+    )
+    expect(toISODay(state3.itemKey)).toBe('2018-06-29')
+  })
+})

--- a/src/ducks/transactions/TriggerErrorCard.jsx
+++ b/src/ducks/transactions/TriggerErrorCard.jsx
@@ -26,7 +26,7 @@ const TriggerErrorCard = ({
     konnector: trigger.message.konnector
   })
 
-  const konnError = new KonnectorJobError(trigger.last_error)
+  const konnError = new KonnectorJobError(trigger.current_state.last_error)
   // We do not have a full konnector object here but we can create a simple
   // one, that is sufficient for getErrorLocaleBound, from the information in
   // the trigger

--- a/src/ducks/transactions/TriggerErrorCard.spec.jsx
+++ b/src/ducks/transactions/TriggerErrorCard.spec.jsx
@@ -14,6 +14,9 @@ describe('trigger error card', () => {
         count={1}
         index={0}
         trigger={{
+          current_state: {
+            last_error: 'LOGIN_FAILED'
+          },
           message: {
             account: '1234',
             konnector: 'boursorama83'

--- a/src/ducks/transactions/__snapshots__/TriggerErrorCard.spec.jsx.snap
+++ b/src/ducks/transactions/__snapshots__/TriggerErrorCard.spec.jsx.snap
@@ -12,6 +12,9 @@ exports[`trigger error card should render correctly 1`] = `
   t={[Function]}
   trigger={
     Object {
+      "current_state": Object {
+        "last_error": "LOGIN_FAILED",
+      },
       "message": Object {
         "account": "1234",
         "konnector": "boursorama83",
@@ -39,7 +42,7 @@ exports[`trigger error card should render correctly 1`] = `
         Transactions.trigger-error.description
       </div>
     }
-    title="Connection error"
+    title="Bad credentials"
   >
     <div
       className="styles__Infos___2ZZVs u-flex u-flex-column u-p-1 u-mih-2 u-flex-justify-center u-ta-left u-stack-m u-bg-chablis u-bdrs-0 u-maw-none u-p-1-half "
@@ -57,7 +60,7 @@ exports[`trigger error card should render correctly 1`] = `
           <div
             className="u-title-h3 u-pomegranate"
           >
-            Connection error
+            Bad credentials
           </div>
         </BaseText>
       </SubTitle>


### PR DESCRIPTION
Previously the logic was, if the itemKey cannot be found in the current data,
let's update it. It was not matching what we wanted : on data update, we want
the selected item to be the latest item available.

EDIT: Also fixed a small bug for error in transaction page.