### PR TITLE
Release 1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-banks",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "main": "src/main.jsx",
   "scripts": {
     "build": "npm run build:browser && npm run build:services",

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
@@ -101,7 +101,7 @@ const CategoryAlertCard = ({ removeAlert, updateAlert, alert, t }) => {
                 {t(
                   alert.accountOrGroup._type === ACCOUNT_DOCTYPE
                     ? 'Settings.budget-category-alerts.for-account'
-                    : 'Settings.budget-category-alerts.for-groups',
+                    : 'Settings.budget-category-alerts.for-group',
                   {
                     threshold: alert.maxThreshold
                   }

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
@@ -1,0 +1,46 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import AppLike from 'test/AppLike'
+import { createClientWithData } from 'test/client'
+import CategoryAlertCard from './CategoryAlertCard'
+import getClient from 'selectors/getClient'
+import { GROUP_DOCTYPE } from 'doctypes'
+
+jest.mock('selectors/getClient', () => jest.fn())
+
+describe('category alert card', () => {
+  it('should correctly render with group', () => {
+    const alert = {
+      categoryId: '400610',
+      maxThreshold: 100,
+      accountOrGroup: {
+        _type: GROUP_DOCTYPE,
+        _id: 'group1337'
+      }
+    }
+    const client = createClientWithData({
+      queries: {
+        groups: {
+          doctype: GROUP_DOCTYPE,
+          data: [
+            { _id: 'group1337', _type: GROUP_DOCTYPE, label: 'My Accounts' }
+          ]
+        }
+      }
+    })
+
+    getClient.mockReturnValue(client)
+    const root = mount(
+      <AppLike client={client} store={client.store}>
+        <CategoryAlertCard
+          alert={alert}
+          updateAlert={jest.fn()}
+          removeAlert={jest.fn()}
+        />
+      </AppLike>
+    )
+    expect(root.text()).toBe(
+      'Monthly budget of 100€in Health expensesfor group My Accounts'
+    )
+  })
+})

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -127,6 +127,15 @@ const TransactionApplicationDateEditorSlide = translate()(
   }
 )
 
+const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
+  const date = getApplicationDate(transaction) || getDate(transaction)
+  Alerter.success(
+    t('Transactions.infos.applicationDateChangedAlert', {
+      applicationDate: f(date, 'MMMM')
+    })
+  )
+}
+
 /**
  * Show information of the transaction
  */
@@ -154,13 +163,8 @@ const TransactionModalInfoContent = withTransaction(props => {
   const [applicationDateBusy, setApplicationDateBusy] = useState(false)
 
   const handleAfterUpdateApplicationDate = updatedTransaction => {
-    const applicationDate = getApplicationDate(updatedTransaction)
     setApplicationDateBusy(false)
-    Alerter.success(
-      t('Transactions.infos.applicationDateChangedAlert', {
-        applicationDate: f(applicationDate, 'MMMM')
-      })
-    )
+    showAlertAfterApplicationDateUpdate(updatedTransaction, t, f)
   }
 
   const handleShowApplicationEditor = ev => {
@@ -184,11 +188,7 @@ const TransactionModalInfoContent = withTransaction(props => {
         transaction,
         null
       )
-      Alerter.success(
-        t('Transactions.infos.applicationDateChangedAlert', {
-          applicationDate: f(getDate(newTransaction), 'MMMM')
-        })
-      )
+      showAlertAfterApplicationDateUpdate(newTransaction, t, f)
     } finally {
       setApplicationDateBusy(false)
     }

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -127,7 +127,7 @@ const TransactionApplicationDateEditorSlide = translate()(
   }
 )
 
-const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
+export const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
   const date = getApplicationDate(transaction) || getDate(transaction)
   Alerter.success(
     t('Transactions.infos.applicationDateChangedAlert', {

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -1,12 +1,23 @@
 /* global mount */
 
 import React from 'react'
-import { DumbTransactionModal as TransactionModal } from './TransactionModal'
+import {
+  DumbTransactionModal as TransactionModal,
+  showAlertAfterApplicationDateUpdate
+} from './TransactionModal'
 import data from '../../../test/fixtures'
 import AppLike from 'test/AppLike'
 import pretty from 'pretty'
 import { createClientWithData } from 'test/client'
 import { ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
+import Alerter from 'cozy-ui/react/Alerter'
+import { format } from 'date-fns'
+import Polyglot from 'node-polyglot'
+import en from 'locales/en.json'
+
+jest.mock('cozy-ui/react/Alerter', () => ({
+  success: jest.fn()
+}))
 
 describe('transaction modal', () => {
   let client
@@ -37,5 +48,42 @@ describe('transaction modal', () => {
       </AppLike>
     )
     expect(pretty(root.html())).toMatchSnapshot()
+  })
+})
+
+describe('change application date alert', () => {
+  const p = new Polyglot()
+  p.extend(en)
+  const t = p.t.bind(p)
+
+  beforeEach(() => {
+    Alerter.success.mockReset()
+  })
+
+  it('should output the correct message', () => {
+    showAlertAfterApplicationDateUpdate(
+      {
+        date: '2019-09-09T12:00'
+      },
+      t,
+      format
+    )
+    expect(Alerter.success).toHaveBeenCalledWith(
+      'Operation assigned to September in the analysis tab'
+    )
+  })
+
+  it('should output the correct message', () => {
+    showAlertAfterApplicationDateUpdate(
+      {
+        date: '2019-09-09T12:00',
+        applicationDate: '2019-08'
+      },
+      t,
+      format
+    )
+    expect(Alerter.success).toHaveBeenCalledWith(
+      'Operation assigned to August in the analysis tab'
+    )
   })
 })

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" android-packageName="io.cozy.banks.mobile" android-versionCode="1060301" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.6.3.1" version="1.6.3">
+<widget xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0" android-packageName="io.cozy.banks.mobile" android-versionCode="1080000" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.8.0.0" version="1.8.0">
   <name>Cozy Banks</name>
   <description>The banking application for Cozy</description>
   <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -15,7 +15,7 @@ export const TestI18n = ({ children }) => {
 }
 
 const AppLike = ({ children, store, client }) => (
-  <Provider store={store}>
+  <Provider store={store || (client && client.store)}>
     <CozyProvider client={client || getClient()}>
       <TestI18n>{children}</TestI18n>
     </CozyProvider>


### PR DESCRIPTION
- [x] Create branch and the PR with the following content
- [x] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode`, `ios-CFBundleVersion` and `AppendUserAgent`.
- [ ] Write changelogs
  - [ ] Android: `src/targets/mobile/fastlane/metadata/android/{lang}/changelogs/ANDROID_VERSION.txt` (⚠️ ANDROID_VERSION should match `android-versionCode` in `config.xml`)
  - [ ] iOS : `src/targets/mobile/fastlane/metadata/ios/{lang}/release_notes.txt`
- [ ] Update metadata and screenshots
- [x] Commit and tag with a beta tag (X.Y.Z-beta.M)
- [x] Push the tag and wait for the CI to push the beta version to the registry
- [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)
- [ ] Release the app on Testflight for iOS. `yarn ios:publish`
- [ ] Release the app on Play Store on `beta` track. `yarn android:publish`
- [ ] Upload the APK (`src/targets/mobile/build/android/cozy-banks.apk`) on [the APK card in Trello](https://trello.com/c/wtToK7IN/1192-apks)
- [ ] Test well on the 3 platforms
- [ ] Tag the branch as prod (X.Y.Z)
- [ ] Push the tag, wait for the CI to push the build to the registry
- [ ] [Promote Android app][playstore] to the production track
- [ ] [Promote iOS app][itunesconnect] to the production track.

<details>
<summary>How to check CI</summary>
In Travis <a href="https://travis-ci.org/cozy/cozy-banks/builds/">logs</a>, you should see

```
Attempting to publish banks (version 0.7.6-beta.0) from https://downcloud.cozycloud.cc/upload/cozy-banks/0.7.6-8f932d80f510e1942fa09865ce3526c166b00b0e/cozy-banks.tar.gz (sha256 dd42d7b55ff3992893cc2432f23a813ded6b6766a880bdf24184d35060150fe7) to https://apps-registry.cozycloud.cc (space: banks)
Application published!
```
To check that the registry has the right version:

```curl "https://apps-registry.cozycloud.cc/banks/registry/banks" | jq '.'```
</details>

<details>
<summary>How to update a Cozy on the beta version of the registry</summary>

```
cozy-stack apps update banks registry://banks/beta --domain drazik2.mycozy.cloud
```

</details>

<details>
<summary>How to deploy on Testflight</summary>

```
yarn ios:publish
```

</details>

<details>
<summary>Managing versions</summary>

#### How to bump versions

At the **start** of the release process

1. Bump the `version` number in `package.json` and `config.xml` according to semver.
2. Copy this version to the `ios-CFBundleVersion` attribute and add a fourth number `.1` (then `.2` for the next beta version etc..)
3. For `android-versionCode`, follow this formula `beta + patch*100 + minor * 10000 + major * 1000000`.
4. Update the version number for the `AppendUserAgent` preference in `config.xml`.

At the **end** of the release process

For iOS you can simply remove the suffix and rebuild/reupload.
For Android, you have nothing to do, and can simply promote the build to the production track.

#### Why not let Cordova manage this automatically ?

The difficulty is that for stores (both PlayStore and iTunesConnect), you cannot have build with the same versionCode (for
Android) or ios-CFBundleVersion (for iOS). Normally those two numbers are managed by Cordova automatically (computed from the `version` attribute) but this
does not work well if during the release process (after having pushed a beta build in Testflight/PlayStore), you want to put a new version (because you have detected bug). If you let Cordova manage this, you would have to change the `version` from your config.xml and your `package.json`, and your production users would see a jump of version.

#### Android versionCode

The android-versionCode has to be a integer. But it has to be related to the `versionName` for debugging/understand purposes. Cordova does patch + minor *100 + major * 10000 but it does not leave space for beta versions (that have the same `versionName`). This is why we go one step further : `beta + patch *100 + minor * 10000 * major * 1000000). 0.7.6-beta1 is then `700601`. This number is not visible to the users, it's `android-versionName` that is visible and it's copied from `version` automatically Cordova.

#### ios-CFBundleVersion

For iOS, this is a little bit better since `ios-CFBundleVersion` can be a string with a fourth number at the end. Add a fourth number `.1` (and then `.2`, `.3` etc..) to your version number while developing, until you are sure that the build is completely ready. Then you can remove the suffix and `ios-CFBundleVersion` will be the same as `version`.

Cordova doc : https://cordova.apache.org/docs/fr/latest/config_ref/
iOS doc : https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364
Android doc : https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes
</details>

[playstore]: https://play.google.com/apps/publish/?pli=1&account=7424624102327137158#ManageReleasesPlace:p=io.cozy.banks.mobile&appid=4975496102553953948
[itunesconnect]: https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/1349814380