### PR TITLE
chore: Remove unused tasks from release PR

### DIFF
--- a/scripts/release-pr-template.txt
+++ b/scripts/release-pr-template.txt
@@ -2,10 +2,6 @@ Release $VERSION
 
 - [ ] Create branch and the PR with the following content
 - [ ] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode`, `ios-CFBundleVersion` and `AppendUserAgent`.
-- [ ] Write changelogs
-  - [ ] Android: `src/targets/mobile/fastlane/metadata/android/{lang}/changelogs/ANDROID_VERSION.txt` (⚠️ ANDROID_VERSION should match `android-versionCode` in `config.xml`)
-  - [ ] iOS : `src/targets/mobile/fastlane/metadata/ios/{lang}/release_notes.txt`
-- [ ] Update metadata and screenshots
 - [ ] Commit and tag with a beta tag (X.Y.Z-beta.M)
 - [ ] Push the tag and wait for the CI to push the beta version to the registry
 - [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)


### PR DESCRIPTION
Removed unused tasks from PR (flo does the tasks directly on the Play Store
and Itunes Connect)