### PR TITLE
Dissociate transactions-error-banner flag and balance-account-errors flags

### DIFF
--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -122,7 +122,7 @@ class AccountRow extends React.PureComponent {
             <div className={styles.AccountRow__subText}>
               {failedTrigger &&
               !flag('demo') &&
-              flag('transactions-error-banner') ? (
+              flag('balance-account-errors') ? (
                 <FailedTriggerMessage trigger={failedTrigger} />
               ) : (
                 <UpdatedAt account={account} t={t} />

--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -34,4 +34,7 @@ if (isDemoCozy()) {
 // Turn on reimbursement tags + new CTAs UI
 flag('reimbursement-tag', true)
 
+// Turn on error banner on transactions page
+flag('transactions-error-banner', true)
+
 window.flag = flag


### PR DESCRIPTION
We want to be able to activate the transactions-error-banner flag on the
transactions page without activating it on the balances page. To achieve
this, we use a different flag (balance-account-errors) on the balances page.

Also enabled transactions-error-banner flag by default.