### PR TITLE
fix: Android targetSDKVersion

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -19,6 +19,7 @@
     </host>
     <ios-team-id value="3AKXFMV43J"/>
   </universal-links>
+  <preference name="android-targetSdkVersion" value="28"/>
   <platform name="android">
     <config-file parent="/manifest/application" target="app/src/main/AndroidManifest.xml">
       <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false"/>


### PR DESCRIPTION
Since the 1st November, android app needs to target at least SDK 28. We can update our cordova-android, but it's easier and safer to only specify this target in the config.