### PR TITLE
fix(loan): Don't crash on reload

### DIFF
--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -28,3 +28,4 @@ export const getClient = () => {
 
 export { default as CleanupStoreClientPlugin } from './cleanup'
 export { default as StartupChecksPlugin } from './checks'
+export * from './utils'

--- a/src/ducks/filters/index.js
+++ b/src/ducks/filters/index.js
@@ -38,10 +38,10 @@ export const getFilteringDoc = createSelector(
 
     switch (rawFilteringDoc._type) {
       case ACCOUNT_DOCTYPE:
-        return accountsById[rawFilteringDoc._id]
+        return accountsById[rawFilteringDoc._id] || rawFilteringDoc
 
       case GROUP_DOCTYPE:
-        return groupsById[rawFilteringDoc._id]
+        return groupsById[rawFilteringDoc._id] || rawFilteringDoc
 
       default:
         return rawFilteringDoc

--- a/src/ducks/loan/LoanListPage.jsx
+++ b/src/ducks/loan/LoanListPage.jsx
@@ -3,6 +3,7 @@ import { Section } from 'components/Section'
 import LoanProgress from 'ducks/loan/LoanProgress'
 import CompositeRow from 'cozy-ui/transpiled/react/CompositeRow'
 import Icon from 'cozy-ui/transpiled/react/Icon'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import { Bold } from 'cozy-ui/transpiled/react/Text'
 import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
@@ -10,6 +11,10 @@ import AccountIcon from 'components/AccountIcon'
 import withFilters from 'components/withFilters'
 import { BalanceDetailsHeader } from 'ducks/balance'
 import { Padded } from 'components/Spacing'
+import { queryConnect } from 'cozy-client'
+import { flowRight as compose } from 'lodash'
+import { accountsConn } from 'doctypes'
+import { isCollectionLoading, hasBeenLoaded } from 'ducks/client'
 
 const PaddedOnDesktop = withBreakpoints()(props => {
   const {
@@ -25,7 +30,19 @@ const PaddedOnDesktop = withBreakpoints()(props => {
 })
 
 const DumbLoanListPage = props => {
-  const { filteringDoc, filterByDoc } = props
+  const { filteringDoc, filterByDoc, accounts: accountsCol } = props
+
+  if (isCollectionLoading(accountsCol) && !hasBeenLoaded(accountsCol)) {
+    return (
+      <>
+        <BalanceDetailsHeader showBalance />
+        <Padded className="u-flex u-flex-justify-center">
+          <Spinner size="xxlarge" />
+        </Padded>
+      </>
+    )
+  }
+
   const accounts = filteringDoc.accounts.data
 
   return (
@@ -57,6 +74,11 @@ const DumbLoanListPage = props => {
   )
 }
 
-const LoanListPage = withFilters(DumbLoanListPage)
+const LoanListPage = compose(
+  withFilters,
+  queryConnect({
+    accounts: accountsConn
+  })
+)(DumbLoanListPage)
 
 export default LoanListPage


### PR DESCRIPTION
When reloading the page, the accounts were not present, so when we tried
to access to the group's accounts relationship, the app crashed. To fix
this, I connected the component to the accounts query and ensured we
have the data before showing the accounts list. While data is loading,
a spinner is shown.