### PR TITLE
feat(linkMyselfToAccounts): Use stack's POST /contact/myself

### DIFF
--- a/src/ducks/account/services.spec.js
+++ b/src/ducks/account/services.spec.js
@@ -36,10 +36,11 @@ describe('linkMyselfToAccounts', () => {
 
       const client = createClientWithData({
         data: {
-          [ACCOUNT_DOCTYPE]: accounts,
-          [CONTACT_DOCTYPE]: [myself]
+          [ACCOUNT_DOCTYPE]: accounts
         }
       })
+
+      client.stackClient.fetchJSON.mockResolvedValue({ data: myself })
 
       await linkMyselfToAccounts({ client })
 
@@ -47,7 +48,7 @@ describe('linkMyselfToAccounts', () => {
     })
   })
 
-  describe('when myself contact does not exist', () => {
+  describe('when myself contact fetching fails', () => {
     it('should bail out', async () => {
       const accounts = [
         { _id: 'a1' },
@@ -67,6 +68,8 @@ describe('linkMyselfToAccounts', () => {
         }
       })
 
+      client.stackClient.fetchJSON.mockRejectedValue()
+
       await linkMyselfToAccounts({ client })
 
       expect(accounts.every(isAccountLinkedToMyself)).toBe(false)
@@ -75,43 +78,42 @@ describe('linkMyselfToAccounts', () => {
 })
 
 describe('unlinkMyselfToAccounts', () => {
-  describe('when myself contact exists', () => {
-    it('should unlink myself contact from all accounts', async () => {
-      const myselfRel = { _id: myself._id, _type: CONTACT_DOCTYPE }
+  it('should unlink myself contact from all accounts', async () => {
+    const myselfRel = { _id: myself._id, _type: CONTACT_DOCTYPE }
 
-      const accounts = [
-        {
-          _id: 'a1',
-          relationships: {
-            owners: {
-              data: [myselfRel]
-            }
-          }
-        },
-        {
-          _id: 'a2',
-          relationships: {
-            owners: {
-              data: [myselfRel]
-            }
+    const accounts = [
+      {
+        _id: 'a1',
+        relationships: {
+          owners: {
+            data: [myselfRel]
           }
         }
-      ]
-
-      const client = createClientWithData({
-        data: {
-          [ACCOUNT_DOCTYPE]: accounts,
-          [CONTACT_DOCTYPE]: [myself]
+      },
+      {
+        _id: 'a2',
+        relationships: {
+          owners: {
+            data: [myselfRel]
+          }
         }
-      })
+      }
+    ]
 
-      await unlinkMyselfFromAccounts({ client })
-
-      expect(accounts.every(isAccountLinkedToMyself)).toBe(false)
+    const client = createClientWithData({
+      data: {
+        [ACCOUNT_DOCTYPE]: accounts
+      }
     })
+
+    client.stackClient.fetchJSON.mockResolvedValue({ data: myself })
+
+    await unlinkMyselfFromAccounts({ client })
+
+    expect(accounts.every(isAccountLinkedToMyself)).toBe(false)
   })
 
-  describe('when myself contact does not exist', () => {
+  describe('when myself contact fetching fails', () => {
     it('should bail out', async () => {
       const myselfRel = { _id: myself._id, _type: CONTACT_DOCTYPE }
 
@@ -139,6 +141,8 @@ describe('unlinkMyselfToAccounts', () => {
           [ACCOUNT_DOCTYPE]: accounts
         }
       })
+
+      client.stackClient.fetchJSON.mockRejectedValue()
 
       await unlinkMyselfFromAccounts({ client })
 

--- a/test/client.js
+++ b/test/client.js
@@ -54,6 +54,7 @@ export const createClientWithData = ({ queries, data, clientOptions }) => {
   })
 
   client.save = jest.fn()
+  client.stackClient.fetchJSON = jest.fn()
 
   return client
 }


### PR DESCRIPTION
This route returns the myself contact if it exists and creates it with
basic infos if it doesn't.
See https://docs.cozy.io/en/cozy-stack/contacts/#post-contactsmyself

So now we get myself contact from this route and we don't have to worry if the contact exists or not. The stack creates it with at least the instance email address if it doesn't exist.

We bail out if the request to the stack to fetch myself contact fails, though.