### PR TITLE
refactor: Remove reimbursement late flag

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,10 +22,6 @@ const ReactHint = ReactHintFactory(React)
 const App = props => {
   const settings = getDefaultedSettingsFromCollection(props.settingsCollection)
   flag('local-model-override', settings.community.localModelOverride.enabled)
-  flag(
-    'reimbursements.late-health-limit',
-    settings.notifications.lateHealthReimbursement.value
-  )
 
   return (
     <Layout>

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -116,9 +116,16 @@ describe('GroupPanel', () => {
 })
 
 describe('Reimbursement virtual group styling', () => {
+  // We need a different date for each test otherwise selectors are not
+  // recomputed since queryCreateSelector bases its memoization on
+  // the lastUpdate of the query
+  const mockedDate = +new Date('2020-01-31T00:00')
+  let i = 0
   beforeEach(() => {
-    MockDate.set('2020-01-31T00:00')
+    MockDate.set(mockedDate + i++)
+    getClient.mockReturnValue(client)
   })
+
   const setup = ({
     lateHealthReimbursementNotificationSetting,
     transactions

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -15,6 +15,7 @@ import ExpansionPanel from '@material-ui/core/ExpansionPanel'
 import { createClientWithData } from 'test/client'
 import { TRANSACTION_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 import getClient from 'selectors/getClient'
+import MockDate from 'mockdate'
 
 jest.mock('components/AccountIcon', () => () => null)
 jest.mock('selectors/getClient')
@@ -113,7 +114,13 @@ describe('GroupPanel', () => {
 })
 
 describe('Reimbursement virtual group styling', () => {
-  const setup = ({ lateHealthReimbursementEnabled, transactions }) => {
+  beforeEach(() => {
+    MockDate.set('2020-01-31T00:00')
+  })
+  const setup = ({
+    lateHealthReimbursementNotificationSetting,
+    transactions
+  }) => {
     const client = createClientWithData({
       queries: {
         transactions: {
@@ -126,9 +133,7 @@ describe('Reimbursement virtual group styling', () => {
             {
               _id: 'settings-1234',
               notifications: {
-                lateHealthReimbursement: {
-                  enabled: lateHealthReimbursementEnabled
-                }
+                lateHealthReimbursement: lateHealthReimbursementNotificationSetting
               }
             }
           ]
@@ -151,10 +156,15 @@ describe('Reimbursement virtual group styling', () => {
     _id: 'Reimbursements'
   }
 
+  const lateHealthReimbursementNotificationSetting = {
+    enabled: true,
+    value: 30
+  }
+
   it('should have specific style if late reimbursements are present and setting is enabled', () => {
     const { state } = setup({
       transactions: [healthExpense],
-      lateHealthReimbursementEnabled: true
+      lateHealthReimbursementNotificationSetting
     })
     expect(
       getGroupPanelSummaryClasses(virtualReimbursementGroup, state)
@@ -167,7 +177,7 @@ describe('Reimbursement virtual group styling', () => {
     const healthCredit = { ...healthExpense, amount: 10 }
     const { state } = setup({
       transactions: [healthCredit],
-      lateHealthReimbursementEnabled: true
+      lateHealthReimbursementNotificationSetting
     })
     expect(
       getGroupPanelSummaryClasses(virtualReimbursementGroup, state)
@@ -177,7 +187,10 @@ describe('Reimbursement virtual group styling', () => {
   it('should not have specific style if setting not enabled', () => {
     const { state } = setup({
       transactions: [healthExpense],
-      lateHealthReimbursementEnabled: false
+      lateHealthReimbursementNotificationSetting: {
+        ...lateHealthReimbursementNotificationSetting,
+        enabled: false
+      }
     })
     expect(
       getGroupPanelSummaryClasses(virtualReimbursementGroup, state)
@@ -187,7 +200,19 @@ describe('Reimbursement virtual group styling', () => {
   it('should not have specific style if not virtual reimbursement group', () => {
     const { state } = setup({
       transactions: [healthExpense],
-      lateHealthReimbursementEnabled: false
+      lateHealthReimbursementNotificationSetting
+    })
+    const normalGroup = {
+      _id: 'deadbeef',
+      accounts: []
+    }
+    expect(getGroupPanelSummaryClasses(normalGroup, state)).toBeFalsy()
+  })
+
+  it('should not have specific style if not virtual reimbursement group', () => {
+    const { state } = setup({
+      transactions: [healthExpense],
+      lateHealthReimbursementNotificationSetting
     })
     const normalGroup = {
       _id: 'deadbeef',

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -26,20 +26,22 @@ const addType = data => {
   })
 }
 
-describe('GroupPanel', () => {
-  const rawGroup = data['io.cozy.bank.groups'][0]
-  let root, client, group, onChange, switches
+const rawGroup = data['io.cozy.bank.groups'][0]
+let client, group
 
-  beforeAll(() => {
-    client = new CozyClient({
-      schema
-    })
-    getClient.mockReturnValue(client)
-    client.setData(addType(data))
-    group = client.hydrateDocument(
-      client.getDocumentFromState('io.cozy.bank.groups', rawGroup._id)
-    )
+beforeAll(() => {
+  client = new CozyClient({
+    schema
   })
+  getClient.mockReturnValue(client)
+  client.setData(addType(data))
+  group = client.hydrateDocument(
+    client.getDocumentFromState('io.cozy.bank.groups', rawGroup._id)
+  )
+})
+
+describe('GroupPanel', () => {
+  let root, onChange, switches
 
   const fakeRouter = {
     push: jest.fn(),

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -114,7 +114,7 @@ class LateHealthReimbursement extends NotificationView {
     const healthExpensesById = keyBy(healthExpenses, h => h._id)
 
     const lateReimbursements = enhancedHealthExpenses
-      .filter(isReimbursementLate)
+      .filter(tr => isReimbursementLate(tr, this.interval))
       .map(t => healthExpensesById[t._id])
 
     log('info', `${lateReimbursements.length} are late health reimbursements`)
@@ -135,7 +135,6 @@ class LateHealthReimbursement extends NotificationView {
     const accountIds = uniq(
       transactions.map(transaction => transaction.account)
     )
-
     return BankAccount.getAll(accountIds)
   }
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.spec.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.spec.js
@@ -44,23 +44,36 @@ describe('LateHealthReimbursement', () => {
   it('should fetch data', async () => {
     jest.spyOn(Transaction, 'queryAll').mockResolvedValue([
       {
+        _id: 't1',
         amount: 20,
         date: '2018-09-16T12:00',
         label: '1',
         account: 'accountId1'
       },
       {
+        _id: 't2',
         amount: 10,
         date: '2018-09-17T12:00',
         label: '2',
         account: 'accountId2'
       },
       {
+        _id: 't3',
         amount: -5,
         date: '2018-09-18T12:00',
         label: '3',
         manualCategoryId: '400610',
         account: 'accountId3',
+        reimbursements: [{ billId: 'io.cozy.bills:billId12345' }]
+      },
+      {
+        _id: 't4',
+        amount: -15,
+        // will never be late since the date is now
+        date: new Date().toISOString(),
+        label: '3',
+        manualCategoryId: '400610',
+        account: 'accountId5',
         reimbursements: [{ billId: 'io.cozy.bills:billId12345' }]
       }
     ])
@@ -74,9 +87,13 @@ describe('LateHealthReimbursement', () => {
     const { notification } = setup({ lang: 'en' })
 
     const res = await notification.fetchData()
+
     expect(Bill.getAll).toHaveBeenCalledWith(['billId12345'])
     expect(BankAccount.getAll).toHaveBeenCalledWith(['accountId3'])
     expect(res.transactions).toHaveLength(1)
+    expect(res.transactions[0]).toMatchObject({
+      account: 'accountId3'
+    })
     expect(res.accounts).toHaveLength(1)
   })
 })

--- a/src/ducks/reimbursements/selectors.js
+++ b/src/ducks/reimbursements/selectors.js
@@ -7,6 +7,8 @@ import {
   isReimbursementLate,
   getReimbursementStatus
 } from 'ducks/transactions/helpers'
+import { getHealthReimbursementLateLimit } from 'ducks/settings/helpers'
+import { getSettings } from 'ducks/settings/selectors'
 
 const groupHealthExpenses = healthExpenses => {
   const reimbursementTagFlag = flag('reimbursements.tag')
@@ -42,8 +44,17 @@ export const getGroupedHealthExpenses = createSelector(
   groupHealthExpenses
 )
 
+export const getHealthReimbursementLateLimitSelector = createSelector(
+  [getSettings],
+  settings => {
+    return getHealthReimbursementLateLimit(settings)
+  }
+)
+
 export const getLateHealthExpenses = createSelector(
-  [getGroupedHealthExpenses],
-  groupedHealthExpenses =>
-    groupedHealthExpenses.pending.filter(isReimbursementLate)
+  [getGroupedHealthExpenses, getHealthReimbursementLateLimitSelector],
+  (groupedHealthExpenses, healthReimbursementLateLimit) =>
+    groupedHealthExpenses.pending.filter(tr =>
+      isReimbursementLate(tr, healthReimbursementLateLimit)
+    )
 )

--- a/src/ducks/reimbursements/selectors.spec.js
+++ b/src/ducks/reimbursements/selectors.spec.js
@@ -1,0 +1,35 @@
+import { getHealthReimbursementLateLimitSelector } from './selectors'
+
+describe('getHealthReimbursementLateLimitSelector', () => {
+  describe('when it is not configured', () => {
+    it('should return the health reimbursement late limit by default', () => {
+      const state = {}
+      const v = getHealthReimbursementLateLimitSelector(state)
+      expect(v).toBe(30)
+    })
+  })
+
+  describe('when it is configured', () => {
+    it('should return the health reimbursement late limit', () => {
+      const state = {
+        cozy: {
+          queries: {
+            settings: {
+              data: [
+                {
+                  notifications: {
+                    lateHealthReimbursement: {
+                      value: 10
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+      const v = getHealthReimbursementLateLimitSelector(state)
+      expect(v).toBe(10)
+    })
+  })
+})

--- a/src/ducks/settings/helpers.js
+++ b/src/ducks/settings/helpers.js
@@ -63,6 +63,19 @@ export const getNotificationFromSettings = (settings, name) => {
   return get(configurationSettings, ['notifications', name])
 }
 
+export const DEFAULT_HEALTH_REIMBURSEMENTS_LATE_LIMIT_IN_DAYS = 30
+
+export const getHealthReimbursementLateLimit = settings => {
+  const lateNotification = getNotificationFromSettings(
+    settings,
+    'lateHealthReimbursement'
+  )
+  return (
+    (lateNotification && lateNotification.value) ||
+    DEFAULT_HEALTH_REIMBURSEMENTS_LATE_LIMIT_IN_DAYS
+  )
+}
+
 export const fetchCategoryAlerts = async client => {
   try {
     const settings = await fetchSettings(client)

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
@@ -18,8 +18,7 @@ import cx from 'classnames'
 import { translate } from 'cozy-ui/react'
 import { flowRight as compose } from 'lodash'
 import { withMutations } from 'cozy-client'
-import { getSettings } from 'ducks/settings/selectors'
-import { getHealthReimbursementLateLimit } from 'ducks/settings/helpers'
+import { getHealthReimbursementLateLimitSelector } from 'ducks/reimbursements/selectors'
 
 export class DumbReimbursementStatusAction extends React.PureComponent {
   state = {
@@ -123,12 +122,9 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
 const ReimbursementStatusAction = compose(
   translate(),
   withMutations(),
-  connect(state => {
-    const settings = getSettings(state)
-    return {
-      healthReimbursementLateLimit: getHealthReimbursementLateLimit(settings)
-    }
-  })
+  connect(state => ({
+    healthReimbursementLateLimit: getHealthReimbursementLateLimitSelector(state)
+  }))
 )(DumbReimbursementStatusAction)
 
 export default ReimbursementStatusAction

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { connect } from 'react-redux'
 import Icon from 'cozy-ui/react/Icon'
 import Chip from 'cozy-ui/react/Chip'
 import Alerter from 'cozy-ui/react/Alerter'
@@ -17,6 +18,8 @@ import cx from 'classnames'
 import { translate } from 'cozy-ui/react'
 import { flowRight as compose } from 'lodash'
 import { withMutations } from 'cozy-client'
+import { getSettings } from 'ducks/settings/selectors'
+import { getHealthReimbursementLateLimit } from 'ducks/settings/helpers'
 
 export class DumbReimbursementStatusAction extends React.PureComponent {
   state = {
@@ -41,10 +44,13 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
   }
 
   renderModalItem() {
-    const { t, transaction } = this.props
+    const { t, transaction, healthReimbursementLateLimit } = this.props
 
     const status = getReimbursementStatus(transaction)
-    const isLate = isReimbursementLate(transaction)
+    const isLate = isReimbursementLate(
+      transaction,
+      healthReimbursementLateLimit
+    )
     const translateKey = isLate ? 'late' : status
     const label = t(`Transactions.actions.reimbursementStatus.${translateKey}`)
 
@@ -60,10 +66,13 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
   }
 
   renderTransactionRow() {
-    const { transaction, t } = this.props
+    const { transaction, t, healthReimbursementLateLimit } = this.props
 
     const status = getReimbursementStatus(transaction)
-    const isLate = isReimbursementLate(transaction)
+    const isLate = isReimbursementLate(
+      transaction,
+      healthReimbursementLateLimit
+    )
 
     if (status === REIMBURSEMENTS_STATUS.noReimbursement) {
       return null
@@ -113,7 +122,13 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
 
 const ReimbursementStatusAction = compose(
   translate(),
-  withMutations()
+  withMutations(),
+  connect(state => {
+    const settings = getSettings(state)
+    return {
+      healthReimbursementLateLimit: getHealthReimbursementLateLimit(settings)
+    }
+  })
 )(DumbReimbursementStatusAction)
 
 export default ReimbursementStatusAction

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -183,7 +183,7 @@ export const getHealthExpenseReimbursementStatus = transaction => {
     : REIMBURSEMENTS_STATUS.pending
 }
 
-export const isReimbursementLate = transaction => {
+export const isReimbursementLate = (transaction, lateLimitInDays) => {
   if (!isHealthExpense(transaction)) {
     return false
   }
@@ -197,10 +197,7 @@ export const isReimbursementLate = transaction => {
   const transactionDate = parseDate(getDate(transaction))
   const today = new Date()
 
-  return (
-    differenceInDays(today, transactionDate) >
-    flag('reimbursements.late-health-limit')
-  )
+  return differenceInDays(today, transactionDate) > lateLimitInDays
 }
 
 export const hasPendingReimbursement = transaction => {

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -14,7 +14,6 @@ import {
 } from './helpers'
 import { BILLS_DOCTYPE, TRANSACTION_DOCTYPE, schema } from 'doctypes'
 import MockDate from 'mockdate'
-import flag from 'cozy-flags'
 import CozyClient from 'cozy-client'
 import { createClientWithData } from 'test/client'
 
@@ -196,10 +195,6 @@ describe('getReimbursementStatus', () => {
 })
 
 describe('isReimbursementLate', () => {
-  beforeEach(() => {
-    flag('reimbursements.late-health-limit', 30)
-  })
-
   afterEach(() => {
     MockDate.reset()
   })
@@ -209,7 +204,7 @@ describe('isReimbursementLate', () => {
       amount: 10
     }
 
-    expect(isReimbursementLate(transaction)).toBe(false)
+    expect(isReimbursementLate(transaction, 30)).toBe(false)
   })
 
   it('should return false if the transaction reimbursement status is not pending', () => {
@@ -224,8 +219,8 @@ describe('isReimbursementLate', () => {
       amount: -10
     }
 
-    expect(isReimbursementLate(t1)).toBe(false)
-    expect(isReimbursementLate(t2)).toBe(false)
+    expect(isReimbursementLate(t1, 30)).toBe(false)
+    expect(isReimbursementLate(t2, 30)).toBe(false)
   })
 
   it('should return false if the transaction reimbursement is pending but for less than one month', () => {
@@ -238,7 +233,7 @@ describe('isReimbursementLate', () => {
       amount: -10
     }
 
-    expect(isReimbursementLate(transaction)).toBe(false)
+    expect(isReimbursementLate(transaction, 30)).toBe(false)
   })
 
   it('should return true if the transaction reimbursement is pending for more than one month', () => {
@@ -251,7 +246,7 @@ describe('isReimbursementLate', () => {
       amount: -10
     }
 
-    expect(isReimbursementLate(transaction)).toBe(true)
+    expect(isReimbursementLate(transaction, 30)).toBe(true)
   })
 })
 


### PR DESCRIPTION
The setting for health reimbursements late limit was "transferred" to flags
   at app initialization. This was a shortcut/hack to easily get the late
   limit in helpers. Now that we can more easily use selectors, it's better to
   use them since they will refresh if the value is changed