### PR TITLE
feat(TransactionPageErrors): Add LOGIN_FAILED to actionable errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cozy-banks",
-  "version": "1.8.1",
+  "version": "1.10.0",
   "main": "src/main.jsx",
   "scripts": {
     "build": "npm run build:browser && npm run build:services",

--- a/scripts/release-pr-template.txt
+++ b/scripts/release-pr-template.txt
@@ -2,6 +2,7 @@ Release $VERSION
 
 - [ ] Create branch and the PR with the following content
 - [ ] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode`, `ios-CFBundleVersion` and `AppendUserAgent`.
+- [ ] Bump version in master for beta/prod versions not to shadow the next versions
 - [ ] Commit and tag with a beta tag (X.Y.Z-beta.M)
 - [ ] Push the tag and wait for the CI to push the beta version to the registry
 - [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)

--- a/src/ducks/transactions/TransactionPageErrors.jsx
+++ b/src/ducks/transactions/TransactionPageErrors.jsx
@@ -25,7 +25,8 @@ const isActionableError = trigger => {
     'TERMS_VERSION_MISMATCH',
     'USER_ACTION_NEEDED',
     'USER_ACTION_NEEDED.CHANGE_PASSWORD',
-    'USER_ACTION_NEEDED.ACCOUNT_REMOVED'
+    'USER_ACTION_NEEDED.ACCOUNT_REMOVED',
+    'LOGIN_FAILED'
   ]
 
   return actionableErrors.includes(trigger.current_state.last_error)


### PR DESCRIPTION
We now want to show LOGIN_FAILED errors on the transactions page. They were previously not shown because we had false positives.