### PR TITLE
fix: Month selector inconsistencies

### DIFF
--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -50,7 +50,7 @@ select-date-height-small = 2.75rem
         background-color var(--selectDatesChipPrimaryBackgroundColor)
         margin 0
 
-        &:active
+        &:not(.SelectDatesButtonDisabled):active
             box-shadow 0px 0px 0px 2px rgba(255, 255, 255, 0.2)
 
         svg

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -4,7 +4,9 @@ import React from 'react'
 import {
   DumbTransactionsPage,
   UnpluggedTransactionsPage,
-  TransactionsPageBar
+  TransactionsPageBar,
+  STEP_INFINITE_SCROLL,
+  MIN_NB_TRANSACTIONS_SHOWN
 } from './TransactionsPage'
 import data from '../../../test/fixtures'
 import PropTypes from 'prop-types'
@@ -55,12 +57,12 @@ describe('TransactionsPage', () => {
 
   // Necessary wrapper to be able to use setProps since `setProps` is
   // only callable on the Enzyme root
-  const Wrapper = ({ filteringDoc }) => (
+  const Wrapper = ({ filteringDoc, filteredTransactions }) => (
     <AppLike>
       <UnpluggedTransactionsPage
         transactions={mkCollection(allTransactions, { fetchStatus: 'loaded' })}
         accounts={mkCollection(allAccounts, { fetchStatus: 'loaded' })}
-        filteredTransactions={allTransactions}
+        filteredTransactions={filteredTransactions || allTransactions}
         filteredAccounts={allAccounts}
         filteringDoc={filteringDoc}
       />
@@ -145,12 +147,18 @@ describe('TransactionsPage', () => {
     })
   })
 
-  it('should call handleChangeMonth if filteringDoc changed', () => {
+  it('should correctly set internal state if filteringDoc changed', () => {
     setup()
     const tp = root.find(DumbTransactionsPage)
     const instance = tp.instance()
     jest.spyOn(instance, 'handleChangeMonth')
-    root.setProps({ filteringDoc: { _id: 'new-doc' } })
-    expect(instance.handleChangeMonth).toHaveBeenCalled()
+    expect(tp.state('limitMax')).toBe(STEP_INFINITE_SCROLL)
+    root.setProps({
+      filteringDoc: { _id: 'new-doc' },
+      filteredTransactions: [{ date: '2019-11-03T13:13' }]
+    })
+    expect(tp.state('currentMonth')).toBe('2019-11')
+    expect(tp.state('limitMin')).toBe(0)
+    expect(tp.state('limitMax')).toBe(MIN_NB_TRANSACTIONS_SHOWN)
   })
 })


### PR DESCRIPTION
Fixes an inconsistency bug on the currentMonth state variable when navigating
between accounts/groups from the transaction page.

More explanation in the concerned commit.