### PR TITLE
feat: Correctly handle parent categories in budget alerts

### DIFF
--- a/src/components/MultiSelect/index.jsx
+++ b/src/components/MultiSelect/index.jsx
@@ -1,7 +1,17 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Row from 'components/Row'
+import Row, { RowBody } from 'components/Row'
+import { translate, Button } from 'cozy-ui/react'
 
+export const ChooseButton = translate()(({ onClick, t }) => (
+  <Button
+    className="u-m-0 u-ph-half"
+    theme="secondary"
+    label={t('General.choose')}
+    size="small"
+    onClick={onClick}
+  />
+))
 /**
  * Select like component to choose an option among a list of options.
  * Options can have children; selecting an option that has children
@@ -35,22 +45,30 @@ class MultiSelect extends Component {
     return item
   }
 
+  handleNavToChildren = item => {
+    const newHistory = [item, ...this.state.history]
+    this.setState({
+      history: newHistory
+    })
+  }
+
   handleSelect = item => {
+    this.props.onSelect(item)
+    setTimeout(() => {
+      this.resetHistory()
+    }, 500)
+  }
+
+  handleClickItem = item => {
     if (item.children && item.children.length > 0) {
-      const newHistory = [item, ...this.state.history]
-      this.setState({
-        history: newHistory
-      })
+      this.handleNavToChildren(item)
     } else {
-      this.props.onSelect(item)
-      setTimeout(() => {
-        this.resetHistory()
-      }, 500)
+      this.handleSelect(item)
     }
   }
 
   render() {
-    const { ContentComponent, HeaderComponent } = this.props
+    const { ContentComponent, HeaderComponent, canSelectParent } = this.props
     const { history } = this.state
     const current = history[0]
     const children = current.children || []
@@ -70,10 +88,14 @@ class MultiSelect extends Component {
               key={item.title}
               isSelected={this.props.isSelected(item, level)}
               icon={item.icon}
-              label={item.title}
-              onClick={() => this.handleSelect(item)}
+              onClick={() => this.handleClickItem(item)}
               hasArrow={item.children && item.children.length > 0}
-            />
+            >
+              <RowBody>{item.title}</RowBody>
+              {item.children && canSelectParent ? (
+                <ChooseButton onClick={() => this.handleSelect(item)} />
+              ) : null}
+            </Row>
           ))}
         </ContentComponent>
       </>
@@ -96,7 +118,8 @@ MultiSelect.propTypes = {
   isSelected: PropTypes.func.isRequired,
   options: PropTypes.shape({
     children: PropTypes.arrayOf(ItemPropType)
-  })
+  }),
+  canSelectParent: PropTypes.bool
 }
 
 export default MultiSelect

--- a/src/components/Row/index.jsx
+++ b/src/components/Row/index.jsx
@@ -3,15 +3,33 @@ import { Media, Bd, Img, Icon } from 'cozy-ui/transpiled/react'
 import styles from './Row.styl'
 import cx from 'classnames'
 
-const Row = ({ isSelected, icon, label, hasArrow, onClick, className }) => (
+export const RowBody = ({ children }) => (
+  <Bd className="u-ellipsis">{children}</Bd>
+)
+
+const Row = ({
+  isSelected,
+  icon,
+  label,
+  children,
+  hasArrow,
+  onClick,
+  className
+}) => (
   <Media
-    className={cx(styles.Row, isSelected ? ' u-text-bold' : '', className)}
+    className={cx(
+      styles.Row,
+      'u-row-m',
+      isSelected ? 'u-text-bold' : '',
+      className
+    )}
     onClick={onClick}
   >
-    {icon && <Img className="u-pr-1">{icon}</Img>}
-    <Bd className="u-ellipsis">{label}</Bd>
+    {icon && <Img>{icon}</Img>}
+    {label ? <RowBody>{label}</RowBody> : null}
+    {children}
     {hasArrow && (
-      <Img className="u-pl-1">
+      <Img>
         <Icon icon="right" color="var(--coolGrey)" />
       </Img>
     )}

--- a/src/ducks/balance/BalanceDetailsHeader.spec.jsx
+++ b/src/ducks/balance/BalanceDetailsHeader.spec.jsx
@@ -17,6 +17,9 @@ const setup = props => {
     {
       context: {
         router: {
+          push: jest.fn(),
+          replace: jest.fn(),
+          go: jest.fn(),
           getCurrentLocation: () => ({
             pathname: '/'
           })

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -32,6 +32,10 @@ describe('GroupPanel', () => {
     )
   })
 
+  const fakeRouter = {
+    push: jest.fn()
+  }
+
   const Wrapper = ({ expanded }) => (
     <AppLike client={client}>
       <GroupPanel
@@ -42,6 +46,7 @@ describe('GroupPanel', () => {
         switches={switches}
         onSwitchChange={() => {}}
         onChange={onChange}
+        router={fakeRouter}
       />
     </AppLike>
   )

--- a/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
+++ b/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
@@ -4,7 +4,6 @@ import keyBy from 'lodash/keyBy'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import NotificationView from 'ducks/notifications/BaseNotificationView'
 import { getCurrentDate } from 'ducks/notifications/utils'
-import { getParentCategory } from 'ducks/categories/helpers'
 import { getCategoryName } from 'ducks/categories/categoriesMap'
 import { getGroupLabel } from 'ducks/groups/helpers'
 import { getAccountLabel } from 'ducks/account/helpers'
@@ -46,9 +45,10 @@ const getAccountOrGroupLabelFromAlert = (
 
 const transformForTemplate = (budgetAlert, t, accountsById, groupsById) => {
   const catId = budgetAlert.alert.categoryId
-  const parentCategoryId = getParentCategory(catId)
   const catName = getCategoryName(catId)
-  const type = parentCategoryId === catId ? 'categories' : 'subcategories'
+  const type = budgetAlert.alert.categoryIsParent
+    ? 'categories'
+    : 'subcategories'
   const accountOrGroupLabel = getAccountOrGroupLabelFromAlert(
     budgetAlert.alert,
     accountsById,

--- a/src/ducks/budgetAlerts/service.spec.js
+++ b/src/ducks/budgetAlerts/service.spec.js
@@ -230,7 +230,8 @@ describe('service', () => {
           {
             ...budgetAlert,
             maxThreshold: 10,
-            categoryId: GOING_OUT_CATEGORY_ID
+            categoryId: GOING_OUT_CATEGORY_ID,
+            categoryIsParent: true
           }
         ],
         expenses: [
@@ -247,7 +248,7 @@ describe('service', () => {
         '2 budgets have exceeded their limit'
       )
       expect(lastPostNotificationCall.data.attributes.message).toEqual(
-        'Health expenses: 251€ > 100€, Others : Outings, trips: 16€ > 10€'
+        'Health expenses: 251€ > 100€, Outings, trips: 68€ > 10€'
       )
     })
   })

--- a/src/ducks/budgetAlerts/service.spec.js
+++ b/src/ducks/budgetAlerts/service.spec.js
@@ -84,6 +84,37 @@ describe('service', () => {
     expect(mockPostNotification).toHaveBeenCalledTimes(1)
   })
 
+  describe('parent category', () => {
+    it('should send a notification when sum of expenses > alert threshold', async () => {
+      const DAILY_LIFE_ID = '400100'
+      const { client, mockPostNotification } = setup({
+        budgetAlerts: [
+          {
+            ...settings.budgetAlerts[0],
+            categoryId: DAILY_LIFE_ID,
+            categoryIsParent: true
+          }
+        ],
+        expenses: julyExpenses
+      })
+      await runCategoryBudgetService(client, { currentDate: '2019-07-15' })
+      expect(fetchCategoryAlerts).toHaveBeenCalledWith(expect.any(CozyClient))
+      expect(updateCategoryAlerts).toHaveBeenCalledWith(
+        expect.any(CozyClient),
+        [
+          {
+            maxThreshold: 100,
+            categoryId: DAILY_LIFE_ID,
+            categoryIsParent: true,
+            lastNotificationAmount: 735,
+            lastNotificationDate: '2017-07-15'
+          }
+        ]
+      )
+      expect(mockPostNotification).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('should not update alerts, nor send a notification when there are no expenses', async () => {
     const { client, mockPostNotification } = setup({
       budgetAlerts: settings.budgetAlerts,

--- a/src/ducks/categories/CategoryChoice.jsx
+++ b/src/ducks/categories/CategoryChoice.jsx
@@ -56,7 +56,7 @@ class CategoryChoice extends Component {
   }
 
   render() {
-    const { t, onCancel, onSelect, modal } = this.props
+    const { t, onCancel, onSelect, modal, canSelectParent } = this.props
 
     const Component = modal ? PopupSelect : MultiSelect
     return (
@@ -65,6 +65,7 @@ class CategoryChoice extends Component {
         title={t('Categories.choice.title')}
         options={this.options}
         isSelected={this.isSelected}
+        canSelectParent={canSelectParent}
         onSelect={subcategory => onSelect(subcategory)}
         onCancel={onCancel}
       />

--- a/src/ducks/categories/CategoryChoice.jsx
+++ b/src/ducks/categories/CategoryChoice.jsx
@@ -23,9 +23,9 @@ export const getOptions = (categories, subcategory = false, t) => {
       option.children = getOptions(option.children, true, t).sort(a => {
         if (a.id === option.id) {
           return 1
+        } else {
+          return -1
         }
-
-        return 0
       })
     }
 

--- a/src/ducks/categories/CategoryChoice.spec.jsx
+++ b/src/ducks/categories/CategoryChoice.spec.jsx
@@ -25,13 +25,14 @@ describe('getCategoriesOptions', () => {
 })
 
 describe('CategoryChoice', () => {
-  const setup = ({ categoryId }) => {
+  const setup = ({ categoryId, canSelectParent }) => {
     const root = mount(
       <TestI18n>
         <CategoryChoice
+          canSelectParent={canSelectParent}
           categoryId={categoryId}
-          onSelect={() => {}}
-          onCancel={() => {}}
+          onSelect={jest.fn()}
+          onCancel={jest.fn()}
         />
       </TestI18n>
     )
@@ -44,11 +45,9 @@ describe('CategoryChoice', () => {
       const selectedRow = findSelectedRow(root)
       expect(selectedRow.length).toBe(1)
       expect(selectedRow.text()).toBe('Everyday life')
-      expect(selectedRow.find(ChooseButton).length).toBe(1)
       selectedRow.simulate('click')
 
       const selectedRow2 = findSelectedRow(root)
-      expect(selectedRow2.find(ChooseButton).length).toBe(0)
       expect(selectedRow2.length).toBe(1)
       expect(selectedRow2.text()).toBe('Dressing')
     })
@@ -65,6 +64,26 @@ describe('CategoryChoice', () => {
       const selectedRow2 = findSelectedRow(root)
       expect(selectedRow2.length).toBe(1)
       expect(selectedRow2.text()).toBe('Others : Everyday life')
+    })
+  })
+
+  describe('when allowing parent to be selected', () => {
+    it('should show a ChooseButton', () => {
+      const { root } = setup({
+        categoryId: DRESSING_CATEGORY_ID,
+        canSelectParent: true
+      })
+      const selectedRow = findSelectedRow(root)
+      expect(selectedRow.length).toBe(1)
+
+      const chooseBtn = selectedRow.find(ChooseButton)
+      expect(chooseBtn.length).toBe(1)
+      chooseBtn.props().onClick()
+      expect(root.find(CategoryChoice).props().onSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: DAILY_LIFE_CATEGORY_ID
+        })
+      )
     })
   })
 })

--- a/src/ducks/categories/CategoryChoice.spec.jsx
+++ b/src/ducks/categories/CategoryChoice.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import CategoryChoice, { getCategoriesOptions } from './CategoryChoice'
 import Row from 'components/Row'
+import { ChooseButton } from 'components/MultiSelect'
 import { TestI18n } from 'test/AppLike'
 
 const isSelectedRow = n => n.type() == Row && n.props().isSelected
@@ -43,9 +44,11 @@ describe('CategoryChoice', () => {
       const selectedRow = findSelectedRow(root)
       expect(selectedRow.length).toBe(1)
       expect(selectedRow.text()).toBe('Everyday life')
+      expect(selectedRow.find(ChooseButton).length).toBe(1)
       selectedRow.simulate('click')
 
       const selectedRow2 = findSelectedRow(root)
+      expect(selectedRow2.find(ChooseButton).length).toBe(0)
       expect(selectedRow2.length).toBe(1)
       expect(selectedRow2.text()).toBe('Dressing')
     })

--- a/src/ducks/categories/categoriesMap.js
+++ b/src/ducks/categories/categoriesMap.js
@@ -112,6 +112,11 @@ export const getParentCategory = catId => {
   return parent && parent.name
 }
 
+export const isParentOf = (possibleParentCatId, catId) => {
+  const parent = categoryToParent.get(catId)
+  return Boolean(parent && parent.id == possibleParentCatId)
+}
+
 Object.keys(tree).forEach(catId => {
   const catName = tree[catId]
   const parentName = getParentCategory(catId)

--- a/src/ducks/categories/categoriesMap.spec.js
+++ b/src/ducks/categories/categoriesMap.spec.js
@@ -1,4 +1,4 @@
-import categoriesMap, { getCategories } from './categoriesMap'
+import categoriesMap, { getCategories, isParentOf } from './categoriesMap'
 
 describe('categories map', function() {
   it('should map ids to categories', function() {
@@ -30,5 +30,14 @@ describe('categories map', function() {
         }
       })
     })
+  })
+
+  it('should be possible to know if a category is parent of another', () => {
+    expect(isParentOf('400100', '400110')).toBe(true)
+    expect(isParentOf('400100', '400111')).toBe(true)
+    expect(isParentOf('400500', '400510')).toBe(true)
+    expect(isParentOf('400100', '400510')).toBe(false)
+    expect(isParentOf('400100', '400710')).toBe(false)
+    expect(isParentOf('400100', '400100')).toBe(true)
   })
 })

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
@@ -89,7 +89,11 @@ const CategoryAlertCard = ({ removeAlert, updateAlert, alert, t }) => {
             {saving ? <Spinner size="small" /> : null}
             <br />
             {t('Settings.budget-category-alerts.for-category', {
-              categoryName: t(`Data.subcategories.${categoryName}`)
+              categoryName: t(
+                `Data.${
+                  alert.categoryIsParent ? 'categories' : 'subcategories'
+                }.${categoryName}`
+              )
             })}
             <br />
             {alert.accountOrGroup ? (

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertEditModal.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertEditModal.jsx
@@ -77,7 +77,11 @@ const CategoryAlertInfoSlide = ({
         <div>
           <ModalRow
             icon={<CategoryIcon categoryId={alert.categoryId} />}
-            label={t(`Data.subcategories.${categoryName}`)}
+            label={t(
+              `Data.${
+                alert.categoryIsParent ? 'categories' : 'subcategories'
+              }.${categoryName}`
+            )}
             onClick={handleRequestChooseCategory}
             hasArrow={true}
           />
@@ -116,6 +120,7 @@ const CategoryAlertEditModal = translate()(
     const handleSelectCategory = category => {
       const updatedAlert = {
         ...alert,
+        categoryIsParent: !!category.children,
         categoryId: category.id
       }
       setAlert(updatedAlert)
@@ -196,6 +201,7 @@ const CategoryAlertEditModal = translate()(
             {choosingCategory ? (
               <CategoryChoice
                 modal={false}
+                canSelectParent={true}
                 categoryId={alert.categoryId}
                 onSelect={handleSelectCategory}
                 onCancel={handleSelectCategoryCancel}

--- a/src/ducks/settings/Configuration.jsx
+++ b/src/ducks/settings/Configuration.jsx
@@ -103,13 +103,6 @@ export class Configuration extends React.Component {
             name="balanceLower"
             unit="€"
           />
-          <DelayedDebitAlert
-            accounts={accounts}
-            onToggle={this.onToggle('notifications.delayedDebit')}
-            onChangeValue={this.onChangeValue('notifications.delayedDebit')}
-            onAccountsChange={this.onDelayedDebitAccountsChange}
-            {...settings.notifications.delayedDebit}
-          />
           <ToggleRow
             title={t('Notifications.if_transaction_greater.settingTitle')}
             description={t('Notifications.if_transaction_greater.description')}
@@ -123,6 +116,13 @@ export class Configuration extends React.Component {
             unit="€"
           />
           <CategoryAlertSettingsPane />
+          <DelayedDebitAlert
+            accounts={accounts}
+            onToggle={this.onToggle('notifications.delayedDebit')}
+            onChangeValue={this.onChangeValue('notifications.delayedDebit')}
+            onAccountsChange={this.onDelayedDebitAccountsChange}
+            {...settings.notifications.delayedDebit}
+          />
           <ToggleRowWrapper>
             <ToggleRowTitle>
               {t('Notifications.health_section.title')}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,7 +4,8 @@
     "deleting": "Deleting...",
     "cancel": "Cancel",
     "confirm": "Confirm",
-    "back": "Back"
+    "back": "Back",
+    "choose": "Choose"
   },
   "Loading": {
     "loading": "Loading...",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,7 +4,8 @@
     "deleting": "Suppression...",
     "cancel": "Annuler",
     "confirm": "Confirmer",
-    "back": "Revenir"
+    "back": "Revenir",
+    "choose": "Choisir"
   },
 
   "Loading": {

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -170,7 +170,7 @@
   "io.cozy.bank.operations": [
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'realEstateLoan' }}",
+      "manualCategoryId": "401010",
       "account": "compteisa1",
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
@@ -180,7 +180,7 @@
     {
       "_id": "edf",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'power' }}",
+      "manualCategoryId": "401080",
       "account": "compteisa1",
       "label": "EDF PARTICULIERS",
       "currency": "€",
@@ -189,7 +189,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "account": "compteisa1",
       "label": "FREEMOBILE",
       "currency": "€",
@@ -201,7 +201,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "account": "compteisa1",
       "label": "FREEMOBILE",
       "currency": "€",
@@ -214,7 +214,7 @@
     {
       "_id": "maifassurance",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'homeInsurance' }}",
+      "manualCategoryId": "401040",
       "account": "compteisa1",
       "label": "MAIF ASSURANCE HABITATION",
       "currency": "€",
@@ -227,7 +227,7 @@
     {
       "_id": "salaireisa1",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "200110",
       "account": "compteisa1",
       "label": "SALAIRE",
       "currency": "€",
@@ -242,7 +242,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'schoolRestaurant' }}",
+      "manualCategoryId": "400420",
       "account": "compteisa1",
       "label": "CANTINE SCOLAIRE",
       "currency": "€",
@@ -251,7 +251,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -260,7 +260,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -269,7 +269,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -278,7 +278,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -287,7 +287,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "account": "compteisa1",
       "label": "H&M",
       "currency": "€",
@@ -296,7 +296,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "400290",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -305,7 +305,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "400290",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -314,7 +314,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'dressing' }}",
+      "manualCategoryId": "400130",
       "account": "compteisa1",
       "label": "FRANCK PROVOST MONCEAU",
       "currency": "€",
@@ -324,7 +324,7 @@
     {
       "_id": "fnac",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "account": "compteisa1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -339,7 +339,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "400810",
       "account": "compteisa1",
       "label": "LA BELLE ASSIETTE",
       "currency": "€",
@@ -348,7 +348,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "KAISER BOULANGERIE",
       "currency": "€",
@@ -357,7 +357,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "KAISER BOULANGERIE",
       "currency": "€",
@@ -366,7 +366,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'kidsAllowance' }}",
+      "manualCategoryId": "400410",
       "account": "compteisa1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -375,7 +375,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "200140",
       "account": "compteisa1",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -384,7 +384,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "200140",
       "account": "compteisa3",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -393,7 +393,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "400180",
       "account": "comptelou1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -402,7 +402,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
+      "manualCategoryId": "400740",
       "account": "comptelou1",
       "label": "GAUMONTPARNASSE",
       "currency": "€",
@@ -411,7 +411,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "400810",
       "account": "comptelou1",
       "label": "MC DONALDS",
       "currency": "€",
@@ -420,7 +420,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -429,7 +429,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -513,7 +513,7 @@
     {
       "_id": "facturebouygues",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "account": "comptegene1",
       "label": "BOUYGUES TELECOM",
       "currency": "€",
@@ -525,7 +525,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'pensionPaid' }}",
+      "manualCategoryId": "400460",
       "account": "comptegene1",
       "label": "RETRAITE",
       "currency": "€",
@@ -534,7 +534,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "400180",
       "account": "comptegene1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -543,7 +543,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "comptegene1",
       "label": "AUCHAN",
       "currency": "€",
@@ -552,7 +552,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "comptegene1",
       "label": "CARREFOUR CITY",
       "currency": "€",
@@ -561,7 +561,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -570,7 +570,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'personalCare' }}",
+      "manualCategoryId": "400190",
       "account": "comptegene1",
       "label": "FRANCE MENAGE",
       "currency": "€",
@@ -579,7 +579,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptegene1",
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
@@ -588,7 +588,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -597,7 +597,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "account": "comptegene1",
       "label": "LA REDOUTE",
       "currency": "€",
@@ -616,7 +616,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'realEstateLoan' }}",
+      "manualCategoryId": "401010",
       "account": "compteisa1",
       "label": "REMBOURSEMENT PRET LCL",
       "currency": "€",
@@ -625,7 +625,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "200110",
       "account": "compteisa1",
       "label": "SALAIRE",
       "currency": "€",
@@ -634,7 +634,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -643,7 +643,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "compteisa1",
       "label": "CARREFOUR MARKET",
       "currency": "€",
@@ -652,7 +652,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -661,7 +661,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -670,7 +670,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "account": "compteisa1",
       "label": "ZARA",
       "currency": "€",
@@ -679,7 +679,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "400290",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -688,7 +688,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'taxi' }}",
+      "manualCategoryId": "400290",
       "account": "compteisa1",
       "label": "UBER",
       "currency": "€",
@@ -697,7 +697,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "400810",
       "account": "compteisa1",
       "label": "LE RICHER",
       "currency": "€",
@@ -706,7 +706,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "kAISER BOULANGERIE",
       "currency": "€",
@@ -715,7 +715,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "compteisa1",
       "label": "kAISER BOULANGERIE",
       "currency": "€",
@@ -724,7 +724,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'kidsAllowance' }}",
+      "manualCategoryId": "400410",
       "account": "compteisa1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -733,7 +733,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "200140",
       "account": "compteisa1",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -742,7 +742,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'dividends' }}",
+      "manualCategoryId": "200140",
       "account": "compteisa3",
       "label": "TRANSFERT LIVRET A",
       "currency": "€",
@@ -751,7 +751,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "400180",
       "account": "comptelou1",
       "label": "ARGENT DE POCHE",
       "currency": "€",
@@ -760,7 +760,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'electronicsAndMultimedia' }}",
+      "manualCategoryId": "400740",
       "account": "comptelou1",
       "label": "UGCCINECITE",
       "currency": "€",
@@ -769,7 +769,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'restaurantsAndBars' }}",
+      "manualCategoryId": "400810",
       "account": "comptelou1",
       "label": "KFC",
       "currency": "€",
@@ -778,7 +778,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -787,7 +787,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptelou1",
       "label": "RETRAIT BNPPARIBAS",
       "currency": "€",
@@ -965,7 +965,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "account": "comptegene1",
       "label": "BOUYGUES TELECOM",
       "currency": "€",
@@ -977,7 +977,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'pensionPaid' }}",
+      "manualCategoryId": "400460",
       "account": "comptegene1",
       "label": "RETRAITE",
       "currency": "€",
@@ -986,7 +986,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'giftsOffered' }}",
+      "manualCategoryId": "400180",
       "account": "comptegene1",
       "label": "FNAC TERNES",
       "currency": "€",
@@ -995,7 +995,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "comptegene1",
       "label": "AUCHAN",
       "currency": "€",
@@ -1004,7 +1004,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'supermarket' }}",
+      "manualCategoryId": "400110",
       "account": "comptegene1",
       "label": "CARREFOUR CITY",
       "currency": "€",
@@ -1013,7 +1013,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -1022,7 +1022,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'personalCare' }}",
+      "manualCategoryId": "400190",
       "account": "comptegene1",
       "label": "FRANCE MENAGE",
       "currency": "€",
@@ -1031,7 +1031,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'uncategorized' }}",
+      "manualCategoryId": "0",
       "account": "comptegene1",
       "label": "RETRAIT CREDIT AGRICOLE",
       "currency": "€",
@@ -1040,7 +1040,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'snaksAndworkMeals' }}",
+      "manualCategoryId": "400160",
       "account": "comptegene1",
       "label": "FRANPRIX",
       "currency": "€",
@@ -1050,7 +1050,7 @@
     {
       "_id": "normalshopping",
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "account": "comptegene1",
       "label": "SOMEWHERE",
       "currency": "€",
@@ -1113,7 +1113,7 @@
     },
     {
       "demo": true,
-      "manualCategoryId": "{{ categoryId 'incomeCat' }}",
+      "manualCategoryId": "200100",
       "account": "comptegene1",
       "label": "Autre revenu",
       "currency": "€",
@@ -1121,7 +1121,7 @@
       "date": "2018-01-19T00:00:00Z"
     },
     {
-      "manualCategoryId": "{{ categoryId 'activityIncome' }}",
+      "manualCategoryId": "200110",
       "account": "compteisa1",
       "label": "Salaire juin 2018",
       "currency": "€",
@@ -1235,7 +1235,7 @@
     {
       "account": "compteisa1",
       "amount": -117,
-      "manualCategoryId": "{{ categoryId 'goingOutAndTravel' }}",
+      "manualCategoryId": "400800",
       "currency": "€",
       "date": "2018-06-08T00:00:00Z",
       "label": "Sncf"
@@ -1243,7 +1243,7 @@
     {
       "account": "compteisa1",
       "amount": -30,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "currency": "€",
       "date": "2018-06-11T00:00:00Z",
       "label": "Free Mobile"
@@ -1299,7 +1299,7 @@
     {
       "account": "compteisa1",
       "amount": -73.50,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "currency": "€",
       "date": "2018-06-13T00:00:00Z",
       "label": "Leclerc Drive"
@@ -1323,7 +1323,7 @@
     {
       "account": "compteisa1",
       "amount": -27.90,
-      "manualCategoryId": "{{ categoryId 'shoppingECommerce' }}",
+      "manualCategoryId": "400112",
       "currency": "€",
       "date": "2018-06-15T00:00:00Z",
       "label": "Just Eat"
@@ -1331,7 +1331,7 @@
     {
       "account": "compteisa1",
       "amount": -9.90,
-      "manualCategoryId": "{{ categoryId 'telecom' }}",
+      "manualCategoryId": "400150",
       "currency": "€",
       "date": "2018-06-15T00:00:00Z",
       "label": "Sosh"
@@ -1363,7 +1363,7 @@
     {
       "account": "compteisa1",
       "amount": -11.90,
-      "manualCategoryId": "{{ categoryId 'booksMoviesMusic' }}",
+      "manualCategoryId": "400750",
       "currency": "€",
       "date": "2018-06-20T00:00:00Z",
       "label": "Netflix"


### PR DESCRIPTION
A flaw in the data model (ids for parent categories are the same as the
the one used for "others" subcategories) is now handled through the use
of an attribute on the alert. If the `categoryIsParent` boolean attribute
is true, all categories pertaining to this category will be included in
when checking for expenses. If it is false, it means that the user has
configured the alert with the "others" category of this parent category.

```
{
  categoryId: '400600'
}
// Others: health

{
  categoryId: '400600',
  categoryIsParent: true
}
// Health parent category
```