### PR TITLE
Pin improvements

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -56,7 +56,12 @@ export default compose(
   // When removing the pin flag, do not forget to replace the exports (uncomment)
   // in ducks/pin/index.browser.jsx so that pin functionality is not included
   // in browsers
-  flag('pin') ? pinGuarded({}) : x => x,
+  flag('pin')
+    ? pinGuarded({
+        timeout: flag('pin.debug') ? 10 * 1000 : null,
+        showTimeout: flag('pin.debug')
+      })
+    : x => x,
   queryConnect({ settingsCollection: settingsConn }),
   withRouter
 )(App)

--- a/src/ducks/pin/LockedBody.jsx
+++ b/src/ducks/pin/LockedBody.jsx
@@ -8,6 +8,10 @@ const saveScroll = node => {
   }
 }
 
+/**
+ * While this component is mounted, it blocks the scroll on document.body
+ * When unmounted, it restores the scroll
+ */
 class LockedBody extends React.Component {
   componentDidMount() {
     this.restoreScroll = saveScroll(document.body)

--- a/src/ducks/pin/PinAuth.jsx
+++ b/src/ducks/pin/PinAuth.jsx
@@ -68,11 +68,6 @@ const FingerprintParagraph = ({ t, onSuccess, onError, onCancel }) => (
  * - It automatically confirms when entered password's length is <props.maxLength>
  */
 class PinAuth extends React.Component {
-  static contextTypes = {
-    store: PropTypes.object.isRequired,
-    client: PropTypes.object.isRequired
-  }
-
   constructor(props) {
     super(props)
     this.handleFingerprintSuccess = this.handleFingerprintSuccess.bind(this)

--- a/src/ducks/pin/PinAuth.jsx
+++ b/src/ducks/pin/PinAuth.jsx
@@ -25,7 +25,7 @@ import fingerprint from 'assets/icons/icon-fingerprint.svg'
 const AttemptCount_ = ({ t, current, max }) => {
   return (
     <div className={styles['Pin__error']}>
-      {/* Have an unbreakspace so that the error when appearing does not // make
+      {/* Have an unbreakable space so that the error, when it appears, does not make
       the previous content jump */}
       {current > 0 ? t('Pin.attempt-count', { current, max }) : '\u00a0'}
     </div>

--- a/src/ducks/pin/PinAuth.jsx
+++ b/src/ducks/pin/PinAuth.jsx
@@ -112,9 +112,10 @@ class PinAuth extends React.Component {
     this.logout()
   }
 
-  logout() {
+  async logout() {
     const { client } = this.props
-    client.logout()
+    await client.logout()
+    window.location.reload()
   }
 
   handleEnteredPin(pinValue) {

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -9,7 +9,7 @@ import { lastInteractionStorage, pinSettingStorage } from './storage'
 
 /**
  * Wraps an App and display a Pin screen after a period
- * of inactivity (touch events on document).
+ * of inactivity (touch/click/resume events on document).
  */
 class PinGuard extends React.Component {
   constructor(props) {
@@ -35,6 +35,7 @@ class PinGuard extends React.Component {
     document.addEventListener('touchstart', this.handleInteraction)
     document.addEventListener('click', this.handleInteraction)
     document.addEventListener('resume', this.handleResume)
+    document.addEventListener('visibilitychange', this.handleResume)
     this.resetTimeout()
   }
 
@@ -42,6 +43,7 @@ class PinGuard extends React.Component {
     document.removeEventListener('touchstart', this.handleInteraction)
     document.removeEventListener('click', this.handleInteraction)
     document.removeEventListener('resume', this.handleResume)
+    document.removeEventListener('visibilitychange', this.handleResume)
     clearTimeout(this.timeout)
   }
 
@@ -68,6 +70,11 @@ class PinGuard extends React.Component {
     // check to be sure that after resume, we display the pin if it
     // is needed
     this.checkToShowPin()
+    this.reloadSetting()
+  }
+
+  reloadSetting() {
+    this.props.pinSetting.fetch()
   }
 
   showPin() {

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -4,6 +4,8 @@ import PinTimeout from 'ducks/pin/PinTimeout.debug'
 import PinAuth from 'ducks/pin/PinAuth'
 import { pinSetting } from 'ducks/pin/queries'
 import { queryConnect } from 'cozy-client'
+import { isCollectionLoading } from 'ducks/client/utils'
+import { lastInteractionStorage } from './storage'
 
 /**
  * Wraps an App and display a Pin screen after a period
@@ -12,10 +14,19 @@ import { queryConnect } from 'cozy-client'
 class PinGuard extends React.Component {
   constructor(props) {
     super(props)
-    this.state = { last: Date.now() }
+    this.initState()
     this.handleInteraction = this.handleInteraction.bind(this)
     this.handlePinSuccess = this.handlePinSuccess.bind(this)
     this.handleResume = this.handleResume.bind(this)
+  }
+
+  initState() {
+    const savedLast = lastInteractionStorage.load()
+    const last = savedLast || Date.now()
+    this.state = {
+      last, // timestamp of last interaction
+      showPin: this.isTooLate(last)
+    }
   }
 
   componentDidMount() {
@@ -67,6 +78,7 @@ class PinGuard extends React.Component {
   handleInteraction() {
     const now = Date.now()
     this.setState({ last: now })
+    lastInteractionStorage.save(now)
     this.resetTimeout()
   }
 

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -14,17 +14,18 @@ import { lastInteractionStorage, pinSettingStorage } from './storage'
 class PinGuard extends React.Component {
   constructor(props) {
     super(props)
-    this.initState()
+    this.state = this.getInitialState()
     this.handleInteraction = this.handleInteraction.bind(this)
     this.handlePinSuccess = this.handlePinSuccess.bind(this)
     this.handleResume = this.handleResume.bind(this)
   }
 
-  initState() {
+  getInitialState() {
     const savedLast = lastInteractionStorage.load()
     const last = savedLast || Date.now()
     const cachedPinSetting = pinSettingStorage.load()
-    this.state = {
+
+    return {
       last, // timestamp of last interaction
       showPin: this.isTooLate(last),
       cachedPinSetting

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -22,7 +22,7 @@ class PinGuard extends React.Component {
     document.addEventListener('touchstart', this.handleInteraction)
     document.addEventListener('click', this.handleInteraction)
     document.addEventListener('resume', this.handleResume)
-    this.handleInteraction()
+    this.resetTimeout()
   }
 
   componentWillUnmount() {
@@ -38,30 +38,50 @@ class PinGuard extends React.Component {
     }
   }
 
+  isTooLate(lastInteractionTimestamp) {
+    return Date.now() - this.props.timeout > lastInteractionTimestamp
+  }
+
+  checkToShowPin() {
+    const now = Date.now()
+    if (this.isTooLate(now)) {
+      this.showPin()
+    }
+  }
+
   handleResume() {
     // setTimeout might not work properly when the application is paused, do this
     // check to be sure that after resume, we display the pin if it
     // is needed
-    if (Date.now() - this.props.timeout > this.state.last) {
-      this.setState({ showPin: true })
-    }
+    this.checkToShowPin()
+  }
+
+  showPin() {
+    this.setState({ showPin: true })
+  }
+
+  hidePin() {
+    this.setState({ showPin: false })
   }
 
   handleInteraction() {
+    const now = Date.now()
+    this.setState({ last: now })
     this.resetTimeout()
   }
 
   resetTimeout() {
-    this.setState({ last: Date.now() })
     clearTimeout(this.timeout)
     this.timeout = setTimeout(() => {
-      this.setState({ showPin: true })
+      this.showPin()
     }, this.props.timeout)
   }
 
   handlePinSuccess() {
+    // Delay a bit the success so that the user sees the success
+    // effect
     setTimeout(() => {
-      this.setState({ showPin: false })
+      this.hidePin()
     }, 500)
   }
 

--- a/src/ducks/pin/PinGuard.spec.jsx
+++ b/src/ducks/pin/PinGuard.spec.jsx
@@ -1,0 +1,123 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import CozyClient from 'cozy-client'
+import { DumbPinGuard as PinGuard } from './PinGuard'
+import AppLike from 'test/AppLike'
+import PinAuth from './PinAuth'
+import { pinSettingStorage, lastInteractionStorage } from './storage'
+
+jest.mock('./storage', () => ({
+  pinSettingStorage: {
+    load: jest.fn(),
+    save: jest.fn()
+  },
+  lastInteractionStorage: {
+    load: jest.fn(),
+    save: jest.fn()
+  }
+}))
+
+jest.mock('./PinAuth', () => () => null)
+
+const PIN_CODE = '111111'
+
+const PIN_DOC = {
+  data: {
+    pin: PIN_CODE
+  }
+}
+
+const pinAuthIsShown = root => root.find(PinAuth).length === 1
+
+describe('PinGuard', () => {
+  const App = () => <div>App</div>
+
+  const setup = ({ pinSetting }) => {
+    const client = new CozyClient({})
+    client.query = jest.fn()
+    const root = mount(
+      <AppLike client={client}>
+        <PinGuard timeout={10 * 1000} pinSetting={pinSetting}>
+          <App />
+        </PinGuard>
+      </AppLike>
+    )
+    return { root }
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('should protect its children if there is a pinSetting doc', () => {
+    jest.useFakeTimers()
+    const { root } = setup({
+      pinSetting: PIN_DOC
+    })
+    expect(pinAuthIsShown(root)).toBe(false)
+    jest.runAllTimers()
+    root.update()
+    expect(pinAuthIsShown(root)).toBe(true)
+  })
+
+  it('should do nothing if there isnt a pinSetting doc', () => {
+    jest.useFakeTimers()
+    const { root } = setup({ pinSetting: { data: null } })
+    expect(pinAuthIsShown(root)).toBe(false)
+    jest.runAllTimers()
+    root.update()
+    expect(pinAuthIsShown(root)).toBe(false)
+  })
+
+  it('should not show PinAuth if pin entered successfully', () => {
+    const { root } = setup({ pinSetting: PIN_DOC })
+    jest.runAllTimers()
+    root.update()
+    expect(pinAuthIsShown(root)).toBe(true)
+    root
+      .find(PinAuth)
+      .props()
+      .onSuccess()
+    jest.runAllTimers()
+    root.update()
+    expect(pinAuthIsShown(root)).toBe(false)
+  })
+
+  it('should remember last interaction', () => {
+    const { root } = setup({ pinSetting: PIN_DOC })
+    jest.spyOn(Date, 'now').mockReturnValue(1337)
+    const instance = root.find(PinGuard).instance()
+    jest.spyOn(instance, 'setState')
+    expect(pinAuthIsShown(root)).toBe(false)
+    instance.handleInteraction()
+    expect(instance.setState).toHaveBeenCalledWith({
+      last: 1337
+    })
+    expect(lastInteractionStorage.save).toHaveBeenCalledWith(1337)
+  })
+
+  it('should get last interaction from localstorage', () => {
+    lastInteractionStorage.load.mockReturnValue(1337)
+    const { root } = setup({ pinSetting: PIN_DOC })
+    expect(pinAuthIsShown(root)).toBe(true)
+  })
+
+  describe('cached pin doc', () => {
+    it('should not show PinAuth if pinDoc still fetching and no cached is present', () => {
+      pinSettingStorage.load.mockReturnValue(null)
+      const { root } = setup({
+        pinSetting: { ...PIN_DOC, fetchStatus: 'loading' }
+      })
+      expect(pinAuthIsShown(root)).toBe(false)
+    })
+
+    it('should use cached pin doc if pin doc is fetching', () => {
+      lastInteractionStorage.load.mockReturnValue(1337)
+      pinSettingStorage.load.mockReturnValue(PIN_DOC.data)
+      const { root } = setup({
+        pinSetting: { ...PIN_DOC, fetchStatus: 'loading' }
+      })
+      expect(pinAuthIsShown(root)).toBe(true)
+    })
+  })
+})

--- a/src/ducks/pin/plugin.js
+++ b/src/ducks/pin/plugin.js
@@ -1,0 +1,18 @@
+import { clear } from './storage'
+
+/**
+ * Used to remove local storage on logout
+ */
+class PinPlugin {
+  constructor(client) {
+    this.client = client
+
+    client.on('beforeLogout', () => {
+      clear()
+    })
+  }
+}
+
+PinPlugin.pluginName = 'pin'
+
+export default PinPlugin

--- a/src/ducks/pin/plugin.spec.js
+++ b/src/ducks/pin/plugin.spec.js
@@ -1,0 +1,15 @@
+import CozyClient from 'cozy-client'
+import { clear } from './storage'
+import PinPlugin from './plugin'
+
+jest.mock('./storage', () => ({ clear: jest.fn() }))
+
+describe('pin plugin', () => {
+  it('should remove storage on logout', () => {
+    const client = new CozyClient({})
+    client.registerPlugin(PinPlugin)
+    expect(clear).not.toHaveBeenCalled()
+    client.emit('beforeLogout')
+    expect(clear).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/ducks/pin/storage.js
+++ b/src/ducks/pin/storage.js
@@ -20,6 +20,10 @@ const storage = (key, toString, fromString) => ({
       return
     }
     localStorage.setItem(key, toString(val))
+  },
+
+  remove: () => {
+    localStorage.removeItem(key)
   }
 })
 
@@ -37,3 +41,8 @@ export const pinSettingStorage = storage(
   JSON.stringify,
   JSON.parse
 )
+
+export const clear = () => {
+  pinSettingStorage.remove()
+  lastInteractionStorage.remove()
+}

--- a/src/ducks/pin/storage.js
+++ b/src/ducks/pin/storage.js
@@ -1,4 +1,5 @@
 const LAST_INTERACTION_KEY = 'cozy.pin-last-interaction'
+const PIN_SETTING_KEY = 'cozy.pin-doc'
 
 const storage = (key, toString, fromString) => ({
   load: () => {
@@ -29,4 +30,10 @@ export const lastInteractionStorage = storage(
     return isNaN(n) ? null : n
   },
   n => n.toString()
+)
+
+export const pinSettingStorage = storage(
+  PIN_SETTING_KEY,
+  JSON.stringify,
+  JSON.parse
 )

--- a/src/ducks/pin/storage.js
+++ b/src/ducks/pin/storage.js
@@ -1,0 +1,32 @@
+const LAST_INTERACTION_KEY = 'cozy.pin-last-interaction'
+
+const storage = (key, toString, fromString) => ({
+  load: () => {
+    const saved = localStorage.getItem(key)
+    if (!saved) {
+      return saved
+    } else {
+      try {
+        return fromString(saved)
+      } catch (e) {
+        return null
+      }
+    }
+  },
+
+  save: val => {
+    if (val === undefined) {
+      return
+    }
+    localStorage.setItem(key, toString(val))
+  }
+})
+
+export const lastInteractionStorage = storage(
+  LAST_INTERACTION_KEY,
+  x => {
+    const n = parseInt(x)
+    return isNaN(n) ? null : n
+  },
+  n => n.toString()
+)

--- a/src/ducks/settings/Debug.jsx
+++ b/src/ducks/settings/Debug.jsx
@@ -11,6 +11,7 @@ import { withClient } from 'cozy-client'
 import { isMobileApp } from 'cozy-device-helper'
 import cx from 'classnames'
 import { getNotificationToken } from 'ducks/client/utils'
+import { pinSettingStorage, lastInteractionStorage } from 'ducks/pin/storage'
 
 const Title = ({ className, ...props }) => (
   <UITitle {...props} className={cx(className, 'u-mb-1')} />
@@ -179,6 +180,15 @@ class DumbDebugSettings extends React.PureComponent {
         <div>
           <Title>Flags</Title>
           <FlagSwitcher.List />
+        </div>
+        <div>
+          <Title>Pin</Title>
+          Setting doc cache
+          <br />
+          <pre>{JSON.stringify(pinSettingStorage.load(), null, 2)}</pre>
+          Last interaction cache
+          <br />
+          <pre>{JSON.stringify(lastInteractionStorage.load(), null, 2)}</pre>
         </div>
         <Versions />
       </Stack>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -26,6 +26,7 @@ import { checkToRefreshToken } from 'utils/token'
 import Alerter from 'cozy-ui/react/Alerter'
 import flag from 'cozy-flags'
 import { makeItShine } from 'utils/display.debug'
+import PinPlugin from 'ducks/pin/plugin'
 
 const D3_LOCALES_MAP = {
   fr: require('d3-time-format/locale/fr-FR.json'),
@@ -66,6 +67,7 @@ const setupApp = async persistedState => {
   client = await getClient(persistedState)
   store = configureStore(client, persistedState)
   client.registerPlugin(CleanupStoreClientPlugin, { store })
+  client.registerPlugin(PinPlugin)
   client.registerPlugin(StartupChecksPlugin, {
     launchTriggers: [
       {


### PR DESCRIPTION
- Do not wait for pin doc to be fetched before showing pin (if already fetched once, use localStorage to store pinDoc)
- While app is mounting, do not flicker the screen without auth if last interaction
was too long ago (use localStorage to store last interaction)

- Clear values stored locally on client's logout