### PR TITLE
fix: Use the good format when calling services

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -67,10 +67,8 @@ class MyKonnector extends BaseKonnector {
     // save `transactions`
 
     await cozyClient.jobs.create('service', {
-      message: {
-        name: 'categorization',
-        slug: 'banks'
-      }
+      name: 'categorization',
+      slug: 'banks'
     })
   }
 }

--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -119,10 +119,8 @@ export const canCategorizeNextChunk = () => {
  */
 export const startService = name => {
   const args = {
-    message: {
-      name,
-      slug: 'banks'
-    }
+    name,
+    slug: 'banks'
   }
 
   return cozyClient.jobs.create('service', args)

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -34,10 +34,8 @@ const Versions = () => {
 const startAndWaitService = async (client, serviceName) => {
   const jobs = client.collection('io.cozy.jobs')
   const { data: job } = await jobs.create('service', {
-    message: {
-      name: serviceName,
-      slug: 'banks'
-    }
+    name: serviceName,
+    slug: 'banks'
   })
   const finalJob = await jobs.waitFor(job.id)
   if (finalJob.state === 'errored') {


### PR DESCRIPTION
We used a format that is working but that is not the one that is really
expected by the stack. It resulted in a weird job structure in the
io.cozy.jobs couch base and Bender was not able to show the service
name.

See https://github.com/cozy/cozy-stack/issues/2159