### PR TITLE
Show and edit bank accounts owners

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "cozy-pouch-link": "6.64.7",
     "cozy-realtime": "3.2.1",
     "cozy-stack-client": "7.8.0",
-    "cozy-ui": "27.12.0",
+    "cozy-ui": "28.3.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "cozy-authentication": "1.19.2",
     "cozy-bar": "7.10.0",
     "cozy-ci": "0.4.1",
-    "cozy-client": "7.10.0",
+    "cozy-client": "7.14.0",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "1.8.0",
     "cozy-doctypes": "1.69.0",

--- a/src/components/Table/styles.styl
+++ b/src/components/Table/styles.styl
@@ -116,4 +116,7 @@
             padding-bottom .5rem
             font-size .75rem
             color var(--coolGrey)
-            max-width fit-content
+            flex-basis auto
+            flex-shrink 0
+            flex-grow 1
+            max-width none

--- a/src/components/Title/Title.styl
+++ b/src/components/Title/Title.styl
@@ -4,6 +4,7 @@
     line-height 2.5rem
     margin 0 auto
     margin-bottom .5rem
+    display flex
 
 .TitleColor_default
     color var(--black) !important

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -173,7 +173,7 @@ export const schema = {
 const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
 
 export const accountsConn = {
-  query: client => client.all(ACCOUNT_DOCTYPE),
+  query: client => client.all(ACCOUNT_DOCTYPE).include(['owners']),
   as: 'accounts',
   fetchPolicy: older30s
 }

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -4,7 +4,8 @@ import {
   overEvery,
   flowRight as compose,
   set,
-  uniqBy
+  uniqBy,
+  flatten
 } from 'lodash'
 import {
   getDate,
@@ -210,4 +211,11 @@ export const addOwnerToAccount = (account, owner) => {
 
 export const getAccountOwners = account => {
   return get(account, 'owners.data', [])
+}
+
+export const getUniqueOwners = accounts => {
+  const allOwners = flatten(accounts.map(getAccountOwners))
+  const uniqOwners = uniqBy(allOwners, owner => owner._id)
+
+  return uniqOwners
 }

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -207,3 +207,7 @@ export const addOwnerToAccount = (account, owner) => {
 
   return account
 }
+
+export const getAccountOwners = account => {
+  return get(account, 'owners.data', [])
+}

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,15 +1,7 @@
 /* global __TARGET__ */
 
 import React, { PureComponent, Fragment } from 'react'
-import {
-  flowRight as compose,
-  get,
-  sumBy,
-  set,
-  debounce,
-  flatten,
-  uniqBy
-} from 'lodash'
+import { flowRight as compose, get, sumBy, set, debounce } from 'lodash'
 
 import { queryConnect, withMutations, withClient } from 'cozy-client'
 import flag from 'cozy-flags'
@@ -36,7 +28,7 @@ import AccountsImporting from 'ducks/balance/components/AccountsImporting'
 
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
-import { getAccountBalance } from 'ducks/account/helpers'
+import { getAccountBalance, getUniqueOwners } from 'ducks/account/helpers'
 import { isBankTrigger } from 'utils/triggers'
 import { getVirtualAccounts, getVirtualGroups } from 'selectors'
 
@@ -406,12 +398,9 @@ class Balance extends PureComponent {
             nbAccounts: accounts.length
           }
 
-    const allOwners = flatten(
-      accounts.map(account => get(account, 'owners.data', []))
-    )
-    const uniqOwners = uniqBy(allOwners, owner => owner._id)
+    const owners = getUniqueOwners(accounts)
     const showOwners =
-      (uniqOwners.length > 1 && flag('balance.show-owners')) ||
+      (owners.length > 1 && flag('balance.show-owners')) ||
       flag('balance.force-show-owners')
 
     return (

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -1,7 +1,15 @@
 /* global __TARGET__ */
 
 import React, { PureComponent, Fragment } from 'react'
-import { flowRight as compose, get, sumBy, set, debounce } from 'lodash'
+import {
+  flowRight as compose,
+  get,
+  sumBy,
+  set,
+  debounce,
+  flattenDeep,
+  uniqBy
+} from 'lodash'
 
 import { queryConnect, withMutations, withClient } from 'cozy-client'
 import flag from 'cozy-flags'
@@ -398,6 +406,14 @@ class Balance extends PureComponent {
             nbAccounts: accounts.length
           }
 
+    const allOwners = flattenDeep(
+      accounts.map(account => get(account, 'owners.data', []))
+    )
+    const uniqOwners = uniqBy(allOwners, owner => owner._id)
+    const showOwners =
+      (uniqOwners.length > 1 && flag('balance.show-owners')) ||
+      flag('balance.force-show-owners')
+
     return (
       <Fragment>
         <BarTheme theme="primary" />
@@ -418,6 +434,7 @@ class Balance extends PureComponent {
             panelsState={this.state.panels}
             onSwitchChange={this.handleSwitchChange}
             onPanelChange={this.debouncedHandlePanelChange}
+            showOwners={showOwners}
           />
         </Padded>
       </Fragment>

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -7,7 +7,7 @@ import {
   sumBy,
   set,
   debounce,
-  flattenDeep,
+  flatten,
   uniqBy
 } from 'lodash'
 
@@ -406,7 +406,7 @@ class Balance extends PureComponent {
             nbAccounts: accounts.length
           }
 
-    const allOwners = flattenDeep(
+    const allOwners = flatten(
       accounts.map(account => get(account, 'owners.data', []))
     )
     const uniqOwners = uniqBy(allOwners, owner => owner._id)

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -21,7 +21,8 @@ class BalancePanels extends React.PureComponent {
     panelsState: PropTypes.object.isRequired,
     onSwitchChange: PropTypes.func,
     onPanelChange: PropTypes.func,
-    withBalance: PropTypes.bool
+    withBalance: PropTypes.bool,
+    showOwners: PropTypes.bool.isRequired
   }
 
   static defaultProps = {
@@ -40,7 +41,8 @@ class BalancePanels extends React.PureComponent {
       panelsState,
       onSwitchChange,
       onPanelChange,
-      withBalance
+      withBalance,
+      showOwners
     } = this.props
 
     const groupsSorted = translateAndSortGroups(groups, t)
@@ -66,6 +68,7 @@ class BalancePanels extends React.PureComponent {
               onSwitchChange={onSwitchChange}
               onChange={onPanelChange}
               withBalance={withBalance}
+              showOwners={showOwners}
             />
           </Delayed>
         ))}

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -57,6 +57,35 @@ const Number = React.memo(function Number({ account }) {
   )
 })
 
+const Owners = React.memo(function Owners(props) {
+  const { owners, className, ...rest } = props
+
+  return (
+    <div className={cx(styles.AccountRow__subText, className)} {...rest}>
+      <Icon
+        icon={owners.length > 1 ? 'team' : 'people'}
+        size={10}
+        className={styles.AccountRow__ownersIcon}
+      />
+      {owners.map(Contact.getDisplayName).join(' - ')}
+    </div>
+  )
+})
+
+const OwnersColumn = props => {
+  const { owners, ...rest } = props
+
+  return (
+    <div className={styles.AccountRow__column} {...rest}>
+      {owners && owners.length > 0 ? (
+        <Owners owners={owners} />
+      ) : (
+        <div className={cx(styles.AccountRow__subText)}>—</div>
+      )}
+    </div>
+  )
+}
+
 const DumbUpdatedAtOrFail = props => {
   const { triggersCol, account, t, className, ...rest } = props
   const triggers = triggersCol.data
@@ -122,6 +151,7 @@ class AccountRow extends React.PureComponent {
     const contactsById = keyBy(contacts, contact => contact._id)
     const ownerRelationships = get(account, 'relationships.owners.data', [])
     const owners = ownerRelationships.map(data => contactsById[data._id])
+    const shouldShowOwners = showOwners && owners && owners.length > 0
 
     const hasWarning = account.balance < warningLimit
     const hasAlert = account.balance < 0
@@ -134,7 +164,8 @@ class AccountRow extends React.PureComponent {
           [styles['AccountRow--hasWarning']]: hasWarning,
           [styles['AccountRow--hasAlert']]: hasAlert,
           [styles['AccountRow--disabled']]:
-            (!checked || disabled) && account.loading !== true
+            (!checked || disabled) && account.loading !== true,
+          [styles['AccountRow--withOwners']]: shouldShowOwners
         })}
         onClick={onClick}
       >
@@ -148,19 +179,11 @@ class AccountRow extends React.PureComponent {
             <div className={styles.AccountRow__label}>
               {account.virtual ? t(accountLabel) : accountLabel}
             </div>
-            {showOwners && owners && owners.length > 0 && (
-              <div className={styles.AccountRow__subText}>
-                <Icon
-                  icon={owners.length > 1 ? 'team' : 'people'}
-                  size={10}
-                  className={styles.AccountRow__ownersIcon}
-                />
-                {owners.map(Contact.getDisplayName).join(' - ')}
-              </div>
-            )}
+            {isMobile && shouldShowOwners && <Owners owners={owners} />}
             <UpdatedAtOrFail triggersCol={triggersCol} account={account} />
           </div>
         </div>
+        {!isMobile && <OwnersColumn owners={owners} />}
         {!isMobile && account.number && <Number account={account} />}
         {!isMobile && (
           <div

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -58,10 +58,10 @@ const Number = React.memo(function Number({ account }) {
 })
 
 const Owners = React.memo(function Owners(props) {
-  const { owners, className, ...rest } = props
+  const { owners, ...rest } = props
 
   return (
-    <div className={cx(styles.AccountRow__subText, className)} {...rest}>
+    <div {...rest}>
       <Icon
         icon={owners.length > 1 ? 'team' : 'people'}
         size={10}
@@ -76,7 +76,13 @@ const OwnersColumn = props => {
   const { owners, ...rest } = props
 
   return (
-    <div className={styles.AccountRow__column} {...rest}>
+    <div
+      className={cx(
+        styles.AccountRow__column,
+        styles['AccountRow__column--secondary']
+      )}
+      {...rest}
+    >
       {owners && owners.length > 0 ? (
         <Owners owners={owners} />
       ) : (
@@ -183,7 +189,12 @@ class AccountRow extends React.PureComponent {
               <div className={styles.AccountRow__label}>
                 {account.virtual ? t(accountLabel) : accountLabel}
               </div>
-              {shouldShowOwners && isMobile && <Owners owners={owners} />}
+              {shouldShowOwners && isMobile && (
+                <Owners
+                  className={styles.AccountRow__subText}
+                  owners={owners}
+                />
+              )}
               {!showUpdatedAtOutside && (
                 <UpdatedAtOrFail triggersCol={triggersCol} account={account} />
               )}

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -158,6 +158,8 @@ class AccountRow extends React.PureComponent {
     const isHealthReimbursements = isHealthReimbursementsAccount(account)
     const accountLabel = getAccountLabel(account)
 
+    const showUpdatedAtOutside = isMobile && shouldShowOwners
+
     return (
       <li
         className={cx(styles.AccountRow, 'u-clickable', {
@@ -169,56 +171,65 @@ class AccountRow extends React.PureComponent {
         })}
         onClick={onClick}
       >
-        <div className={styles.AccountRow__column}>
-          <div className={styles.AccountRow__logo}>
-            <AccountIcon account={account} />
-            {isHealthReimbursements && <HealthReimbursementsIcon />}
-          </div>
-
-          <div className={styles.AccountRow__labelWrapper}>
-            <div className={styles.AccountRow__label}>
-              {account.virtual ? t(accountLabel) : accountLabel}
+        <div className={styles.AccountRow__mainLine}>
+          <div className={styles.AccountRow__column}>
+            <div className={styles.AccountRow__logo}>
+              <AccountIcon account={account} />
+              {isHealthReimbursements && <HealthReimbursementsIcon />}
             </div>
-            {isMobile && shouldShowOwners && <Owners owners={owners} />}
-            <UpdatedAtOrFail triggersCol={triggersCol} account={account} />
+
+            <div className={styles.AccountRow__labelWrapper}>
+              <div className={styles.AccountRow__label}>
+                {account.virtual ? t(accountLabel) : accountLabel}
+              </div>
+              {shouldShowOwners && isMobile && <Owners owners={owners} />}
+              {!showUpdatedAtOutside && (
+                <UpdatedAtOrFail triggersCol={triggersCol} account={account} />
+              )}
+            </div>
           </div>
-        </div>
-        {!isMobile && <OwnersColumn owners={owners} />}
-        {!isMobile && account.number && <Number account={account} />}
-        {!isMobile && (
+          {!isMobile && <OwnersColumn owners={owners} />}
+          {!isMobile && account.number && <Number account={account} />}
+          {!isMobile && (
+            <div
+              className={cx(
+                styles.AccountRow__column,
+                styles['AccountRow__column--secondary']
+              )}
+            >
+              {getAccountInstitutionLabel(account)}
+            </div>
+          )}
           <div
             className={cx(
               styles.AccountRow__column,
-              styles['AccountRow__column--secondary']
+              styles.AccountRow__figureSwitchWrapper
             )}
           >
-            {getAccountInstitutionLabel(account)}
+            <Figure
+              symbol="€"
+              total={getAccountBalance(account)}
+              className={cx(styles.AccountRow__figure)}
+              totalClassName={styles.AccountRow__figure}
+              currencyClassName={styles.AccountRow__figure}
+            />
+            {/* color: Do not deactivate interactions with the button,
+            only color it to look disabled */}
+            <Switch
+              disableRipple
+              checked={checked}
+              color={disabled ? 'default' : 'primary'}
+              onClick={this.handleSwitchClick}
+              id={id}
+              onChange={onSwitchChange}
+            />
+          </div>
+        </div>
+        {showUpdatedAtOutside && (
+          <div className={styles.AccountRow__subLine}>
+            <UpdatedAtOrFail triggersCol={triggersCol} account={account} />
           </div>
         )}
-        <div
-          className={cx(
-            styles.AccountRow__column,
-            styles.AccountRow__figureSwitchWrapper
-          )}
-        >
-          <Figure
-            symbol="€"
-            total={getAccountBalance(account)}
-            className={cx(styles.AccountRow__figure)}
-            totalClassName={styles.AccountRow__figure}
-            currencyClassName={styles.AccountRow__figure}
-          />
-          {/* color: Do not deactivate interactions with the button,
-            only color it to look disabled */}
-          <Switch
-            disableRipple
-            checked={checked}
-            color={disabled ? 'default' : 'primary'}
-            onClick={this.handleSwitchClick}
-            id={id}
-            onChange={onSwitchChange}
-          />
-        </div>
       </li>
     )
   }

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -83,11 +83,7 @@ const OwnersColumn = props => {
       )}
       {...rest}
     >
-      {owners && owners.length > 0 ? (
-        <Owners owners={owners} />
-      ) : (
-        <div className={cx(styles.AccountRow__subText)}>—</div>
-      )}
+      {owners && owners.length > 0 ? <Owners owners={owners} /> : null}
     </div>
   )
 }

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -147,6 +147,7 @@ class AccountRow extends React.PureComponent {
       client
     } = this.props
 
+    // TODO Extract it to a selector
     const contacts = client.getCollectionFromState(CONTACT_DOCTYPE)
     const contactsById = keyBy(contacts, contact => contact._id)
     const ownerRelationships = get(account, 'relationships.owners.data', [])

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -2,9 +2,9 @@
 
 .AccountRow
     display flex
-    justify-content space-between
+    flex-direction column
+    justify-content center
     height 4rem
-    align-items center
     padding-left 1rem
     padding-right 0.5rem
     background-color var(--white)
@@ -102,3 +102,12 @@
 
 .AccountRow__ownersIcon
     margin-right 0.25rem
+
+.AccountRow__mainLine
+    display flex
+    justify-content space-between
+    align-items center
+    width 100%
+
+.AccountRow__subLine
+    padding-left rem(40)

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -96,3 +96,6 @@
     .AccountRow__logo
         opacity 0.5
 
+
+.AccountRow__ownersIcon
+    margin-right 0.25rem

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -66,6 +66,8 @@
     font-size 0.75rem
     color var(--coolGrey)
     line-height 1.5
+    text-overflow ellipsis
+    overflow hidden
 
 .AccountRow__updatedAtIcon
     vertical-align top

--- a/src/ducks/balance/components/AccountRow.styl
+++ b/src/ducks/balance/components/AccountRow.styl
@@ -96,6 +96,9 @@
     .AccountRow__logo
         opacity 0.5
 
+.AccountRow--withOwners
+    +small-screen()
+        height rem(82)
 
 .AccountRow__ownersIcon
     margin-right 0.25rem

--- a/src/ducks/balance/components/AccountsList.jsx
+++ b/src/ducks/balance/components/AccountsList.jsx
@@ -13,7 +13,8 @@ class AccountsList extends React.PureComponent {
     group: PropTypes.object.isRequired,
     warningLimit: PropTypes.number.isRequired,
     switches: PropTypes.object.isRequired,
-    onSwitchChange: PropTypes.func
+    onSwitchChange: PropTypes.func,
+    showOwners: PropTypes.bool.isRequired
   }
 
   static defaultProps = {
@@ -28,7 +29,13 @@ class AccountsList extends React.PureComponent {
   }
 
   render() {
-    const { group, warningLimit, switches, onSwitchChange } = this.props
+    const {
+      group,
+      warningLimit,
+      switches,
+      onSwitchChange,
+      showOwners
+    } = this.props
     const accounts = group.accounts.data || []
 
     return (
@@ -54,6 +61,7 @@ class AccountsList extends React.PureComponent {
               disabled={switchState.disabled}
               id={`${group._id}.accounts.${a._id}`}
               onSwitchChange={onSwitchChange}
+              showOwners={showOwners}
             />
           )
         })}

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -74,7 +74,8 @@ class GroupPanel extends React.PureComponent {
     expanded: PropTypes.bool.isRequired,
     onSwitchChange: PropTypes.func,
     onChange: PropTypes.func,
-    withBalance: PropTypes.bool
+    withBalance: PropTypes.bool,
+    showOwners: PropTypes.bool.isRequired
   }
 
   static defaultProps = {
@@ -126,7 +127,8 @@ class GroupPanel extends React.PureComponent {
       withBalance,
       t,
       className,
-      groupPanelSummaryClasses
+      groupPanelSummaryClasses,
+      showOwners
     } = this.props
 
     const nbAccounts = group.accounts.data.length
@@ -205,6 +207,7 @@ class GroupPanel extends React.PureComponent {
               warningLimit={warningLimit}
               switches={switches}
               onSwitchChange={onSwitchChange}
+              showOwners={showOwners}
             />
           ) : (
             <Stack className="u-m-1">

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -26,6 +26,8 @@ import { ACCOUNT_DOCTYPE, APP_DOCTYPE } from 'doctypes'
 import { Padded } from 'components/Spacing'
 import { logException } from 'lib/sentry'
 import withFilters from 'components/withFilters'
+import flag from 'cozy-flags'
+import NewAccountSettings from './NewAccountSettings'
 
 const DeleteConfirm = ({
   cancel,
@@ -236,11 +238,7 @@ const GeneralSettings = compose(
   withFilters
 )(_GeneralSettings)
 
-const AccountSettings = function({
-  routeParams,
-  t,
-  breakpoints: { isMobile }
-}) {
+const OldAccountSettings = ({ routeParams, t, breakpoints: { isMobile } }) => {
   return (
     <Query query={client => client.get(ACCOUNT_DOCTYPE, routeParams.accountId)}>
       {({ data, fetchStatus }) => {
@@ -285,6 +283,14 @@ const AccountSettings = function({
       }}
     </Query>
   )
+}
+
+const AccountSettings = function(props) {
+  if (flag('settings.new-account-details-page')) {
+    return <NewAccountSettings {...props} />
+  } else {
+    return <OldAccountSettings {...props} />
+  }
 }
 
 export default compose(

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -14,9 +14,12 @@ import AddAccountLink from 'ducks/settings/AddAccountLink'
 import cx from 'classnames'
 import {
   getAccountInstitutionLabel,
-  getAccountType
+  getAccountType,
+  getAccountOwners
 } from 'ducks/account/helpers'
 import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
+import { Contact } from 'cozy-doctypes'
+import flag from 'cozy-flags'
 
 import { accountsConn, APP_DOCTYPE } from 'doctypes'
 
@@ -46,9 +49,18 @@ const _AccountLine = ({ account, router, t }) => (
         _: t('Data.accountTypes.Other')
       })}
     </td>
-    <td className={styles.AcnsStg__shared}>
-      <AccountSharingStatus withText account={account} />
-    </td>
+    {flag('settings.show-accounts-owners') ? (
+      <td className={styles.AcnsStg__owner}>
+        {getAccountOwners(account)
+          .map(Contact.getDisplayName)
+          .join(' - ')}
+        <AccountSharingStatus withText account={account} />
+      </td>
+    ) : (
+      <td className={styles.AcnsStg__shared}>
+        <AccountSharingStatus withText account={account} />
+      </td>
+    )}
     <td className={styles.AcnsStg__actions} />
   </tr>
 )
@@ -62,21 +74,33 @@ const renderAccount = account => (
   <AccountLine account={account} key={account._id} />
 )
 
-const AccountsTable = ({ accounts, t }) => (
-  <Table className={styles.AcnsStg__accounts}>
-    <thead>
-      <tr>
-        <th className={styles.AcnsStg__libelle}>{t('Accounts.label')}</th>
-        <th className={styles.AcnsStg__bank}>{t('Accounts.bank')}</th>
-        <th className={styles.AcnsStg__number}>{t('Accounts.account')}</th>
-        <th className={styles.AcnsStg__type}>{t('Accounts.type')}</th>
-        <th className={styles.AcnsStg__shared}>{t('Accounts.shared')}</th>
-        <th className={styles.AcnsStg__actions} />
-      </tr>
-    </thead>
-    <tbody>{accounts.map(renderAccount)}</tbody>
-  </Table>
-)
+const AccountsTable = ({ accounts, t }) => {
+  const showAccountsOwners = flag('settings.show-accounts-owners')
+
+  return (
+    <Table className={styles.AcnsStg__accounts}>
+      <thead>
+        <tr>
+          <th className={styles.AcnsStg__libelle}>{t('Accounts.label')}</th>
+          <th className={styles.AcnsStg__bank}>{t('Accounts.bank')}</th>
+          <th className={styles.AcnsStg__number}>{t('Accounts.account')}</th>
+          <th className={styles.AcnsStg__type}>{t('Accounts.type')}</th>
+          <th
+            className={
+              showAccountsOwners
+                ? styles.AcnsStg__owner
+                : styles.AcnsStg__shared
+            }
+          >
+            {t(`Accounts.${showAccountsOwners ? 'owner' : 'shared'}`)}
+          </th>
+          <th className={styles.AcnsStg__actions} />
+        </tr>
+      </thead>
+      <tbody>{accounts.map(renderAccount)}</tbody>
+    </Table>
+  )
+}
 
 class AccountsSettings extends Component {
   render() {

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -92,7 +92,7 @@ const AccountsTable = ({ accounts, t }) => {
                 : styles.AcnsStg__shared
             }
           >
-            {t(`Accounts.${showAccountsOwners ? 'owner' : 'shared'}`)}
+            {showAccountsOwners ? t('Accounts.owner') : t('Accounts.shared')}
           </th>
           <th className={styles.AcnsStg__actions} />
         </tr>

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -25,7 +25,7 @@
         maxed-flex-basis 15%
         color var(--coolGrey)
 
-        +small-screen
+        +small-screen()
             td&
                 background-color red
                 maxed-flex-basis 33%

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -18,9 +18,17 @@
     &__bank
         maxed-flex-basis 20%
 
+        +small-screen
+            maxed-flex-basis 33%
+
     &__number
         maxed-flex-basis 15%
         color var(--coolGrey)
+
+        +small-screen
+            td&
+                background-color red
+                maxed-flex-basis 33%
 
     &__type
         maxed-flex-basis 15%
@@ -30,18 +38,23 @@
             td& // increase selectivity with td
                 display none
 
-    &__shared
+    &__shared,
+    &__owner
         maxed-flex-basis 15%
 
     &__actions
         maxed-flex-basis 10%
         text-align right
 
+        +small-screen()
+            td& // increase selectivity with td
+                display none
+
     &__accountRow
         composes mobile-row from '../../components/Table/styles.styl'
         composes nav-row from '../commons/mobile.styl'// @stylint ignore
 
-    &__bank, &__number
+    &__bank, &__number, &__shared, &__owner
         composes mobile-row-label from '../../components/Table/styles.styl'
 
 .AcnStg

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -27,7 +27,6 @@
 
         +small-screen()
             td&
-                background-color red
                 maxed-flex-basis 33%
 
     &__type

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -41,6 +41,9 @@
     &__owner
         maxed-flex-basis 15%
 
+    &__owner
+        color var(--coolGrey)
+
     &__actions
         maxed-flex-basis 10%
         text-align right

--- a/src/ducks/settings/NewAccountSettings.jsx
+++ b/src/ducks/settings/NewAccountSettings.jsx
@@ -216,13 +216,22 @@ const NewAccountSettings = props => {
 
   const handleRemoveAccount = async account => {
     setDeleting(true)
-    await client.destroy(account)
 
-    if (filteringDoc && account._id === filteringDoc._id) {
-      resetFilterByDoc()
+    try {
+      await client.destroy(account)
+
+      if (filteringDoc && account._id === filteringDoc._id) {
+        resetFilterByDoc()
+      }
+
+      router.push('/settings/accounts')
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+      Alerter.error(t('AccountSettings.deletion_error'))
+    } finally {
+      setDeleting(false)
     }
-
-    router.push('/settings/accounts')
   }
 
   const confirmPrimaryText = t('AccountSettings.confirm-deletion.description')

--- a/src/ducks/settings/NewAccountSettings.jsx
+++ b/src/ducks/settings/NewAccountSettings.jsx
@@ -1,0 +1,318 @@
+/* global cozy */
+import React, { useState } from 'react'
+import BarTheme from 'ducks/bar/BarTheme'
+import { PageTitle } from 'components/Title'
+import BackButton from 'components/BackButton'
+import { Query, withClient } from 'cozy-client'
+import { ACCOUNT_DOCTYPE } from 'doctypes'
+import Loading from 'components/Loading'
+import {
+  getAccountLabel,
+  getAccountInstitutionLabel,
+  getAccountType,
+  getAccountOwners
+} from 'ducks/account/helpers'
+import { Padded } from 'components/Spacing'
+import Button from 'cozy-ui/transpiled/react/Button'
+import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
+import cx from 'classnames'
+import styles from 'ducks/settings/NewAccountSettings.styl'
+import Alerter from 'cozy-ui/react/Alerter'
+import Menu from 'cozy-ui/transpiled/react/MuiCozyTheme/Menus'
+import MenuItem from '@material-ui/core/MenuItem'
+import Modal from 'cozy-ui/react/Modal'
+import { connect } from 'react-redux'
+import { getHomeURL } from 'ducks/apps/selectors'
+import { flowRight as compose, set } from 'lodash'
+import { translate } from 'cozy-ui/react'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Field from 'cozy-ui/transpiled/react/Field'
+import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField'
+import Stack from 'cozy-ui/transpiled/react/Stack'
+import ContactPicker from 'cozy-ui/transpiled/react/ContactPicker'
+import withFilters from 'components/withFilters'
+import { withBreakpoints } from 'cozy-ui/transpiled/react'
+
+const { BarRight } = cozy.bar
+
+const DumbAccountSettingsForm = props => {
+  const {
+    account,
+    onSubmit,
+    onCancel,
+    breakpoints: { isMobile },
+    t,
+    f, // eslint-disable-line no-unused-vars
+    ...rest
+  } = props
+
+  const [shortLabel, setShortLabel] = useState(getAccountLabel(account))
+  const [owners, setOwners] = useState(getAccountOwners(account))
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    onSubmit({ shortLabel, owners })
+  }
+
+  const fieldVariant = isMobile ? 'default' : 'inline'
+
+  return (
+    <form onSubmit={handleSubmit} {...rest}>
+      <Stack spacing={isMobile ? 's' : 'm'}>
+        <Field
+          id="account-label"
+          label={t('AccountSettings.label')}
+          value={shortLabel}
+          onChange={e => setShortLabel(e.target.value)}
+          variant={fieldVariant}
+          className={styles.Form__field}
+        />
+        <CollectionField
+          label={t('AccountSettings.owner')}
+          values={owners}
+          component={ContactPicker}
+          addButtonLabel={t('AccountSettings.addOwnerBtn')}
+          removeButtonLabel={t('AccountSettings.removeOwnerBtn')}
+          variant={fieldVariant}
+          onChange={owners => setOwners(owners)}
+          placeholder={t('AccountSettings.ownerPlaceholder')}
+        />
+        <Field
+          id="account-institution"
+          label={t('AccountSettings.bank')}
+          value={getAccountInstitutionLabel(account)}
+          disabled
+          variant={fieldVariant}
+          className={styles.Form__field}
+        />
+        <Field
+          id="account-number"
+          label={t('AccountSettings.number')}
+          value={account.number}
+          disabled
+          variant={fieldVariant}
+          className={styles.Form__field}
+        />
+        <Field
+          id="account-type"
+          label={t('AccountSettings.type')}
+          value={getAccountType(account)}
+          disabled
+          variant={fieldVariant}
+          className={styles.Form__field}
+        />
+      </Stack>
+      <FormControls onCancel={onCancel} t={t} />
+    </form>
+  )
+}
+
+const AccountSettingsForm = compose(
+  withBreakpoints(),
+  translate()
+)(DumbAccountSettingsForm)
+
+const FormControls = props => {
+  const { onCancel, form, className, t, ...rest } = props
+
+  return (
+    <div className={cx(styles.FormControls, className)} {...rest}>
+      <Button
+        label={t('General.cancel')}
+        theme="secondary"
+        onClick={onCancel}
+      />
+      <Button
+        type="submit"
+        form={form}
+        label={t('AccountSettings.apply')}
+        theme="primary"
+      />
+    </div>
+  )
+}
+
+const DeleteConfirm = ({
+  cancel,
+  confirm,
+  title,
+  description,
+  secondaryText,
+  primaryText
+}) => {
+  return (
+    <Modal
+      title={title}
+      description={<div dangerouslySetInnerHTML={{ __html: description }} />}
+      secondaryType="secondary"
+      secondaryText={secondaryText}
+      secondaryAction={cancel}
+      dismissAction={cancel}
+      primaryType="danger"
+      primaryText={primaryText}
+      primaryAction={confirm}
+    />
+  )
+}
+
+const NewAccountSettings = props => {
+  const {
+    breakpoints: { isMobile },
+    routeParams,
+    t,
+    router,
+    client,
+    homeUrl,
+    filteringDoc,
+    resetFilterByDoc
+  } = props
+
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const saveAccount = async (account, fields) => {
+    Object.keys(fields).forEach(key => {
+      if (key === 'owners') {
+        set(
+          account,
+          'relationships.owners.data',
+          fields[key].map(owner => ({
+            _id: owner._id,
+            _type: owner._type
+          }))
+        )
+        return
+      }
+
+      account[key] = fields[key]
+    })
+
+    try {
+      await client.save(account)
+      router.push('/settings/accounts')
+      Alerter.success(t('AccountSettings.success'))
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error(err)
+      Alerter.error(t('AccountSettings.failure'))
+    }
+  }
+
+  const handleRemoveAccount = async account => {
+    setDeleting(true)
+    await client.destroy(account)
+
+    if (filteringDoc && account._id === filteringDoc._id) {
+      resetFilterByDoc()
+    }
+
+    router.push('/settings/accounts')
+  }
+
+  const confirmPrimaryText = t('AccountSettings.confirm-deletion.description')
+    .replace('#{LINK}', homeUrl ? `<a href="${homeUrl}" target="_blank">` : '')
+    .replace('#{/LINK}', homeUrl ? '</a>' : '')
+    .replace('#{APP_NAME}', name)
+
+  return (
+    <>
+      <BarTheme theme="primary" />
+      <Query
+        query={client =>
+          client.get(ACCOUNT_DOCTYPE, routeParams.accountId).include(['owners'])
+        }
+      >
+        {({ data, fetchStatus }) => {
+          if (fetchStatus === 'loading') {
+            return <Loading />
+          }
+
+          if (!data) {
+            return null
+          }
+
+          const account = data
+
+          return (
+            <Padded
+              className={cx({
+                'u-pt-2': !isMobile
+              })}
+            >
+              {isMobile && (
+                <>
+                  <BackButton to="/settings/accounts" arrow theme="primary" />
+                  <BarRight>
+                    <Menu
+                      position="right"
+                      component={
+                        <Button
+                          icon="dots"
+                          iconOnly
+                          label="click"
+                          extension="narrow"
+                          className={styles.Menu__btn}
+                        />
+                      }
+                    >
+                      <MenuItem onClick={() => setShowDeleteConfirmation(true)}>
+                        {t('AccountSettings.removeAccountBtn')}
+                      </MenuItem>
+                    </Menu>
+                  </BarRight>
+                </>
+              )}
+              <PageTitle color={isMobile ? 'primary' : 'default'}>
+                {!isMobile && <BackButton to="/settings/accounts" arrow />}
+                {getAccountLabel(account)}
+                {!isMobile && (
+                  <Button
+                    className="u-ml-0 u-mr-0 u-ml-auto"
+                    label={t('AccountSettings.removeAccountBtn')}
+                    theme="danger-outline"
+                    onClick={() => setShowDeleteConfirmation(true)}
+                  />
+                )}
+              </PageTitle>
+              <NarrowContent className={cx({ 'u-mt-2': !isMobile })}>
+                <AccountSettingsForm
+                  account={account}
+                  id="account-settings-form"
+                  onSubmit={fields => saveAccount(account, fields)}
+                  onCancel={() => router.push('/settings/accounts')}
+                />
+                {showDeleteConfirmation ? (
+                  <DeleteConfirm
+                    title={t('AccountSettings.confirm-deletion.title')}
+                    description={confirmPrimaryText}
+                    primaryText={
+                      deleting ? (
+                        <Spinner color="white" />
+                      ) : (
+                        t('AccountSettings.confirm-deletion.confirm')
+                      )
+                    }
+                    secondaryText={t('General.cancel')}
+                    confirm={() => handleRemoveAccount(account)}
+                    cancel={() => setShowDeleteConfirmation(false)}
+                  />
+                ) : null}
+              </NarrowContent>
+            </Padded>
+          )
+        }}
+      </Query>
+    </>
+  )
+}
+
+const mapStateToProps = state => ({
+  homeUrl: getHomeURL(state)
+})
+
+export default compose(
+  withClient,
+  connect(mapStateToProps),
+  translate(),
+  withFilters
+)(NewAccountSettings)

--- a/src/ducks/settings/NewAccountSettings.jsx
+++ b/src/ducks/settings/NewAccountSettings.jsx
@@ -29,11 +29,25 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Field from 'cozy-ui/transpiled/react/Field'
 import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField'
 import Stack from 'cozy-ui/transpiled/react/Stack'
-import ContactPicker from 'cozy-ui/transpiled/react/ContactPicker'
+import BaseContactPicker from 'cozy-ui/transpiled/react/ContactPicker'
 import withFilters from 'components/withFilters'
 import { withBreakpoints } from 'cozy-ui/transpiled/react'
 
 const { BarRight } = cozy.bar
+
+const ContactPicker = translate()(props => {
+  // eslint-disable-next-line no-unused-vars
+  const { t, f, ...rest } = props
+
+  return (
+    <BaseContactPicker
+      listPlaceholder={t('AccountSettings.listPlaceholder')}
+      listEmptyMessage={t('AccountSettings.listEmptyMessage')}
+      addContactLabel={t('AccountSettings.addContactLabel')}
+      {...props}
+    />
+  )
+})
 
 const DumbAccountSettingsForm = props => {
   const {

--- a/src/ducks/settings/NewAccountSettings.jsx
+++ b/src/ducks/settings/NewAccountSettings.jsx
@@ -292,7 +292,7 @@ const NewAccountSettings = props => {
                 {getAccountLabel(account)}
                 {!isMobile && (
                   <Button
-                    className="u-ml-0 u-mr-0 u-ml-auto"
+                    className="u-mr-0 u-ml-auto"
                     label={t('AccountSettings.removeAccountBtn')}
                     theme="danger-outline"
                     onClick={() => setShowDeleteConfirmation(true)}

--- a/src/ducks/settings/NewAccountSettings.styl
+++ b/src/ducks/settings/NewAccountSettings.styl
@@ -1,5 +1,7 @@
 @require 'settings/breakpoints'
 
+// We want fields that are not a CollectionField to align their right edge with
+// CollectionField fields right edge.
 right_padding = 2.5rem
 
 .TextField

--- a/src/ducks/settings/NewAccountSettings.styl
+++ b/src/ducks/settings/NewAccountSettings.styl
@@ -1,0 +1,46 @@
+@require 'settings/breakpoints'
+
+right_padding = 2.5rem
+
+.TextField
+    width 100%
+
+.FormControls
+    position fixed
+    bottom 0
+    left 0
+    right 0
+    background-color white
+    height 3.5rem
+    z-index 20
+    display flex
+    align-items center
+    padding 0 0.5rem
+    box-shadow 0 -2px 2px 0 rgba(0, 0, 0, 0.06)
+
+    > *
+        flex-grow 1
+
+    > :first-child
+        margin-left 0
+
+    > :last-child
+        margin-right 0
+
+    +medium-screen('min')
+        position static
+        box-shadow unset
+        padding 0
+        justify-content flex-end
+        height auto
+        margin-top 2rem
+        padding-right right_padding
+
+        > *
+            flex-grow 0
+
+.Form__field
+    padding-right right_padding
+
+.Menu__btn
+    height 100%

--- a/src/ducks/transactions/__snapshots__/TriggerErrorCard.spec.jsx.snap
+++ b/src/ducks/transactions/__snapshots__/TriggerErrorCard.spec.jsx.snap
@@ -72,16 +72,23 @@ exports[`trigger error card should render correctly 1`] = `
           icon="warning"
           spin={false}
         >
-          <svg
+          <Component
             className="styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R"
             height="16"
             style={Object {}}
             width="16"
           >
-            <use
-              xlinkHref="#warning"
-            />
-          </svg>
+            <svg
+              className="styles__Infos__icon___1IdYS u-w-1 u-h-1 u-flex-shrink-0 styles__icon___23x3R"
+              height="16"
+              style={Object {}}
+              width="16"
+            >
+              <use
+                xlinkHref="#warning"
+              />
+            </svg>
+          </Component>
         </Icon>
         <Text
           className="u-ta-left u-pl-half"
@@ -136,7 +143,7 @@ exports[`trigger error card should render correctly 1`] = `
                   icon="openwith"
                   spin={false}
                 >
-                  <svg
+                  <Component
                     aria-hidden={true}
                     className="styles__icon___23x3R"
                     focusable="false"
@@ -144,10 +151,19 @@ exports[`trigger error card should render correctly 1`] = `
                     style={Object {}}
                     width="16"
                   >
-                    <use
-                      xlinkHref="#openwith"
-                    />
-                  </svg>
+                    <svg
+                      aria-hidden={true}
+                      className="styles__icon___23x3R"
+                      focusable="false"
+                      height="16"
+                      style={Object {}}
+                      width="16"
+                    >
+                      <use
+                        xlinkHref="#openwith"
+                      />
+                    </svg>
+                  </Component>
                 </Icon>
                 <span
                   className={null}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -65,7 +65,10 @@
     "apply": "Apply",
     "success": "Account updated successfully",
     "failure": "Error while updating the account",
-    "removeAccountBtn": "Remove the account"
+    "removeAccountBtn": "Remove the account",
+    "listPlaceholder": "Search a contact",
+    "listEmptyMessage": "No contact found",
+    "addContactLabel": "Add a contact"
   },
 
   "Balance": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,7 +53,19 @@
       "confirm": "Confirm account deletion",
       "title": "Are you definitive ?"
     },
-    "deletion_error": "An error occurred while group deletion."
+    "deletion_error": "An error occurred while group deletion.",
+    "label": "Label",
+    "owner": "Owner",
+    "addOwnerBtn": "Add an owner",
+    "removeOwnerBtn": "Remove this owner",
+    "ownerPlaceholder": "Select an owner",
+    "bank": "Bank",
+    "number": "Number",
+    "type": "Type",
+    "apply": "Apply",
+    "success": "Account updated successfully",
+    "failure": "Error while updating the account",
+    "removeAccountBtn": "Remove the account"
   },
 
   "Balance": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,7 +116,8 @@
     "type": "Type",
     "bank": "Bank",
     "label": "Label",
-    "manage-accounts": "Manage my accounts"
+    "manage-accounts": "Manage my accounts",
+    "owner": "Owner"
   },
   "Groups": {
     "edit_group": "Edit Group",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -85,7 +85,8 @@
     "shared": "Partagé",
     "shared-accounts": "Comptes que l'on m'a partagé",
     "type": "Type",
-    "manage-accounts": "Gérer mes comptes"
+    "manage-accounts": "Gérer mes comptes",
+    "owner": "Titulaire"
   },
 
   "Balance": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -57,7 +57,19 @@
       "confirm": "Confirmer la suppression",
       "title": "Êtes-vous sûr ?"
     },
-    "deletion_error": "Une erreur est survenue lors de la suppression du compte."
+    "deletion_error": "Une erreur est survenue lors de la suppression du compte.",
+    "label": "Libellé",
+    "owner": "Titulaire",
+    "addOwnerBtn": "Ajouter un titulaire",
+    "removeOwnerBtn": "Supprimer ce titulaire",
+    "ownerPlaceholder": "Sélectionner un titulaire",
+    "bank": "Banque",
+    "number": "Numéro",
+    "type": "Type",
+    "apply": "Appliquer",
+    "success": "Compte mis à jour avec succès",
+    "failure": "Erreur lors de la mise à jour du compte",
+    "removeAccountBtn": "Effacer le compte"
   },
 
   "Accounts": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -69,7 +69,10 @@
     "apply": "Appliquer",
     "success": "Compte mis à jour avec succès",
     "failure": "Erreur lors de la mise à jour du compte",
-    "removeAccountBtn": "Effacer le compte"
+    "removeAccountBtn": "Effacer le compte",
+    "listPlaceholder": "Rechercher un contact",
+    "listEmptyMessage": "Aucun contact trouvé",
+    "addContactLabel": "Créer un contact"
   },
 
   "Accounts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,13 +4541,13 @@ cozy-client-js@^0.15.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-7.10.0.tgz#79f61e500132ae99fb2aab960a0700270204e355"
-  integrity sha512-H9fLh/Inyjsj47gQwASVXnmExeKXQmn2WPDLHjFw3v2Zd21SNGYnmLkmnAvE9HGcudkJeqX++w55Vht0zQOCiA==
+cozy-client@7.14.0:
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-7.14.0.tgz#ecf9c8d599595d4c4104254b5930814b3c48b47b"
+  integrity sha512-eOraWKoXBEkovddfJL/fDD7aUxphlaDD1gvgWLz0qAMY5PL28uQMsrtqDIdAtjQdCG0zqo8wOngzlSIxgvi6Uw==
   dependencies:
     cozy-device-helper "^1.7.3"
-    cozy-stack-client "^7.8.0"
+    cozy-stack-client "^7.12.0"
     lodash "^4.17.13"
     microee "^0.0.6"
     prop-types "^15.6.2"
@@ -4806,7 +4806,7 @@ cozy-realtime@3.2.1:
   dependencies:
     minilog "3.1.0"
 
-cozy-stack-client@7.8.0, cozy-stack-client@^7.8.0:
+cozy-stack-client@7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-7.8.0.tgz#357d22e1b1658540ca71650c1821835ce25163c1"
   integrity sha512-yP9/Aw/QkocnzbnPygTiKT3uYPuyN+DkSXK1YqFVSwZYbJr8L1XsTqw4GaiHo4a5DXSbwN9Sxt+p0qGZKZFQVA==
@@ -4828,6 +4828,15 @@ cozy-stack-client@^6.65.0:
   version "6.65.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-6.65.0.tgz#bd6cdeef0c8031b71203361f8d1d865cab2f5aeb"
   integrity sha512-VqUhx5PNA6j5qraccSBVP4A5s6tBFnaJ/taglpAgH4R+4DnK/zTxch4sMPa01cI5iMWGxbD00jpFlBd7kK6OIw==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-7.12.0.tgz#9a5df9fa77730d04cf1a31c1e5db9c931c8db94d"
+  integrity sha512-ld0/Hm4F9HGjGESEg/QbO71cRFslprxo4EZ4bWKhm5gi1iMeUnOBeDHSTI36iI+xs4ouZTvf9KxTcnkchKG8Cw==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4867,10 +4867,10 @@ cozy-ui@24.3.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@27.12.0:
-  version "27.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-27.12.0.tgz#b71dd6c26f1e609f17008df06360de6485e53f15"
-  integrity sha512-jcYQFzVj4gG2QMpIVu7QKXme2zdddYv2cVFqg5o9tA+Z9kbGp3FrYKq1pO7UuyfuqAqCCmLl+/kR5LX/zYF/1Q==
+cozy-ui@28.3.0:
+  version "28.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.3.0.tgz#ae786570b41dd0e01b658b516303baab6a84ef4c"
+  integrity sha512-fDAVvhWLuDnWV4lopFpMDfPqeOHQC3V/8Jg+9khnzmGCFVu0YVxMF0AfPfjtMXZfe7CxnTrg2NFZ2ZdFdvMM6A==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
This adds all features around the bank accounts owners.

On the home page, we show the owners if there are more than 1 differents unique owners accross all bank acounts. On desktop, we add a column on each row. On mobile, I had to update a little the DOM structure because vertical alignment between columns depends on the presence of owners (see screenshots below). (this is behind the `balance.show-owners` flag. It is also possible to use the `balance.force-show-owners` flag to force owners rendering, even if there is only one unique owners).

On the accounts list parameters page, we want to show the owners on each line. (this is behind the `settings.show-accounts-owners` flag).

On the account parameters page, we show a completely new component (behind the `settings.new-account-details-page` flag).