### PR TITLE
Warning tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "cozy-pouch-link": "6.64.7",
     "cozy-realtime": "3.3.0",
     "cozy-stack-client": "8.7.0",
-    "cozy-ui": "28.9.1",
+    "cozy-ui": "28.10.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/balance/BalanceDetailsHeader.spec.jsx
+++ b/src/ducks/balance/BalanceDetailsHeader.spec.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { DumbBalanceDetailsHeader } from './BalanceDetailsHeader'
 import BarBalance from 'components/BarBalance'
 import AppLike from 'test/AppLike'
+import mockRouter from 'test/mockRouter'
 import { getClient } from 'ducks/client'
 
 // eslint-disable-next-line no-unused-vars
@@ -17,9 +18,7 @@ const setup = props => {
     {
       context: {
         router: {
-          push: jest.fn(),
-          replace: jest.fn(),
-          go: jest.fn(),
+          ...mockRouter,
           getCurrentLocation: () => ({
             pathname: '/'
           })

--- a/src/ducks/balance/components/AccountRow.jsx
+++ b/src/ducks/balance/components/AccountRow.jsx
@@ -5,7 +5,7 @@ import { withBreakpoints, translate } from 'cozy-ui/react'
 import flag from 'cozy-flags'
 import Icon from 'cozy-ui/react/Icon'
 import cx from 'classnames'
-import { get, flowRight as compose, keyBy } from 'lodash'
+import { get, flowRight as compose, keyBy, omit } from 'lodash'
 import Switch from 'components/Switch'
 import { Figure } from 'components/Figure'
 import {
@@ -89,7 +89,7 @@ const OwnersColumn = props => {
 }
 
 const DumbUpdatedAtOrFail = props => {
-  const { triggersCol, account, t, className, ...rest } = props
+  const { triggersCol, account, t, className, ...rest } = omit(props, 'f')
   const triggers = triggersCol.data
 
   const failedTrigger = triggers.find(

--- a/src/ducks/balance/components/GroupPanel.jsx
+++ b/src/ducks/balance/components/GroupPanel.jsx
@@ -39,6 +39,7 @@ const GroupPanelSummary = withStyles({
     paddingRight: '0',
     height: '100%'
   },
+  expanded: {},
   expandIcon: {
     left: '0.375rem',
     right: 'auto',

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -16,6 +16,7 @@ import { createClientWithData } from 'test/client'
 import { TRANSACTION_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 import getClient from 'selectors/getClient'
 import MockDate from 'mockdate'
+import mockRouter from 'test/mockRouter'
 
 jest.mock('components/AccountIcon', () => () => null)
 jest.mock('selectors/getClient')
@@ -43,16 +44,6 @@ beforeAll(() => {
 describe('GroupPanel', () => {
   let root, onChange, switches
 
-  const fakeRouter = {
-    push: jest.fn(),
-    replace: jest.fn(),
-    go: jest.fn(),
-    goBack: jest.fn(),
-    goForward: jest.fn(),
-    setRouteLeaveHook: jest.fn(),
-    isActive: jest.fn()
-  }
-
   const Wrapper = ({ expanded }) => (
     <AppLike client={client}>
       <GroupPanel
@@ -63,7 +54,7 @@ describe('GroupPanel', () => {
         switches={switches}
         onSwitchChange={() => {}}
         onChange={onChange}
-        router={fakeRouter}
+        router={mockRouter}
       />
     </AppLike>
   )

--- a/src/ducks/balance/components/GroupPanel.spec.jsx
+++ b/src/ducks/balance/components/GroupPanel.spec.jsx
@@ -145,6 +145,7 @@ describe('Reimbursement virtual group styling', () => {
   }
 
   const healthExpense = {
+    account: 'comptegene1',
     manualCategoryId: '400610',
     amount: -10,
     _id: 'transaction-1234',

--- a/src/ducks/settings/GroupSettings.spec.js
+++ b/src/ducks/settings/GroupSettings.spec.js
@@ -75,11 +75,15 @@ describe('GroupSettings', () => {
 
     const root = mount(
       <AppLike>
-        <AccountLine
-          account={account}
-          group={group}
-          toggleAccount={toggleAccount}
-        />
+        <table>
+          <tbody>
+            <AccountLine
+              account={account}
+              group={group}
+              toggleAccount={toggleAccount}
+            />
+          </tbody>
+        </table>
       </AppLike>
     )
 

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -295,7 +295,12 @@ const TransactionModalInfo = withBreakpoints()(
 )
 
 const TransactionModal = ({ requestClose, ...props }) => (
-  <PageModal dismissAction={requestClose} into="body" overflowHidden>
+  <PageModal
+    aria-label={props.t('Transactions.infos.modal-label')}
+    dismissAction={requestClose}
+    into="body"
+    overflowHidden
+  >
     <ModalStack>
       <TransactionModalInfo {...props} requestClose={requestClose} />
     </ModalStack>

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -11,6 +11,7 @@ import data from '../../../test/fixtures'
 import PropTypes from 'prop-types'
 import AppLike from 'test/AppLike'
 import { getClient } from 'ducks/client'
+import mockRouter from 'test/mockRouter'
 
 const allAccounts = data['io.cozy.bank.accounts']
 const allTransactions = data['io.cozy.bank.operations']
@@ -71,13 +72,7 @@ describe('TransactionsPage', () => {
   const setup = () => {
     const context = {
       router: {
-        push: () => {},
-        replace: () => {},
-        go: () => {},
-        goBack: () => {},
-        goForward: () => {},
-        setRouteLeaveHook: () => {},
-        isActive: () => {},
+        ...mockRouter,
         getCurrentLocation: () => ({
           pathname: '/'
         }),

--- a/src/ducks/transactions/TransactionsPage.spec.jsx
+++ b/src/ducks/transactions/TransactionsPage.spec.jsx
@@ -10,14 +10,15 @@ import {
 import data from '../../../test/fixtures'
 import PropTypes from 'prop-types'
 import AppLike from 'test/AppLike'
+import { mkFakeChain } from 'test/client'
 import { getClient } from 'ducks/client'
 import mockRouter from 'test/mockRouter'
 
 const allAccounts = data['io.cozy.bank.accounts']
 const allTransactions = data['io.cozy.bank.operations']
 
-// eslint-disable-next-line no-unused-vars
 const client = getClient()
+client.chain = mkFakeChain()
 
 const saveWindowWidth = () => {
   let windowWidth = window.innerWidth
@@ -58,7 +59,7 @@ describe('TransactionsPage', () => {
   // Necessary wrapper to be able to use setProps since `setProps` is
   // only callable on the Enzyme root
   const Wrapper = ({ filteringDoc, filteredTransactions }) => (
-    <AppLike>
+    <AppLike client={client}>
       <UnpluggedTransactionsPage
         transactions={mkCollection(allTransactions, { fetchStatus: 'loaded' })}
         accounts={mkCollection(allAccounts, { fetchStatus: 'loaded' })}

--- a/src/ducks/transactions/__snapshots__/TransactionModal.spec.jsx.snap
+++ b/src/ducks/transactions/__snapshots__/TransactionModal.spec.jsx.snap
@@ -4,7 +4,7 @@ exports[`transaction modal should render correctly 1`] = `
 "<div class=\\"styles__c-modal-container___31zmi\\">
   <div class=\\"styles__c-overlay___31iWd\\">
     <div class=\\"styles__c-modal-wrapper___8PyE9\\">
-      <div class=\\"styles__c-modal___33aV9 styles__c-modal--small___XUfOM styles__c-modal--overflowHidden___3H87t styles__c-modal--closable___29CLQ\\" role=\\"dialog\\" aria-modal=\\"true\\"><button class=\\"styles__c-modal-close___1v2bp styles__c-modal-close--notitle___1rqne\\" type=\\"button\\" aria-label=\\"close\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"24\\" height=\\"24\\">
+      <div class=\\"styles__c-modal___33aV9 styles__c-modal--small___XUfOM styles__c-modal--overflowHidden___3H87t styles__c-modal--closable___29CLQ\\" role=\\"dialog\\" aria-modal=\\"true\\" aria-label=\\"Transaction infos\\"><button class=\\"styles__c-modal-close___1v2bp styles__c-modal-close--notitle___1rqne\\" type=\\"button\\" aria-label=\\"close\\"><svg class=\\"styles__icon___23x3R\\" style=\\"fill: var(--coolGrey);\\" width=\\"24\\" height=\\"24\\">
             <use xlink:href=\\"#cross\\"></use>
           </svg></button>
         <div>

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -52,7 +52,7 @@ export class DumbBillChip extends React.PureComponent {
       invoiceId = this.getInvoiceId(bill)[1]
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.log(err)
+      console.warn(err)
       return null
     }
 

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.spec.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.spec.jsx
@@ -2,12 +2,39 @@ import React from 'react'
 import { DumbBillChip } from './BillChip'
 import { shallow } from 'enzyme'
 
+jest.mock('ducks/transactions/FileOpener', () => ({ children }) => children)
+
 describe('BillChip', () => {
-  it('should render nothing if the given bill has no invoice', () => {
-    const bill = { _id: 'fakebill' }
+  describe('when the bill has no invoice', () => {
+    beforeEach(() => {
+      jest.spyOn(console, 'warn').mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      // eslint-disable-next-line no-console
+      console.warn.mockRestore()
+    })
+
+    it('should render nothing', () => {
+      const bill = {
+        _id: 'fakebill'
+      }
+
+      const t = key => key
+
+      expect(shallow(<DumbBillChip bill={bill} t={t} />).html()).toBe(null)
+    })
+  })
+
+  it('should render a Chip', () => {
+    const bill = {
+      _id: 'fakebill',
+      invoice: 'io.cozy.files:deadbeef'
+    }
 
     const t = key => key
 
-    expect(shallow(<DumbBillChip bill={bill} t={t} />).html()).toBe(null)
+    const root = shallow(<DumbBillChip bill={bill} t={t} />)
+    expect(root).toMatchSnapshot()
   })
 })

--- a/src/ducks/transactions/actions/AttachedDocsAction/__snapshots__/BillChip.spec.jsx.snap
+++ b/src/ducks/transactions/actions/AttachedDocsAction/__snapshots__/BillChip.spec.jsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BillChip should render a Chip 1`] = `
+<Component
+  fileId="deadbeef"
+  key="deadbeef"
+>
+  <Chip
+    component="button"
+    size="small"
+    theme="normal"
+    variant="outlined"
+  >
+    <FileIcon
+      className="u-flex-shrink-0"
+    />
+    Transactions.actions.attachedDocs.billWithoutVendor
+  </Chip>
+</Component>
+`;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,6 +372,7 @@
       }
     },
     "infos": {
+      "modal-label": "Transaction infos",
       "account": "Account",
       "institution": "Bank",
       "originalBankLabel": "Original label",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -189,6 +189,7 @@
       }
     },
     "infos": {
+      "modal-label": "Détails de la transaction",
       "account": "Compte",
       "institution": "Banque",
       "originalBankLabel": "Libellé original",

--- a/test/client.js
+++ b/test/client.js
@@ -8,6 +8,10 @@ const defaultOptions = {
   token: 'MyOwnToken'
 }
 
+export const mkFakeChain = () => ({
+  request: jest.fn().mockReturnValue({ data: [] })
+})
+
 export const getClient = ({ uri, token, fetchJSONReturn } = defaultOptions) => {
   const client = new CozyClient({
     schema,
@@ -24,6 +28,7 @@ export const getClient = ({ uri, token, fetchJSONReturn } = defaultOptions) => {
       }
     }
   }
+  client.chain = mkFakeChain()
   return client
 }
 

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -21,6 +21,13 @@
       "__DEST__": "/Fichiers_de_démo/MAIF/Demo_cozy-Appel_cotisation_MAIF_2017.pdf"
     }
   ],
+  "io.cozy.contacts": [{
+    "_id": "contact1",
+    "name": {
+      "givenName": "Claude",
+      "familyName": "Douillet"
+    }
+  }],
   "io.cozy.bank.accounts": [
     {
       "_id": "compteisa4",

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -1,6 +1,7 @@
 import { configure, mount, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import logger from 'cozy-logger'
+import { makeDeprecatedLifecycleMatcher, ignoreOnConditions } from './jestUtils'
 
 // To avoid the errors while creating theme (since no CSS stylesheet
 // defining CSS variables is injected during tests)
@@ -25,3 +26,28 @@ global.cozy = {
     setTheme: () => null
   }
 }
+
+const ignoredWarnings = {
+  I18n: {
+    reason: 'Preact compatibility',
+    matcher: makeDeprecatedLifecycleMatcher('I18n')
+  },
+  ModalContent: {
+    reason: 'Preact compatibility',
+    matcher: makeDeprecatedLifecycleMatcher('ModalContent')
+  },
+
+  // Until we upgrade react-redux to > 5, we will have deprecated lifecycle
+  // methods on connected components
+  ConnectedRedux: {
+    reason: 'Wrapped in Connect()',
+    matcher: makeDeprecatedLifecycleMatcher('Connect(')
+  }
+}
+
+// Ignore warnings that we think are not problematic, see
+// https://github.com/cozy/cozy-ui/issues/1318
+console.warn = ignoreOnConditions(
+  console.warn,
+  Object.values(ignoredWarnings).map(x => x.matcher)
+)

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -47,7 +47,9 @@ const ignoredWarnings = {
 
 // Ignore warnings that we think are not problematic, see
 // https://github.com/cozy/cozy-ui/issues/1318
+// eslint-disable-next-line no-console
 console.warn = ignoreOnConditions(
+  // eslint-disable-next-line no-console
   console.warn,
   Object.values(ignoredWarnings).map(x => x.matcher)
 )

--- a/test/jestUtils.js
+++ b/test/jestUtils.js
@@ -1,0 +1,19 @@
+const isDeprecatedLifecycleWarning = (msg, componentName) => {
+  return (
+    msg.includes('has been renamed, and is not recommended for use') &&
+    msg.includes(componentName)
+  )
+}
+
+export const ignoreOnConditions = (originalWarn, ignoreConditions) => {
+  return function(...args) {
+    const msg = args[0]
+    if (ignoreConditions.some(condition => condition(msg))) {
+      return
+    }
+    originalWarn.apply(this, args)
+  }
+}
+
+export const makeDeprecatedLifecycleMatcher = componentName => msg =>
+  isDeprecatedLifecycleWarning(msg, componentName)

--- a/test/mockRouter.js
+++ b/test/mockRouter.js
@@ -1,0 +1,11 @@
+const mockRouter = {
+  push: jest.fn(),
+  replace: jest.fn(),
+  go: jest.fn(),
+  goBack: jest.fn(),
+  goForward: jest.fn(),
+  setRouteLeaveHook: jest.fn(),
+  isActive: jest.fn()
+}
+
+export default mockRouter

--- a/yarn.lock
+++ b/yarn.lock
@@ -4874,10 +4874,10 @@ cozy-ui@24.3.0:
     react-pdf "^4.0.5"
     react-select "2.2.0"
 
-cozy-ui@28.9.1:
-  version "28.9.1"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.9.1.tgz#6e1920e1d982d9e73873cdeaf1347de0e113f540"
-  integrity sha512-Bsz8RIQ4WU5RBgWdk1CaprWl3GAoug3WyA5BBDnBft9X4KnFF341TO4Lm1A/9+epP5NMK9kxXTRGRkTAtW2GDA==
+cozy-ui@28.10.0:
+  version "28.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-28.10.0.tgz#1114c130ac239ab9ce9ac2f6cd5ce10859cffefc"
+  integrity sha512-dnZNFmdRJB58FiXuKOM5szRgBDgR0ysR2Cx0hiqTS/eKJ2Xko4MyIBnFhbDWu+vGkvSVLmH4N8QmN8Q//Hjb0w==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"


### PR DESCRIPTION
Remove some warnings in tests. We are almost there ! At some point we will be able put

```
console.warn = logAndThrowException
```

Warnings are a useful tool when there are a small number of them but we had so much of them that the ratio signal / noise was too low, making us ignoring them where they can be of good help when refactoring / spotting bad patterns.