### PR TITLE
Implement account or group filtering for notifications

### DIFF
--- a/src/ducks/notifications/BalanceLower/index.spec.js
+++ b/src/ducks/notifications/BalanceLower/index.spec.js
@@ -1,0 +1,136 @@
+import CozyClient from 'cozy-client'
+import BalanceLower from './index'
+import fixtures from 'test/fixtures/unit-tests.json'
+import MockDate from 'mockdate'
+import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
+import maxBy from 'lodash/maxBy'
+import minBy from 'lodash/minBy'
+
+const unique = arr => Array.from(new Set(arr))
+
+const minValueBy = (arr, fn) => fn(minBy(arr, fn))
+const maxValueBy = (arr, fn) => fn(maxBy(arr, fn))
+const getIDFromAccount = account => account._id
+const getAccountBalance = account => account.balance
+
+describe('balance lower', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(msg => {
+      throw new Error(`Warning during tests ${msg}`)
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const setup = ({ value, accountOrGroup } = {}) => {
+    const cozyUrl = 'http://cozy.tools:8080'
+    const client = new CozyClient({
+      uri: cozyUrl
+    })
+    const locales = {}
+
+    const operations = fixtures['io.cozy.bank.operations']
+    const maxDate = operations.map(x => x.date).sort()[0]
+    MockDate.set(maxDate)
+
+    const config = {
+      value: value || 5000,
+      accountOrGroup: accountOrGroup || null,
+      data: {
+        accounts: fixtures['io.cozy.bank.accounts'],
+        groups: fixtures['io.cozy.bank.groups']
+      },
+      client,
+      locales,
+      cozyUrl
+    }
+    const notification = new BalanceLower(config)
+    return { config, client, notification }
+  }
+
+  it('should keep config in its internal state', () => {
+    const { notification, config } = setup()
+    expect(notification.config).toBe(config)
+  })
+
+  describe('without accountOrGroup', () => {
+    it('should compute relevant accounts', async () => {
+      const { notification } = setup({ value: 5000 })
+      const { accounts } = await notification.buildData()
+      expect(accounts).toHaveLength(4)
+      expect(maxValueBy(accounts, getAccountBalance)).toBeLessThan(5000)
+    })
+
+    it('should compute relevant accounts for a different value', async () => {
+      const { notification } = setup({ value: 3000 })
+      const { accounts } = await notification.buildData()
+      expect(accounts).toHaveLength(2)
+      expect(maxValueBy(accounts, getAccountBalance)).toBeLessThan(3000)
+      expect(unique(accounts.map(getIDFromAccount))).toEqual([
+        'compteisa4',
+        'comptelou1'
+      ])
+    })
+  })
+
+  describe('with account', () => {
+    const compteisa1 = {
+      _id: 'compteisa1',
+      _type: ACCOUNT_DOCTYPE
+    }
+
+    it('should compute relevant accounts', async () => {
+      const { notification } = setup({
+        accountOrGroup: compteisa1
+      })
+      const { accounts } = await notification.buildData()
+      expect(accounts).toHaveLength(1)
+      expect(unique(accounts.map(getIDFromAccount))).toEqual(['compteisa1'])
+    })
+
+    it('should compute relevant accounts for a different value', async () => {
+      const { notification } = setup({
+        value: 3000,
+        accountOrGroup: compteisa1
+      })
+      const data = await notification.buildData()
+      expect(data).toBeUndefined()
+    })
+  })
+
+  describe('with group', () => {
+    const isabelleGroup = {
+      _id: 'b3e33d6cc334ed5ef49738a2be2880a2',
+      _type: GROUP_DOCTYPE
+    }
+
+    it('should compute relevant accounts', async () => {
+      const { notification } = setup({
+        accountOrGroup: isabelleGroup,
+        value: 5000
+      })
+      const { accounts } = await notification.buildData()
+      expect(accounts).toHaveLength(2)
+      expect(unique(accounts.map(getIDFromAccount))).toEqual([
+        'compteisa1',
+        'comptelou1'
+      ])
+      expect(minValueBy(accounts, getAccountBalance)).toBeLessThan(5000)
+      expect(maxValueBy(accounts, getAccountBalance)).toBe(3974.25)
+    })
+
+    it('should compute relevant accounts for a different value', async () => {
+      const { notification } = setup({
+        value: 500,
+        accountOrGroup: isabelleGroup
+      })
+      const { accounts } = await notification.buildData()
+      expect(accounts).toHaveLength(1)
+      expect(unique(accounts.map(getIDFromAccount))).toEqual(['comptelou1'])
+      expect(minValueBy(accounts, getAccountBalance)).toBeLessThan(500)
+      expect(maxValueBy(accounts, getAccountBalance)).toBe(325.24)
+    })
+  })
+})

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -2,15 +2,13 @@ import { subDays } from 'date-fns'
 import NotificationView from 'ducks/notifications/BaseNotificationView'
 import { sortBy, fromPairs } from 'lodash'
 import log from 'cozy-logger'
-import {
-  getDate,
-  isNew as isNewTransaction,
-  isTransactionAmountGreaterThan
-} from 'ducks/transactions/helpers'
+import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
+import { isTransactionAmountGreaterThan } from 'ducks/notifications/helpers'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import template from './template.hbs'
 import { prepareTransactions, getCurrentDate } from 'ducks/notifications/utils'
 import { toText } from 'cozy-notifications'
+import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 
 const ACCOUNT_SEL = '.js-account'
 const DATE_SEL = '.js-date'
@@ -49,11 +47,32 @@ const customToText = cozyHTMLEmail => {
   return toText(cozyHTMLEmail, getContent)
 }
 
+const isTransactionFromAccount = account => transaction =>
+  transaction.account === account._id
+
+const isTransactionFromGroup = group => transaction =>
+  group.accounts.includes(transaction.account)
+
+const makeAccountOrGroupFilter = (groups, accountOrGroup) => {
+  const noFilter = () => true
+  if (!accountOrGroup) {
+    return noFilter
+  } else if (accountOrGroup._type === ACCOUNT_DOCTYPE) {
+    return isTransactionFromAccount(accountOrGroup)
+  } else if (accountOrGroup._type === GROUP_DOCTYPE) {
+    const group = groups.find(group => group._id === accountOrGroup._id)
+    if (!group || !group.accounts) {
+      return noFilter
+    } else {
+      return isTransactionFromGroup(group)
+    }
+  }
+}
+
 class TransactionGreater extends NotificationView {
   constructor(config) {
     super(config)
-
-    this.maxAmount = config.value
+    this.config = config
   }
 
   filterTransactions(transactions) {
@@ -62,7 +81,10 @@ class TransactionGreater extends NotificationView {
     return transactions
       .filter(isNewTransaction)
       .filter(tr => new Date(getDate(tr)) > fourDaysAgo)
-      .filter(isTransactionAmountGreaterThan(this.maxAmount))
+      .filter(isTransactionAmountGreaterThan(this.config.value))
+      .filter(
+        makeAccountOrGroupFilter(this.data.groups, this.config.accountOrGroup)
+      )
   }
 
   async fetchData() {
@@ -115,7 +137,7 @@ class TransactionGreater extends NotificationView {
         }
       : {
           transactionsLength: transactions.length,
-          maxAmount: this.maxAmount
+          maxAmount: this.config.value
         }
 
     const translateKey = 'Notifications.if_transaction_greater.notification'

--- a/src/ducks/notifications/TransactionGreater/index.spec.js
+++ b/src/ducks/notifications/TransactionGreater/index.spec.js
@@ -1,0 +1,154 @@
+import CozyClient from 'cozy-client'
+import TransactionGreater from './index'
+import fixtures from 'test/fixtures/unit-tests.json'
+import MockDate from 'mockdate'
+import compose from 'lodash/flowRight'
+import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
+import maxBy from 'lodash/maxBy'
+import minBy from 'lodash/minBy'
+
+const addRev = doc => {
+  return { ...doc, _rev: '1-deadbeef' }
+}
+
+const prepareTransactionForTest = compose(addRev)
+
+const unique = arr => Array.from(new Set(arr))
+
+const minValueBy = (arr, fn) => fn(minBy(arr, fn))
+const maxValueBy = (arr, fn) => fn(maxBy(arr, fn))
+const getTransactionAbsAmount = tr => Math.abs(tr.amount)
+const getAccountIDFromTransaction = transaction => transaction.account
+
+describe('transaction greater', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(msg => {
+      throw new Error(`Warning during tests ${msg}`)
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const setup = ({ value, accountOrGroup } = {}) => {
+    const cozyUrl = 'http://cozy.tools:8080'
+    const client = new CozyClient({
+      uri: cozyUrl
+    })
+    const locales = {}
+
+    const operations = fixtures['io.cozy.bank.operations']
+    const maxDate = operations.map(x => x.date).sort()[0]
+    MockDate.set(maxDate)
+
+    const config = {
+      value: value || 10,
+      accountOrGroup: accountOrGroup || null,
+      data: {
+        transactions: operations.map(prepareTransactionForTest),
+        accounts: fixtures['io.cozy.bank.accounts'],
+        groups: fixtures['io.cozy.bank.groups']
+      },
+      client,
+      locales,
+      cozyUrl
+    }
+    const notification = new TransactionGreater(config)
+    return { config, client, notification }
+  }
+
+  it('should keep config in its internal state', () => {
+    const { notification, config } = setup()
+    expect(notification.config).toBe(config)
+  })
+
+  describe('without accountOrGroup', () => {
+    it('should compute relevant transactions', async () => {
+      const { notification } = setup()
+      const { transactions } = await notification.buildData()
+      expect(transactions).toHaveLength(116)
+    })
+    it('should compute relevant transactions for a different value', async () => {
+      const { notification } = setup({ value: 100 })
+      const { transactions } = await notification.buildData()
+      expect(transactions).toHaveLength(22)
+      expect(unique(transactions.map(getAccountIDFromTransaction))).toEqual([
+        'compteisa1',
+        'compteisa3',
+        'comptegene1'
+      ])
+    })
+  })
+
+  describe('with account', () => {
+    const compteisa1 = {
+      _id: 'compteisa1',
+      _type: ACCOUNT_DOCTYPE
+    }
+
+    it('should compute relevant transactions', async () => {
+      const { notification } = setup({
+        accountOrGroup: compteisa1
+      })
+      const data = await notification.buildData()
+      expect(data.transactions).toHaveLength(63)
+      expect(
+        unique(data.transactions.map(getAccountIDFromTransaction))
+      ).toEqual(['compteisa1'])
+    })
+
+    it('should compute relevant transactions for a different value', async () => {
+      const { notification } = setup({
+        value: 100,
+        accountOrGroup: compteisa1
+      })
+      const data = await notification.buildData()
+      expect(data.transactions).toHaveLength(16)
+      expect(
+        unique(data.transactions.map(getAccountIDFromTransaction))
+      ).toEqual(['compteisa1'])
+    })
+  })
+
+  describe('with group', () => {
+    const isabelleGroup = {
+      _id: 'b3e33d6cc334ed5ef49738a2be2880a2',
+      _type: GROUP_DOCTYPE
+    }
+
+    it('should compute relevant transactions', async () => {
+      const { notification } = setup({
+        accountOrGroup: isabelleGroup
+      })
+      const { transactions } = await notification.buildData()
+      expect(transactions).toHaveLength(76)
+      expect(unique(transactions.map(getAccountIDFromTransaction))).toEqual([
+        'compteisa1',
+        'compteisa3',
+        'comptelou1'
+      ])
+      expect(minValueBy(transactions, getTransactionAbsAmount)).toBeGreaterThan(
+        10
+      )
+      expect(maxValueBy(transactions, getTransactionAbsAmount)).toBe(3870.54)
+    })
+
+    it('should compute relevant transactions for a different value', async () => {
+      const { notification } = setup({
+        value: 100,
+        accountOrGroup: isabelleGroup
+      })
+      const { transactions } = await notification.buildData()
+      expect(transactions).toHaveLength(19)
+      expect(unique(transactions.map(getAccountIDFromTransaction))).toEqual([
+        'compteisa1',
+        'compteisa3'
+      ])
+      expect(minValueBy(transactions, getTransactionAbsAmount)).toBeGreaterThan(
+        100
+      )
+      expect(maxValueBy(transactions, getTransactionAbsAmount)).toBe(3870.54)
+    })
+  })
+})

--- a/src/ducks/notifications/services.spec.js
+++ b/src/ducks/notifications/services.spec.js
@@ -118,6 +118,9 @@ const mockEnvForEachTest = values => {
 describe('service', () => {
   beforeEach(() => {
     jest
+      .spyOn(CozyClient.prototype, 'query')
+      .mockReturnValue({ data: [{ _id: 'group-id-1', label: 'My group' }] })
+    jest
       .spyOn(BankAccount, 'getAll')
       .mockReturnValue([
         { _id: 'c0ffeedeadbeef', label: 'My bank account', balance: 123 }


### PR DESCRIPTION
User can choose an account or a group to further filter a notification.
Implemented on 

- BalanceLower
- TransactionGreater