### PR TITLE
fix: Crash when selecting group in notification setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prewatch:mobile:cold": "npm run clean:mobile",
     "lint": "npm-run-all --parallel 'lint:*'",
     "lint:js": "eslint --fix 'src/**/*.js' 'src/**/*.jsx' 'test/**/*.js'",
+    "lint:js:changes": "git diff --name-only master..HEAD | grep -E 'jsx?$' | xargs yarn eslint --fix",
     "lint:styles": "stylint src/styles --config ./.stylintrc",
     "stack:docker": "docker run --rm -it -p 8080:8080 -p 8025:8025 -v \"$(pwd)/build/\":/data/cozy-app/banks cozy/cozy-app-dev",
     "test": "jest --runInBand",

--- a/src/ducks/settings/CategoryAlerts/AccountGroupChoice.spec.jsx
+++ b/src/ducks/settings/CategoryAlerts/AccountGroupChoice.spec.jsx
@@ -32,7 +32,7 @@ describe('AccountGroupChoice', () => {
       groups: fakeCol(fixtures['io.cozy.bank.groups']),
       accounts: fakeCol(fixtures['io.cozy.bank.accounts'])
     })
-    expect(root.find(Row).length).toBe(10)
+    expect(root.find(Row).length).toBe(11)
   })
 
   it('should work with virtual groups', () => {

--- a/src/ducks/settings/helpers.js
+++ b/src/ducks/settings/helpers.js
@@ -7,6 +7,8 @@ import { connect } from 'react-redux'
 import { getDocumentFromState } from 'cozy-client/dist/store'
 import { getAccountLabel } from 'ducks/account/helpers'
 import { getGroupLabel } from 'ducks/groups/helpers'
+import { translate } from 'cozy-ui/transpiled/react'
+import compose from 'lodash/flowRight'
 
 const log = logger.namespace('settings.helpers')
 
@@ -77,7 +79,7 @@ export const updateCategoryAlerts = async (client, updatedAlerts) => {
   return updateSettings(client, settings)
 }
 
-export const getAccountOrGroupLabel = accountOrGroup => {
+export const getAccountOrGroupLabel = (accountOrGroup, t) => {
   if (!accountOrGroup) {
     return null
   }
@@ -85,19 +87,23 @@ export const getAccountOrGroupLabel = accountOrGroup => {
     case ACCOUNT_DOCTYPE:
       return getAccountLabel(accountOrGroup)
     case GROUP_DOCTYPE:
-      return getGroupLabel(accountOrGroup)
+      return getGroupLabel(accountOrGroup, t)
     default:
       return ''
   }
 }
 
 export const withAccountOrGroupLabeller = propName =>
-  connect(state => ({
-    [propName]: partialDoc =>
-      getAccountOrGroupLabel(
-        getDocumentFromState(state, partialDoc._type, partialDoc._id)
-      )
-  }))
+  compose(
+    translate(),
+    connect((state, ownProps) => ({
+      [propName]: partialDoc =>
+        getAccountOrGroupLabel(
+          getDocumentFromState(state, partialDoc._type, partialDoc._id),
+          ownProps.t
+        )
+    }))
+  )
 
 const boldRx = /\*(.*?)\*/g
 export const markdownBold = str => {

--- a/src/ducks/settings/helpers.spec.js
+++ b/src/ducks/settings/helpers.spec.js
@@ -1,4 +1,12 @@
-const { fetchSettings } = require('./helpers')
+import React from 'react'
+import { mount } from 'enzyme'
+import fixtures from 'test/fixtures/unit-tests.json'
+import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
+
+import AppLike from 'test/AppLike'
+import { createClientWithData } from 'test/client'
+
+import { fetchSettings, withAccountOrGroupLabeller } from './helpers'
 
 describe('defaulted settings', () => {
   it('should return defaulted settings', async () => {
@@ -24,5 +32,68 @@ describe('defaulted settings', () => {
     }
     const settings = await fetchSettings(fakeClient)
     expect(settings).toMatchSnapshot()
+  })
+})
+
+describe('withAccountOrGroupLabeller', () => {
+  const setup = ({ accountOrGroup }) => {
+    const client = createClientWithData({
+      queries: {
+        groups: {
+          doctype: GROUP_DOCTYPE,
+          data: fixtures[GROUP_DOCTYPE]
+        },
+        accounts: {
+          doctype: ACCOUNT_DOCTYPE,
+          data: fixtures[ACCOUNT_DOCTYPE]
+        }
+      }
+    })
+
+    const DumbComponent = ({ accountOrGroup, getAccountOrGroupLabel }) => {
+      return <div>{getAccountOrGroupLabel(accountOrGroup)}</div>
+    }
+
+    const Component = withAccountOrGroupLabeller('getAccountOrGroupLabel')(
+      DumbComponent
+    )
+
+    const root = mount(
+      <AppLike client={client} store={client.store}>
+        <Component accountOrGroup={accountOrGroup} />
+      </AppLike>
+    )
+    return { root }
+  }
+
+  it('should correctly name an account', () => {
+    const { root } = setup({
+      accountOrGroup: {
+        _id: 'compteisa1',
+        _type: ACCOUNT_DOCTYPE
+      }
+    })
+    expect(root.text()).toBe('Compte courant Isabelle')
+  })
+
+  it('should correctly name a group', () => {
+    const ENLARGED_FAMILY_GROUP_ID = 'f1d11eb324b64d604cbeee734e77de66'
+    const { root } = setup({
+      accountOrGroup: {
+        _id: ENLARGED_FAMILY_GROUP_ID,
+        _type: GROUP_DOCTYPE
+      }
+    })
+    expect(root.text()).toBe('Famille élargie')
+  })
+
+  it('should correctly name an autogroup', () => {
+    const { root } = setup({
+      accountOrGroup: {
+        _id: 'autogroup1',
+        _type: GROUP_DOCTYPE
+      }
+    })
+    expect(root.text()).toBe('Checking accounts')
   })
 })

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -153,6 +153,10 @@
       ],
       "id": "b3e33d6cc334ed5ef49738a2be2880a2",
       "label": "Isabelle"
+    },
+    {
+      "_id": "autogroup1",
+      "accountType": "Checkings"
     }
   ],
   "io.cozy.mocks.recipients": [


### PR DESCRIPTION
To correctly label a group, we need to pass `t` in case it is
a virtual or auto group.