### PR TITLE
Fix plugin initialisation

### DIFF
--- a/src/ducks/client/mobile/mobile.js
+++ b/src/ducks/client/mobile/mobile.js
@@ -49,8 +49,8 @@ export const getManifestOptions = manifest => {
 }
 
 const registerPluginsAndHandlers = client => {
-  client.register(PushPlugin)
-  client.register(SentryPlugin)
+  client.registerPlugin(PushPlugin)
+  client.registerPlugin(SentryPlugin)
 }
 
 export const getClient = () => {

--- a/src/ducks/client/mobile/mobile.spec.js
+++ b/src/ducks/client/mobile/mobile.spec.js
@@ -1,0 +1,10 @@
+import { getClient } from './mobile'
+
+describe('get mobile client', () => {
+  it('should correctly register plugins', () => {
+    global.__APP_VERSION__ = '1.5.0'
+    const client = getClient()
+    expect(client.plugins.push).not.toBeUndefined()
+    expect(client.plugins.sentry).not.toBeUndefined()
+  })
+})

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -71,6 +71,20 @@ const ServiceButton = ({ name: serviceName, client }) => {
   )
 }
 
+const DeviceToken = ({ client }) => {
+  const notificationToken = getNotificationToken(client)
+  return (
+    <>
+      <SubTitle>Device token</SubTitle>
+      <p>
+        {notificationToken
+          ? notificationToken
+          : '⚠️ Cannot receive notifications'}
+      </p>
+    </>
+  )
+}
+
 class DumbDebugSettings extends React.PureComponent {
   toggleNoAccount() {
     const noAccountValue = !flag('balance.no-account')
@@ -138,7 +152,7 @@ class DumbDebugSettings extends React.PureComponent {
         <div>
           <Title>Client info</Title>
           <SubTitle>URI</SubTitle>
-          <p>{this.props.client.stackClient.uri}</p>
+          <p>{client.stackClient.uri}</p>
           {client.stackClient.oauthOptions ? (
             <>
               <SubTitle>OAuth document id</SubTitle>
@@ -148,12 +162,7 @@ class DumbDebugSettings extends React.PureComponent {
         </div>
         <div>
           <Title>Notifications</Title>
-          {isMobileApp() ? (
-            <>
-              <SubTitle>Device token</SubTitle>
-              <p>{getNotificationToken(client)}</p>
-            </>
-          ) : null}
+          {isMobileApp() ? <DeviceToken client={client} /> : null}
           <Button
             label="Send notification"
             onClick={() => this.sendNotification()}


### PR DESCRIPTION
Plugin like Push and Sentry were not correctly initialized since the
register method was called instead of the registerPlugin method.
Unfortunately the register method exists on the client and does not
fail in case of wrong argument.