### PR TITLE
feat(AccountsSettings): On mobile, show owners alongside the label

### DIFF
--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router'
 import { translate } from 'cozy-ui/react'
 import Button from 'cozy-ui/react/Button'
 import Icon from 'cozy-ui/react/Icon'
+import { withBreakpoints } from 'cozy-ui/react'
 import { groupBy, flowRight as compose, sortBy } from 'lodash'
 import Table from 'components/Table'
 import Loading from 'components/Loading'
@@ -31,14 +32,26 @@ import { accountsConn, APP_DOCTYPE } from 'doctypes'
 import AccountSharingStatus from 'components/AccountSharingStatus'
 
 // TODO react-router v4
-const _AccountLine = ({ account, router, t }) => (
+const _AccountLine = ({ account, router, t, breakpoints: { isMobile } }) => (
   <tr
     key={account.id}
     onClick={() => router.push(`/settings/accounts/${account.id}`)}
     className={styles.AcnsStg__accountRow}
   >
     <td className={styles.AcnsStg__libelle}>
-      {account.shortLabel || account.label}
+      <div className={styles.AcnsStg__libelleInner}>
+        <div>{account.shortLabel || account.label}</div>
+        {isMobile ? (
+          <>
+            <div className="u-ph-half">-</div>
+            <div>
+              {getAccountOwners(account)
+                .map(Contact.getDisplayName)
+                .join(' - ')}
+            </div>
+          </>
+        ) : null}
+      </div>
     </td>
     <td className={styles.AcnsStg__bank}>
       {getAccountInstitutionLabel(account)}
@@ -54,7 +67,6 @@ const _AccountLine = ({ account, router, t }) => (
         {getAccountOwners(account)
           .map(Contact.getDisplayName)
           .join(' - ')}
-        <AccountSharingStatus withText account={account} />
       </td>
     ) : (
       <td className={styles.AcnsStg__shared}>
@@ -67,7 +79,8 @@ const _AccountLine = ({ account, router, t }) => (
 
 const AccountLine = compose(
   translate(),
-  withRouter
+  withRouter,
+  withBreakpoints()
 )(_AccountLine)
 
 const renderAccount = account => (

--- a/src/ducks/settings/AccountsSettings.styl
+++ b/src/ducks/settings/AccountsSettings.styl
@@ -44,6 +44,10 @@
     &__owner
         color var(--coolGrey)
 
+        +small-screen()
+            td&
+                display none
+
     &__actions
         maxed-flex-basis 10%
         text-align right
@@ -58,6 +62,16 @@
 
     &__bank, &__number, &__shared, &__owner
         composes mobile-row-label from '../../components/Table/styles.styl'
+
+.AcnsStg__libelleInner
+    display flex
+
+    > *
+        overflow hidden
+        text-overflow ellipsis
+
+    +small-screen()
+        padding-right 0.5rem
 
 .AcnStg
     &__tabList


### PR DESCRIPTION
When the label and/or the owners are too long, they are cut with ellipsis.

![image](https://user-images.githubusercontent.com/1606068/70258470-9885fe80-178c-11ea-958d-d226ef4f21f8.png)

![image](https://user-images.githubusercontent.com/1606068/70258604-c79c7000-178c-11ea-9aaa-6dacfb7cab42.png)
