### PR TITLE
UI tweaks for category alerts

### DIFF
--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -45,13 +45,7 @@ const GroupPanelSummary = withStyles(() => ({
 
 const GroupPanelExpandIcon = React.memo(function GroupPanelExpandIcon() {
   return (
-    <span className="u-click-xl">
-      <Icon
-        icon="bottom"
-        className={styles.GroupPanelSummary__icon}
-        width={12}
-      />
-    </span>
+    <Icon icon="bottom" className={styles.GroupPanelSummary__icon} width={12} />
   )
 })
 

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
@@ -116,11 +116,12 @@ const CategoryAlertCard = ({ removeAlert, updateAlert, alert, t }) => {
             ) : null}
           </div>
           <div className="u-media-fixed u-ml-1">
-            <Icon
-              color="var(--coolGrey)"
-              icon="cross"
+            <span
               onClick={handleRequestRemoval}
-            />
+              className="u-expanded-click-area"
+            >
+              <Icon color="var(--coolGrey)" icon="cross" />
+            </span>
           </div>
         </div>
       </Card>

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.styl
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.styl
@@ -4,6 +4,7 @@
     cursor pointer
     box-sizing border-box
     width 400px
+    overflow hidden
 
     +small-screen()
         width 100%

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -533,8 +533,8 @@
         "category-label": "Catégorie",
         "threshold-label": "Budget mensuel",
         "account-group-label": "Compte ou groupe",
-        "create-ok": "Créer l'alerte",
-        "update-ok": "Mettre à jour l'alerte",
+        "create-ok": "Créer",
+        "update-ok": "Mettre à jour",
         "cancel": "Annuler"
       },
       "remove": {

--- a/src/styles/utilities.styl
+++ b/src/styles/utilities.styl
@@ -27,11 +27,16 @@
     .u-w-100
         width 100%
 
-    .u-click-xl::after
-      width 130%
-      height 130%
-      top -15%
-      left -15%
+    // TODO Move utility to cozy-ui
+    .u-expanded-click-area
+      position relative
+      display inline-block
+
+    .u-expanded-click-area::after
+      width 300%
+      height 300%
+      top -100%
+      left -100%
       content '\00a0'
       display block
       position absolute


### PR DESCRIPTION
- Change text of buttons for buttons of modal not to be on two lines on mobile
- Increase click area of remove alert button (area shown below)

<img width="428" alt="image" src="https://user-images.githubusercontent.com/465582/69338470-93409400-0c63-11ea-8ed9-1ba3b85d810a.png">
