### PR TITLE
Backported fixes from release 1.8.0

### DIFF
--- a/scripts/release-pr-template.txt
+++ b/scripts/release-pr-template.txt
@@ -2,10 +2,6 @@ Release $VERSION
 
 - [ ] Create branch and the PR with the following content
 - [ ] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode`, `ios-CFBundleVersion` and `AppendUserAgent`.
-- [ ] Write changelogs
-  - [ ] Android: `src/targets/mobile/fastlane/metadata/android/{lang}/changelogs/ANDROID_VERSION.txt` (⚠️ ANDROID_VERSION should match `android-versionCode` in `config.xml`)
-  - [ ] iOS : `src/targets/mobile/fastlane/metadata/ios/{lang}/release_notes.txt`
-- [ ] Update metadata and screenshots
 - [ ] Commit and tag with a beta tag (X.Y.Z-beta.M)
 - [ ] Push the tag and wait for the CI to push the beta version to the registry
 - [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.jsx
@@ -101,7 +101,7 @@ const CategoryAlertCard = ({ removeAlert, updateAlert, alert, t }) => {
                 {t(
                   alert.accountOrGroup._type === ACCOUNT_DOCTYPE
                     ? 'Settings.budget-category-alerts.for-account'
-                    : 'Settings.budget-category-alerts.for-groups',
+                    : 'Settings.budget-category-alerts.for-group',
                   {
                     threshold: alert.maxThreshold
                   }

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
@@ -1,0 +1,46 @@
+import { mount } from 'enzyme'
+import React from 'react'
+import AppLike from 'test/AppLike'
+import { createClientWithData } from 'test/client'
+import CategoryAlertCard from './CategoryAlertCard'
+import getClient from 'selectors/getClient'
+import { GROUP_DOCTYPE } from 'doctypes'
+
+jest.mock('selectors/getClient', () => jest.fn())
+
+describe('category alert card', () => {
+  it('should correctly render with group', () => {
+    const alert = {
+      categoryId: '400610',
+      maxThreshold: 100,
+      accountOrGroup: {
+        _type: GROUP_DOCTYPE,
+        _id: 'group1337'
+      }
+    }
+    const client = createClientWithData({
+      queries: {
+        groups: {
+          doctype: GROUP_DOCTYPE,
+          data: [
+            { _id: 'group1337', _type: GROUP_DOCTYPE, label: 'My Accounts' }
+          ]
+        }
+      }
+    })
+
+    getClient.mockReturnValue(client)
+    const root = mount(
+      <AppLike client={client} store={client.store}>
+        <CategoryAlertCard
+          alert={alert}
+          updateAlert={jest.fn()}
+          removeAlert={jest.fn()}
+        />
+      </AppLike>
+    )
+    expect(root.text()).toBe(
+      'Monthly budget of 100€in Health expensesfor group My Accounts'
+    )
+  })
+})

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -127,6 +127,15 @@ const TransactionApplicationDateEditorSlide = translate()(
   }
 )
 
+const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
+  const date = getApplicationDate(transaction) || getDate(transaction)
+  Alerter.success(
+    t('Transactions.infos.applicationDateChangedAlert', {
+      applicationDate: f(date, 'MMMM')
+    })
+  )
+}
+
 /**
  * Show information of the transaction
  */
@@ -154,13 +163,8 @@ const TransactionModalInfoContent = withTransaction(props => {
   const [applicationDateBusy, setApplicationDateBusy] = useState(false)
 
   const handleAfterUpdateApplicationDate = updatedTransaction => {
-    const applicationDate = getApplicationDate(updatedTransaction)
     setApplicationDateBusy(false)
-    Alerter.success(
-      t('Transactions.infos.applicationDateChangedAlert', {
-        applicationDate: f(applicationDate, 'MMMM')
-      })
-    )
+    showAlertAfterApplicationDateUpdate(updatedTransaction, t, f)
   }
 
   const handleShowApplicationEditor = ev => {
@@ -184,11 +188,7 @@ const TransactionModalInfoContent = withTransaction(props => {
         transaction,
         null
       )
-      Alerter.success(
-        t('Transactions.infos.applicationDateChangedAlert', {
-          applicationDate: f(getDate(newTransaction), 'MMMM')
-        })
-      )
+      showAlertAfterApplicationDateUpdate(newTransaction, t, f)
     } finally {
       setApplicationDateBusy(false)
     }

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -127,7 +127,7 @@ const TransactionApplicationDateEditorSlide = translate()(
   }
 )
 
-const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
+export const showAlertAfterApplicationDateUpdate = (transaction, t, f) => {
   const date = getApplicationDate(transaction) || getDate(transaction)
   Alerter.success(
     t('Transactions.infos.applicationDateChangedAlert', {

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -1,12 +1,23 @@
 /* global mount */
 
 import React from 'react'
-import { DumbTransactionModal as TransactionModal } from './TransactionModal'
+import {
+  DumbTransactionModal as TransactionModal,
+  showAlertAfterApplicationDateUpdate
+} from './TransactionModal'
 import data from '../../../test/fixtures'
 import AppLike from 'test/AppLike'
 import pretty from 'pretty'
 import { createClientWithData } from 'test/client'
 import { ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
+import Alerter from 'cozy-ui/react/Alerter'
+import { format } from 'date-fns'
+import Polyglot from 'node-polyglot'
+import en from 'locales/en.json'
+
+jest.mock('cozy-ui/react/Alerter', () => ({
+  success: jest.fn()
+}))
 
 describe('transaction modal', () => {
   let client
@@ -37,5 +48,42 @@ describe('transaction modal', () => {
       </AppLike>
     )
     expect(pretty(root.html())).toMatchSnapshot()
+  })
+})
+
+describe('change application date alert', () => {
+  const p = new Polyglot()
+  p.extend(en)
+  const t = p.t.bind(p)
+
+  beforeEach(() => {
+    Alerter.success.mockReset()
+  })
+
+  it('should output the correct message', () => {
+    showAlertAfterApplicationDateUpdate(
+      {
+        date: '2019-09-09T12:00'
+      },
+      t,
+      format
+    )
+    expect(Alerter.success).toHaveBeenCalledWith(
+      'Operation assigned to September in the analysis tab'
+    )
+  })
+
+  it('should output the correct message', () => {
+    showAlertAfterApplicationDateUpdate(
+      {
+        date: '2019-09-09T12:00',
+        applicationDate: '2019-08'
+      },
+      t,
+      format
+    )
+    expect(Alerter.success).toHaveBeenCalledWith(
+      'Operation assigned to August in the analysis tab'
+    )
   })
 })

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -15,7 +15,7 @@ export const TestI18n = ({ children }) => {
 }
 
 const AppLike = ({ children, store, client }) => (
-  <Provider store={store}>
+  <Provider store={store || (client && client.store)}>
     <CozyProvider client={client || getClient()}>
       <TestI18n>{children}</TestI18n>
     </CozyProvider>


### PR DESCRIPTION
- Correct i18n string for category alert card when the alert is configured for a group
- Correct text in alert when application date of a transaction is changed
  back to the original month