### PR TITLE
feat(transactions): Show only actionable accounts errors

### DIFF
--- a/src/ducks/transactions/TransactionPageErrors.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.jsx
@@ -18,6 +18,19 @@ import flag from 'cozy-flags'
 
 const getCreatedByApp = acc => get(acc, 'cozyMetadata.createdByApp')
 
+const isActionableError = trigger => {
+  const actionableErrors = [
+    'CHALLENGE_ASKED',
+    'DISK_QUOTA_EXCEEDED',
+    'TERMS_VERSION_MISMATCH',
+    'USER_ACTION_NEEDED',
+    'USER_ACTION_NEEDED.CHANGE_PASSWORD',
+    'USER_ACTION_NEEDED.ACCOUNT_REMOVED'
+  ]
+
+  return actionableErrors.includes(trigger.current_state.last_error)
+}
+
 /**
  * Returns
  * - failed triggers corresponding to the given accounts.
@@ -36,6 +49,7 @@ export const getDerivedData = ({ triggerCol, accounts }) => {
     triggers
       .filter(isBankTrigger)
       .filter(isErrored)
+      .filter(isActionableError)
       .filter(tr => konnectorToAccounts[tr.message.konnector]),
     tr => tr.message.konnector
   )

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1572,6 +1572,18 @@
   ],
   "io.cozy.triggers": [
     {
+      "_id": "t1336",
+      "message": {
+        "konnector": "revolut",
+        "account": "account-revolut"
+      },
+      "worker": "konnector",
+      "current_state": {
+        "status": "errored",
+        "last_error": "LOGIN_FAILED"
+      }
+    },
+    {
       "_id": "t1337",
       "message": {
         "konnector": "revolut",
@@ -1579,7 +1591,8 @@
       },
       "worker": "konnector",
       "current_state": {
-        "status": "errored"
+        "status": "errored",
+        "last_error": "CHALLENGE_ASKED"
       }
     },
     {
@@ -1590,7 +1603,8 @@
       },
       "worker": "konnector",
       "current_state": {
-        "status": "errored"
+        "status": "errored",
+        "last_error": "USER_ACTION_NEEDED"
       }
     },
     {


### PR DESCRIPTION
Since all errors are not actionable for the user, we don't show all
errors, but some of them:

CHALLENGE_ASKED
DISK_QUOTA_EXCEEDED
TERMS_VERSION_MISMATCH
USER_ACTION_NEEDED
USER_ACTION_NEEDED.CHANGE_PASSWORD
USER_ACTION_NEEDED.ACCOUNT_REMOVED

We don't show LOGIN_FAILED errors because we have too many false
positives for this error.