### PR TITLE
fix: Back button styles were wrong on mobile

### DIFF
--- a/src/components/BackButton/index.jsx
+++ b/src/components/BackButton/index.jsx
@@ -34,7 +34,7 @@ BackButton.defaultProps = {
 export const BarBackButton = ({ onClick, color }) => (
   <BarLeft>
     <BackButton
-      className="coz-bar-btn coz-bar-burger"
+      className={cx(styles.BackArrow, 'coz-bar-btn coz-bar-burger')}
       color={color}
       onClick={onClick}
     />

--- a/src/components/BackButton/index.jsx
+++ b/src/components/BackButton/index.jsx
@@ -31,14 +31,17 @@ BackButton.defaultProps = {
   color: 'var(--coolGrey)'
 }
 
-export const BarBackButton = ({ onClick, color }) => (
-  <BarLeft>
-    <BackButton
-      className={cx(styles.BackArrow, 'coz-bar-btn coz-bar-burger')}
-      color={color}
-      onClick={onClick}
-    />
-  </BarLeft>
+export const BarBackButton = withBreakpoints()(
+  ({ onClick, color, breakpoints: { isMobile } }) =>
+    isMobile ? (
+      <BarLeft>
+        <BackButton
+          className={cx(styles.BackArrow, 'coz-bar-btn coz-bar-burger')}
+          color={color}
+          onClick={onClick}
+        />
+      </BarLeft>
+    ) : null
 )
 
 /**

--- a/src/components/BackButton/style.styl
+++ b/src/components/BackButton/style.styl
@@ -1,3 +1,5 @@
+@require 'settings/breakpoints'
+
 .BackArrow.BackArrow
     float left
     font-size 1.25rem
@@ -7,9 +9,15 @@
     border-radius 100%
     width 2rem
     display inline-flex
-    height 2rem
+    height 3rem
     justify-content center
     align-items center
+    border 0
+    background transparent
+
+    +small-screen()
+        &
+            margin-right 1rem
 
 .BackArrow.BackArrow:active
     background rgba(255, 255, 255, 0.2)

--- a/src/components/EditionModal/EditionModal.jsx
+++ b/src/components/EditionModal/EditionModal.jsx
@@ -21,7 +21,7 @@ import resultWithArgs from 'utils/resultWithArgs'
 import Confirmation from 'components/Confirmation'
 import { withBreakpoints } from 'cozy-ui/react'
 
-import { BackButton } from 'components/BackButton'
+import { BackIcon } from 'components/BackButton'
 
 export const CHOOSING_TYPES = {
   category: 'category',
@@ -38,7 +38,9 @@ const TYPES_WITH_SELECTOR = {
 }
 
 const BackArrow = ({ onClick }) => (
-  <BackButton className="u-mr-1" onClick={onClick} />
+  <span className="u-mr-1" onClick={onClick}>
+    <BackIcon color="var(--coolGrey)" />
+  </span>
 )
 
 const SectionsPerType = {

--- a/src/components/Title/Title.styl
+++ b/src/components/Title/Title.styl
@@ -3,8 +3,8 @@
 .Title
     line-height 2.5rem
     margin 0 auto
-    margin-bottom .5rem
     display flex
+    align-items center
 
 .TitleColor_default
     color var(--black) !important

--- a/src/ducks/reimbursements/ReimbursementsPage.styl
+++ b/src/ducks/reimbursements/ReimbursementsPage.styl
@@ -2,7 +2,7 @@
 
 .ReimbursementsPage__title
     display flex
-    alignItems center
+    align-items center
     margin-bottom 1rem
 
     +medium-screen()


### PR DESCRIPTION
BackArrow were not applied correctly.

We badly need automated screenshots.

<img width="638" alt="image" src="https://user-images.githubusercontent.com/465582/71177420-4359ea80-226c-11ea-9190-c95bf8a437c1.png">

<img width="610" alt="image" src="https://user-images.githubusercontent.com/465582/71177428-494fcb80-226c-11ea-8577-f0a43bb6539e.png">

<img width="511" alt="image" src="https://user-images.githubusercontent.com/465582/71177444-510f7000-226c-11ea-8698-ff2c3a5f4ef8.png">

<img width="551" alt="image" src="https://user-images.githubusercontent.com/465582/71177464-5967ab00-226c-11ea-9927-5a713b6c9168.png">

