### PR TITLE
fix: Tabs no longer take all the width of the screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "cozy-pouch-link": "6.64.7",
     "cozy-realtime": "3.2.1",
     "cozy-stack-client": "7.8.0",
-    "cozy-ui": "26.5.0",
+    "cozy-ui": "26.8.1",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/settings/Settings.styl
+++ b/src/ducks/settings/Settings.styl
@@ -16,7 +16,6 @@
         border-bottom 0
 
         & > *
-            width 100%
             text-align center
 
 

--- a/src/ducks/settings/Settings.styl
+++ b/src/ducks/settings/Settings.styl
@@ -11,13 +11,8 @@
 
 .bnk-tabs .bnk-coz-tab-list
     +small-screen()
-        display flex
         padding-left 0
         border-bottom 0
-
-        & > *
-            text-align center
-
 
 .settings__title
     padding 1.5rem 2rem

--- a/yarn.lock
+++ b/yarn.lock
@@ -4904,10 +4904,10 @@ cozy-ui@24.3.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@26.5.0:
-  version "26.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-26.5.0.tgz#7d9adc092dbb8a846bb84e70983012060a2d8e26"
-  integrity sha512-upiKIIsfhErnfR4q7J43mdyuaULZ+e8axFyZuKEU5VhbtzWduvLOrrdC/SHgXKS4uBjVYFMdP9DEQEuqjcIK9g==
+cozy-ui@26.8.1:
+  version "26.8.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-26.8.1.tgz#ebf7f735681e6734bca96b9673605ec168fb3f09"
+  integrity sha512-ivCe2hgCgk5cnSIZuJrMkRUxgT79nP4psrZ3B716DK3SK7DFltpHVGqwirCuf3IXNOAzeToeUiFhYowkvEFKuQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Introduced after cozy-ui put flex-basis auto on tab items