### PR TITLE
feat: Do not show connection errors banner when browsing via categ

### DIFF
--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -209,7 +209,7 @@ export class TransactionsDumb extends React.Component {
   }
 
   render() {
-    const { limitMin, limitMax, manualLoadMore } = this.props
+    const { limitMin, limitMax, manualLoadMore, isOnSubcategory } = this.props
     return (
       <InfiniteScroll
         manual={manualLoadMore}
@@ -225,7 +225,7 @@ export class TransactionsDumb extends React.Component {
         onScroll={this.handleScroll}
         className={this.props.className}
       >
-        <TransactionPageErrors />
+        {!isOnSubcategory ? <TransactionPageErrors /> : null}
         <ScrollRestore
           limitMin={limitMin}
           limitMax={limitMax}

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -9,6 +9,7 @@ import AppLike from '../../../test/AppLike'
 import { Caption } from 'cozy-ui/react/Text'
 import { getClient } from 'test/client'
 import { normalizeData } from 'test/store'
+import TransactionPageErrors from 'ducks/transactions/TransactionPageErrors'
 
 // No need to test this here
 jest.mock('ducks/transactions/TransactionPageErrors', () => () => null)
@@ -80,15 +81,32 @@ describe('Transactions', () => {
     .spyOn(TransactionsDumb.prototype, 'renderTransactions')
     .mockReturnValue(<div />)
 
-  it('should sort transactions from props on mount and on update', () => {
+  const setup = ({ isOnSubcategory }) => {
     const transactions = data['io.cozy.bank.operations']
 
     const root = mount(
       <TransactionsDumb
         breakpoints={{ isDesktop: false }}
         transactions={transactions}
+        isOnSubcategory={isOnSubcategory}
       />
     )
+
+    return { root, transactions }
+  }
+
+  it('should not show transaction errors while on subcateg', () => {
+    const { root } = setup({ isOnSubcategory: true })
+    expect(root.find(TransactionPageErrors).length).toBe(0)
+  })
+
+  it('should show transaction errors while not on subcateg', () => {
+    const { root } = setup({ isOnSubcategory: false })
+    expect(root.find(TransactionPageErrors).length).toBe(1)
+  })
+
+  it('should sort transactions from props on mount and on update', () => {
+    const { root, transactions } = setup({ isOnSubcategory: false })
 
     expect(root.instance().transactions).toEqual(sortByDate(transactions))
 

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -208,6 +208,7 @@ class TransactionsPage extends Component {
     const { limitMin, limitMax, infiniteScrollTop } = this.state
     const { t } = this.props
     const transactions = this.getTransactions()
+    const isOnSubcategory = onSubcategory(this.props)
 
     if (transactions.length === 0) {
       return (
@@ -220,6 +221,7 @@ class TransactionsPage extends Component {
     return (
       <Delayed delay={0} fallback={<FakeTransactions />}>
         <TransactionsWithSelection
+          isOnSubcategory={isOnSubcategory}
           limitMin={limitMin}
           limitMax={limitMax}
           onReachTop={this.handleDecreaseLimitMin}

--- a/src/ducks/transactions/actions/KonnectorAction/helpers.js
+++ b/src/ducks/transactions/actions/KonnectorAction/helpers.js
@@ -23,4 +23,4 @@ export const findMatchingBrandWithoutTrigger = (transaction, brands) => {
   return matchingBrand
 }
 
-export const hasUrls = urls => urls['COLLECT'] || urls['HOME']
+export const hasUrls = urls => urls && (urls['COLLECT'] || urls['HOME'])


### PR DESCRIPTION
Transactions.jsx now knows if on subcateg and does not show the error
banner if we are on a subcategory.