### PR TITLE
fix: Convert default alert rules to list

### DIFF
--- a/src/ducks/settings/__snapshots__/helpers.spec.js.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.js.snap
@@ -26,14 +26,18 @@ Object {
     "processedAccounts": Array [],
   },
   "notifications": Object {
-    "balanceLower": Object {
-      "enabled": false,
-      "value": 600,
-    },
-    "delayedDebit": Object {
-      "enabled": false,
-      "value": 2,
-    },
+    "balanceLower": Array [
+      Object {
+        "enabled": false,
+        "value": 100,
+      },
+    ],
+    "delayedDebit": Array [
+      Object {
+        "enabled": false,
+        "value": 2,
+      },
+    ],
     "healthBillLinked": Object {
       "enabled": true,
     },
@@ -51,10 +55,12 @@ Object {
     "salaire": Object {
       "enabled": false,
     },
-    "transactionGreater": Object {
-      "enabled": true,
-      "value": 600,
-    },
+    "transactionGreater": Array [
+      Object {
+        "enabled": true,
+        "value": 600,
+      },
+    ],
   },
   "showIncomeCategory": true,
 }

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -11,14 +11,18 @@ export const DEFAULTS_SETTINGS = {
   },
   notifications: {
     lastSeq: 0,
-    balanceLower: {
-      value: 100,
-      enabled: false
-    },
-    transactionGreater: {
-      value: 600,
-      enabled: true
-    },
+    balanceLower: [
+      {
+        value: 100,
+        enabled: false
+      }
+    ],
+    transactionGreater: [
+      {
+        value: 600,
+        enabled: true
+      }
+    ],
     healthBillLinked: {
       enabled: true
     },
@@ -26,10 +30,12 @@ export const DEFAULTS_SETTINGS = {
       value: 30,
       enabled: false
     },
-    delayedDebit: {
-      enabled: false,
-      value: 2
-    },
+    delayedDebit: [
+      {
+        enabled: false,
+        value: 2
+      }
+    ],
     salaire: {
       enabled: false
     },


### PR DESCRIPTION
We have to update  the default settings to use the new multi rule format.