### PR TITLE
Tests reactivate tests on reimbursements hydratation

### DIFF
--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -28,7 +28,7 @@ const fakeCozyClient = {
   }
 }
 
-describe('transaction', () => {
+describe('reimbursements', () => {
   const healthId = '400610'
   const BILL_ID = '1234'
   let store, transaction // , bill
@@ -43,28 +43,26 @@ describe('transaction', () => {
     // store.dispatch(createDocument(BILLS_DOCTYPE, bill))
   })
 
-  describe('reimbursements', () => {
-    it('should be hydrated if transaction in health category', () => {
-      const transactions = [transaction].map(t =>
-        hydrateTransaction(store.getState(), t)
-      )
-      expect(transactions[0].reimbursements[0].bill).toBeTruthy()
-      expect(transactions[0].reimbursements[0].bill._id).toBe(BILL_ID)
-    })
+  it('should be hydrated if transaction in health category', () => {
+    const transactions = [transaction].map(t =>
+      hydrateTransaction(store.getState(), t)
+    )
+    expect(transactions[0].reimbursements[0].bill).toBeTruthy()
+    expect(transactions[0].reimbursements[0].bill._id).toBe(BILL_ID)
+  })
 
-    it('should not be hydrated if transaction not in the health category', () => {
-      const transactions = [
-        { ...transaction, automaticCategoryId: '1000' }
-      ].map(t => hydrateTransaction(store.getState(), t))
-      expect(transactions[0].reimbursements[0].bill).toBe(undefined)
-    })
+  it('should not be hydrated if transaction not in the health category', () => {
+    const transactions = [{ ...transaction, automaticCategoryId: '1000' }].map(
+      t => hydrateTransaction(store.getState(), t)
+    )
+    expect(transactions[0].reimbursements[0].bill).toBe(undefined)
+  })
 
-    it('should not be hydrated if bill does not exist in store', () => {
-      const transactions = [
-        { ...transaction, reimbursements: [{ billId: undefined }] }
-      ].map(t => hydrateTransaction(store.getState(), t))
-      expect(transactions[0].reimbursements[0].bill).toBe(undefined)
-    })
+  it('should not be hydrated if bill does not exist in store', () => {
+    const transactions = [
+      { ...transaction, reimbursements: [{ billId: undefined }] }
+    ].map(t => hydrateTransaction(store.getState(), t))
+    expect(transactions[0].reimbursements[0].bill).toBe(undefined)
   })
 })
 

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -28,7 +28,7 @@ const fakeCozyClient = {
   }
 }
 
-xdescribe('transaction', () => {
+describe('transaction', () => {
   const healthId = '400610'
   const BILL_ID = '1234'
   let store, transaction // , bill

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -1,6 +1,4 @@
-import configureStore from 'store/configureStore'
 import {
-  hydrateTransaction,
   getDate,
   getReimbursedAmount,
   isFullyReimbursed,
@@ -14,55 +12,66 @@ import {
   getApplicationDate,
   REIMBURSEMENTS_STATUS
 } from './helpers'
-import { BILLS_DOCTYPE } from 'doctypes'
+import { BILLS_DOCTYPE, TRANSACTION_DOCTYPE, schema } from 'doctypes'
 import MockDate from 'mockdate'
 import flag from 'cozy-flags'
 import CozyClient from 'cozy-client'
-
-const fakeCozyClient = {
-  attachStore: () => {},
-  createDocument: (doctype, doc) => {
-    doc._type = doctype
-    doc.id = doc._id
-    return Promise.resolve({ data: [doc] })
-  }
-}
+import { createClientWithData } from 'test/client'
 
 describe('reimbursements', () => {
+  let client
   const healthId = '400610'
   const BILL_ID = '1234'
-  let store, transaction // , bill
-  beforeEach(() => {
-    transaction = {
+  const bills = [
+    {
+      _type: BILLS_DOCTYPE,
+      _id: `${BILL_ID}`
+    }
+  ]
+  const transactions = [
+    {
+      _type: TRANSACTION_DOCTYPE,
       automaticCategoryId: healthId,
       amount: -10,
       reimbursements: [{ billId: `${BILLS_DOCTYPE}:${BILL_ID}` }]
     }
-    // bill = { _id: BILL_ID, invoice: 'io.cozy.files:4567' }
-    store = configureStore(fakeCozyClient)
-    // store.dispatch(createDocument(BILLS_DOCTYPE, bill))
+  ]
+  const transaction = transactions[0]
+
+  const getFirstReimbursementBill = transaction =>
+    transaction.reimbursements.data[0].bill
+
+  beforeEach(() => {
+    client = createClientWithData({
+      queries: {
+        bills: {
+          doctype: BILLS_DOCTYPE,
+          data: bills
+        },
+        transactions: {
+          doctype: TRANSACTION_DOCTYPE,
+          data: transactions
+        }
+      },
+      clientOptions: {
+        schema
+      }
+    })
   })
 
   it('should be hydrated if transaction in health category', () => {
-    const transactions = [transaction].map(t =>
-      hydrateTransaction(store.getState(), t)
+    const transactions = [transaction].map(transaction =>
+      client.hydrateDocument(transaction)
     )
-    expect(transactions[0].reimbursements[0].bill).toBeTruthy()
-    expect(transactions[0].reimbursements[0].bill._id).toBe(BILL_ID)
-  })
-
-  it('should not be hydrated if transaction not in the health category', () => {
-    const transactions = [{ ...transaction, automaticCategoryId: '1000' }].map(
-      t => hydrateTransaction(store.getState(), t)
-    )
-    expect(transactions[0].reimbursements[0].bill).toBe(undefined)
+    expect(getFirstReimbursementBill(transactions[0])).toBeTruthy()
+    expect(getFirstReimbursementBill(transactions[0])._id).toBe(BILL_ID)
   })
 
   it('should not be hydrated if bill does not exist in store', () => {
     const transactions = [
       { ...transaction, reimbursements: [{ billId: undefined }] }
-    ].map(t => hydrateTransaction(store.getState(), t))
-    expect(transactions[0].reimbursements[0].bill).toBe(undefined)
+    ].map(transaction => client.hydrateDocument(transaction))
+    expect(getFirstReimbursementBill(transactions[0])).toBe(undefined)
   })
 })
 


### PR DESCRIPTION
Some tests related to reimbursements hydratation were ignored via
xdescribe. I reworked the tests to use createClientWithData and
client.hydrateDocument, which should be closer to what we do outside
of tests.

There remains a test "should not be hydrated if transaction not in the health category" which I had to mark a `xit`. I think we should remove this
test as it seems to be out of date now that normal transactions can have
reimbursements. @drazik ?