### PR TITLE
Handle uninstalled contacts app

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "cozy-logger": "1.6.0",
     "cozy-notifications": "0.3.2",
     "cozy-pouch-link": "6.64.7",
-    "cozy-realtime": "3.2.1",
+    "cozy-realtime": "3.3.0",
     "cozy-stack-client": "8.7.0",
     "cozy-ui": "28.8.0",
     "d3": "5.11.0",

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "cozy-pouch-link": "6.64.7",
     "cozy-realtime": "3.3.0",
     "cozy-stack-client": "8.7.0",
-    "cozy-ui": "28.8.0",
+    "cozy-ui": "28.9.1",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -1,5 +1,6 @@
 /* global __TARGET__ */
 import { Intents } from 'cozy-interapp'
+import { RealtimePlugin } from 'cozy-realtime'
 
 let client
 
@@ -15,6 +16,8 @@ export const getClient = () => {
 
   const intents = new Intents({ client })
   client.intents = intents
+
+  client.registerPlugin(RealtimePlugin)
 
   // Used as a hack to prevent circular dependency.
   // Some selectors need to access cozyClient to correctly hydrate.

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,10 +4874,10 @@ cozy-ui@24.3.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@28.8.0:
-  version "28.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.8.0.tgz#cdc95e5bc1e7eb8e3641cccaa706b81b9f4f988a"
-  integrity sha512-ynvwQtRsskGnOEmBt4mNxwv/Od5DsXGJcEXxQ+VR94SIsKg95NR5Aap6OFSuks4RWfdUWLxn7SZ+RK2Km6nxAQ==
+cozy-ui@28.9.1:
+  version "28.9.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.9.1.tgz#6e1920e1d982d9e73873cdeaf1347de0e113f540"
+  integrity sha512-Bsz8RIQ4WU5RBgWdk1CaprWl3GAoug3WyA5BBDnBft9X4KnFF341TO4Lm1A/9+epP5NMK9kxXTRGRkTAtW2GDA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4806,6 +4806,13 @@ cozy-realtime@3.2.1:
   dependencies:
     minilog "3.1.0"
 
+cozy-realtime@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.3.0.tgz#7d4a4d6938330ab9b3437255e8f016b87a08b19c"
+  integrity sha512-szI22Rl8aaufw94jNMX1PCxswGHPQVBJHjnxibphM17UmymlZe7J1ILrsm+jBZkKDAvnProHNONtNOfjJLFc3g==
+  dependencies:
+    minilog "https://github.com/cozy/minilog.git#master"
+
 cozy-stack-client@8.7.0, cozy-stack-client@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-8.7.0.tgz#736c13cb086fe95b464a22dce578b8e8ebb06221"
@@ -11439,6 +11446,12 @@ minilog@3.1.0, minilog@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/minilog/-/minilog-3.1.0.tgz#d2d0f1887ca363d1acf0ea86d5c4df293b3fb675"
   integrity sha1-0tDxiHyjY9Gs8OqG1cTfKTs/tnU=
+  dependencies:
+    microee "0.0.6"
+
+"minilog@https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
When the user wants to add a contact to a bank account via the « add a contact » button of the ContactPicker, but don't have the contacts app installed, we want to redirect him to the store. That's the job done by https://github.com/cozy/cozy-ui/pull/1326. But for it to work, we have to register a realtime plugin to our client. For now the realtime plugin is implemented here and we will be able to extract it elsewhere (cozy-client? cozy-realtime?)

Todo:

- [x] Update cozy-ui when https://github.com/cozy/cozy-ui/pull/1326 has been merged
- [x] Update cozy-realtime when https://github.com/cozy/cozy-libs/pull/902 has been merged