### PR TITLE
fix: Not in modal TransactionCategoryEditor

### DIFF
--- a/src/ducks/categories/withUpdateCategory.jsx
+++ b/src/ducks/categories/withUpdateCategory.jsx
@@ -15,6 +15,7 @@ export default () => Wrapped => props => {
       <Wrapped {...props} showCategoryChoice={handleShow} />
       {modalOpened ? (
         <TransactionCategoryEditor
+          modal={true}
           beforeUpdate={hide}
           onCancel={hide}
           transaction={props.transaction}

--- a/src/ducks/transactions/TransactionCategoryEditor.jsx
+++ b/src/ducks/transactions/TransactionCategoryEditor.jsx
@@ -8,7 +8,14 @@ import { withClient } from 'cozy-client'
  * Edits a transaction's category through CategoryChoice
  */
 const TransactionCategoryEditor = withClient(props => {
-  const { client, transaction, beforeUpdate, afterUpdate, onCancel } = props
+  const {
+    client,
+    transaction,
+    beforeUpdate,
+    afterUpdate,
+    onCancel,
+    modal
+  } = props
 
   const handleSelect = async category => {
     if (beforeUpdate) {
@@ -30,12 +37,16 @@ const TransactionCategoryEditor = withClient(props => {
 
   return (
     <CategoryChoice
-      modal={false}
+      modal={modal}
       categoryId={getCategoryId(transaction)}
       onSelect={handleSelect}
       onCancel={handleCancel}
     />
   )
 })
+
+TransactionCategoryEditor.defaultProps = {
+  modal: false
+}
 
 export default TransactionCategoryEditor

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -4,7 +4,6 @@
 
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { flowRight as compose } from 'lodash'
 import cx from 'classnames'
 
 import {
@@ -299,29 +298,25 @@ const TransactionModalInfo = withBreakpoints()(
   )
 )
 
-const TransactionModal = ({ requestClose, ...props }) => (
-  <PageModal
-    aria-label={props.t('Transactions.infos.modal-label')}
-    dismissAction={requestClose}
-    into="body"
-    overflowHidden
-  >
-    <ModalStack>
-      <TransactionModalInfo {...props} requestClose={requestClose} />
-    </ModalStack>
-  </PageModal>
-)
+const TransactionModal = ({ requestClose, ...props }) => {
+  const { t } = useI18n()
+  return (
+    <PageModal
+      aria-label={t('Transactions.infos.modal-label')}
+      dismissAction={requestClose}
+      into="body"
+      overflowHidden
+    >
+      <ModalStack>
+        <TransactionModalInfo {...props} requestClose={requestClose} />
+      </ModalStack>
+    </PageModal>
+  )
+}
 
 TransactionModal.propTypes = {
   requestClose: PropTypes.func.isRequired,
   transactionId: PropTypes.string.isRequired
 }
 
-const DumbTransactionModal = compose(
-  translate(),
-  withBreakpoints()
-)(TransactionModal)
-
-export default DumbTransactionModal
-
-export { DumbTransactionModal }
+export default TransactionModal

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -1,8 +1,7 @@
 /* global mount */
 
 import React from 'react'
-import {
-  DumbTransactionModal as TransactionModal,
+import TransactionModal, {
   showAlertAfterApplicationDateUpdate
 } from './TransactionModal'
 import data from '../../../test/fixtures'

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -244,25 +244,24 @@ const Transactions = compose(
   translate()
 )(TransactionsDumb)
 
-export class TransactionsWithSelection extends React.Component {
-  static defaultProps = {
-    withScroll: true
-  }
+export const TransactionsWithSelection = ({
+  withScroll,
+  className,
+  ...rest
+}) => (
+  <div
+    className={cx(
+      {
+        [styles.ScrollingElement]: withScroll
+      },
+      'js-scrolling-element',
+      className
+    )}
+  >
+    <Transactions {...rest} />
+  </div>
+)
 
-  render() {
-    const { withScroll, className, ...rest } = this.props
-    return (
-      <div
-        className={cx(
-          {
-            [styles.ScrollingElement]: withScroll
-          },
-          'js-scrolling-element',
-          className
-        )}
-      >
-        <Transactions selectTransaction={this.selectTransaction} {...rest} />
-      </div>
-    )
-  }
+TransactionsWithSelection.defaultProps = {
+  withScroll: true
 }


### PR DESCRIPTION
After refactoring TransactionCategoryEditor so that it can appear not 
necessarily in a modal, we forgot the one place where it should be in a modal