### PR TITLE
refactor: Same condition for rendering and matching for reimbursements

### DIFF
--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
@@ -4,7 +4,8 @@ import Chip from 'cozy-ui/react/Chip'
 import Alerter from 'cozy-ui/react/Alerter'
 import {
   getReimbursementStatus,
-  isReimbursementLate
+  isReimbursementLate,
+  REIMBURSEMENTS_STATUS
 } from 'ducks/transactions/helpers'
 import { TransactionModalRow } from 'ducks/transactions/TransactionModal'
 import ReimbursementStatusModal from 'ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal'
@@ -61,7 +62,7 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
     const status = getReimbursementStatus(transaction)
     const isLate = isReimbursementLate(transaction)
 
-    if (status === 'no-reimbursement') {
+    if (status === REIMBURSEMENTS_STATUS.noReimbursement) {
       return null
     }
 

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.spec.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.spec.jsx
@@ -1,7 +1,11 @@
 import { DumbReimbursementStatusAction } from './ReimbursementStatusAction'
 import React from 'react'
 import { shallow } from 'enzyme'
-import { getReimbursementStatus, isReimbursementLate } from '../../helpers'
+import {
+  REIMBURSEMENTS_STATUS,
+  getReimbursementStatus,
+  isReimbursementLate
+} from '../../helpers'
 
 jest.mock('../../helpers')
 
@@ -27,25 +31,31 @@ describe('DumbReimbursementStatusAction', () => {
 
   describe('transaction row context', () => {
     it('should render correctly for a pending reimbursement', () => {
-      const { wrapper } = setup({ reimbursementStatus: 'pending' })
+      const { wrapper } = setup({
+        reimbursementStatus: REIMBURSEMENTS_STATUS.pending
+      })
       expect(wrapper.html()).toMatchSnapshot()
     })
 
     it('should render correctly for a reimbursed transaction', () => {
-      const { wrapper } = setup({ reimbursementStatus: 'reimbursed' })
+      const { wrapper } = setup({
+        reimbursementStatus: REIMBURSEMENTS_STATUS.reimbursed
+      })
       expect(wrapper.html()).toMatchSnapshot()
     })
 
     it('should render correctly for a late reimbursement', () => {
       const { wrapper } = setup({
-        reimbursementStatus: 'pending',
+        reimbursementStatus: REIMBURSEMENTS_STATUS.pending,
         isLate: true
       })
       expect(wrapper.html()).toMatchSnapshot()
     })
 
     it('should render correctly for a transaction that will not be reimbursed', () => {
-      const { wrapper } = setup({ reimbursementStatus: 'no-reimbursement' })
+      const { wrapper } = setup({
+        reimbursementStatus: REIMBURSEMENTS_STATUS.noReimbursement
+      })
       expect(wrapper.html()).toMatchSnapshot()
     })
   })
@@ -53,7 +63,7 @@ describe('DumbReimbursementStatusAction', () => {
   describe('modal item context', () => {
     it('should render correctly for a pending reimbursement', () => {
       const { wrapper } = setup({
-        reimbursementStatus: 'pending',
+        reimbursementStatus: REIMBURSEMENTS_STATUS.pending,
         isModalItem: true
       })
 
@@ -62,7 +72,7 @@ describe('DumbReimbursementStatusAction', () => {
 
     it('should render correctly for a reimbursed transaction', () => {
       const { wrapper } = setup({
-        reimbursementStatus: 'reimbursed',
+        reimbursementStatus: REIMBURSEMENTS_STATUS.reimbursed,
         isModalItem: true
       })
       expect(wrapper.html()).toMatchSnapshot()
@@ -70,7 +80,7 @@ describe('DumbReimbursementStatusAction', () => {
 
     it('should render correctly for a late reimbursement', () => {
       const { wrapper } = setup({
-        reimbursementStatus: 'pending',
+        reimbursementStatus: REIMBURSEMENTS_STATUS.pending,
         isLate: true,
         isModalItem: true
       })
@@ -79,7 +89,7 @@ describe('DumbReimbursementStatusAction', () => {
 
     it('should render correctly for a transaction that will not be reimbursed', () => {
       const { wrapper } = setup({
-        reimbursementStatus: 'no-reimbursement',
+        reimbursementStatus: REIMBURSEMENTS_STATUS.noReimbursement,
         isModalItem: true
       })
       expect(wrapper.html()).toMatchSnapshot()

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/match.js
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/match.js
@@ -1,9 +1,15 @@
 import flag from 'cozy-flags'
-import { isExpense } from 'ducks/transactions/helpers'
+import {
+  getReimbursementStatus,
+  REIMBURSEMENTS_STATUS
+} from 'ducks/transactions/helpers'
 
 const match = transaction => {
-  // TODO match only if the component is going to render something
-  return isExpense(transaction) && flag('reimbursements.tag')
+  const status = getReimbursementStatus(transaction)
+  return (
+    status !== REIMBURSEMENTS_STATUS.noReimbursement &&
+    flag('reimbursements.tag')
+  )
 }
 
 export default match

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/match.spec.js
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/match.spec.js
@@ -1,0 +1,19 @@
+import match from './match'
+import { REIMBURSEMENTS_STATUS } from 'ducks/transactions/helpers'
+
+jest.mock('cozy-flags', () => () => true)
+
+describe('ReimbursementStatusAction match', () => {
+  it('should not match if the transaction has a no-reimbursement status', () => {
+    const transaction = {
+      amount: 60
+    }
+    expect(match(transaction)).toBe(false)
+    expect(
+      match({
+        ...transaction,
+        reimbursementStatus: REIMBURSEMENTS_STATUS.reimbursed
+      })
+    ).toBe(true)
+  })
+})

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -109,6 +109,13 @@ export const hasReimbursements = transaction => {
   return reimbursements.length > 0
 }
 
+export const REIMBURSEMENTS_STATUS = {
+  noReimbursement: 'no-reimbursement',
+  pending: 'pending',
+  reimbursed: 'reimbursed',
+  late: 'late'
+}
+
 export const getBills = transaction => {
   const allBills = get(transaction, 'bills.data', [])
 
@@ -168,7 +175,9 @@ export const getHealthExpenseReimbursementStatus = transaction => {
     return transaction.reimbursementStatus
   }
 
-  return isFullyReimbursed(transaction) ? 'reimbursed' : 'pending'
+  return isFullyReimbursed(transaction)
+    ? REIMBURSEMENTS_STATUS.reimbursed
+    : REIMBURSEMENTS_STATUS.pending
 }
 
 export const isReimbursementLate = transaction => {
@@ -178,7 +187,7 @@ export const isReimbursementLate = transaction => {
 
   const status = getReimbursementStatus(transaction)
 
-  if (status !== 'pending') {
+  if (status !== REIMBURSEMENTS_STATUS.pending) {
     return false
   }
 
@@ -192,7 +201,7 @@ export const isReimbursementLate = transaction => {
 }
 
 export const hasPendingReimbursement = transaction => {
-  return getReimbursementStatus(transaction) === 'pending'
+  return getReimbursementStatus(transaction) === REIMBURSEMENTS_STATUS.pending
 }
 
 export const isAlreadyNotified = (transaction, notificationClass) => {

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -11,7 +11,8 @@ import {
   hasBills,
   isAlreadyNotified,
   updateApplicationDate,
-  getApplicationDate
+  getApplicationDate,
+  REIMBURSEMENTS_STATUS
 } from './helpers'
 import { BILLS_DOCTYPE } from 'doctypes'
 import MockDate from 'mockdate'
@@ -167,8 +168,8 @@ describe('getReimbursementStatus', () => {
         }
       }
 
-      expect(getReimbursementStatus(t1)).toBe('pending')
-      expect(getReimbursementStatus(t2)).toBe('pending')
+      expect(getReimbursementStatus(t1)).toBe(REIMBURSEMENTS_STATUS.pending)
+      expect(getReimbursementStatus(t2)).toBe(REIMBURSEMENTS_STATUS.pending)
     })
 
     it('should return `reimbursed` if the status is undefined and the transaction is fully reimbursed', () => {
@@ -180,7 +181,9 @@ describe('getReimbursementStatus', () => {
         }
       }
 
-      expect(getReimbursementStatus(transaction)).toBe('reimbursed')
+      expect(getReimbursementStatus(transaction)).toBe(
+        REIMBURSEMENTS_STATUS.reimbursed
+      )
     })
   })
 })


### PR DESCRIPTION
By using the same condition, we ensure that when we match, we can render
something.

In c537e0367e49f00047617936b245ede5172014c6 you added a comment Drazik, I think I am doing what you meant but if you can confirm :)