### PR TITLE
feat: Enable loan details page flag by default

### DIFF
--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -52,4 +52,7 @@ flag('reimbursements.tag', true)
 // Turn on error banner on transactions page
 flag('transactions.error-banner', true)
 
+// Turn on loan details page
+flag('loan-details-page', true)
+
 window.flag = flag


### PR DESCRIPTION
We want to enable the new loan details page for everyone.