### PR TITLE
fix(LoanProgress): Render nothing if some data is missing

### DIFF
--- a/src/ducks/loan/LoanProgress.jsx
+++ b/src/ducks/loan/LoanProgress.jsx
@@ -15,6 +15,10 @@ const DumbLoanProgress = props => {
   const reimbursedAmount = getReimbursedAmount(account)
   const borrowedAmount = getBorrowedAmount(account)
 
+  if (!reimbursedAmount && !borrowedAmount) {
+    return null
+  }
+
   return (
     <>
       <PercentageBar value={percentage} color="var(--emerald)" />

--- a/src/ducks/loan/LoanProgress.spec.jsx
+++ b/src/ducks/loan/LoanProgress.spec.jsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import LoanProgress from './LoanProgress'
+
+describe('when the account has no info about amount', () => {
+  it('should render nothing', () => {
+    const account = { _id: 'account', type: 'Loan' }
+    const root = mount(<LoanProgress t={key => key} account={account} />)
+
+    expect(root.html()).toBe('')
+  })
+})


### PR DESCRIPTION
A loan account does not necessary have all the required amount
properties to show a progress bar. When it doesn't have it, we simply
show nothing.