### PR TITLE
UI considers a transaction as reimbursed if it has at least 1 b…

### DIFF
--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -126,13 +126,17 @@ describe('buildHealthReimbursementsVirtualAccount', () => {
   })
 
   it('should take reimbursements into account', () => {
-    transactions[0].reimbursements = {
-      data: [{ amount: 5 }]
-    }
+    const virtualAccount = buildHealthReimbursementsVirtualAccount([
+      {
+        ...transactions[0],
+        reimbursements: {
+          data: [{ amount: 5 }]
+        }
+      },
+      ...transactions.slice(1)
+    ])
 
-    const virtualAccount = buildHealthReimbursementsVirtualAccount(transactions)
-
-    expect(virtualAccount.balance).toBe(35)
+    expect(virtualAccount.balance).toBe(30)
   })
 
   it('should return a well formed account', () => {

--- a/src/ducks/transactions/TransactionRow.spec.jsx
+++ b/src/ducks/transactions/TransactionRow.spec.jsx
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme'
 import React from 'react'
-import { TestI18n } from 'test/AppLike'
+import AppLike from 'test/AppLike'
 import { RowMobile as TransactionRowMobile } from './TransactionRow'
 
 describe('TransactionRow', () => {
@@ -21,9 +21,9 @@ describe('TransactionRow', () => {
       ...transactionAttributes
     }
     const root = mount(
-      <TestI18n>
+      <AppLike>
         <TransactionRowMobile transaction={transaction} />
-      </TestI18n>
+      </AppLike>
     )
     return { root }
   }

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -178,7 +178,7 @@ export const getHealthExpenseReimbursementStatus = transaction => {
     return transaction.reimbursementStatus
   }
 
-  return isFullyReimbursed(transaction)
+  return hasReimbursements(transaction)
     ? REIMBURSEMENTS_STATUS.reimbursed
     : REIMBURSEMENTS_STATUS.pending
 }

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -160,7 +160,7 @@ describe('getReimbursementStatus', () => {
   })
 
   describe('Health expense case', () => {
-    it('should return `pending` if the status is undefined and the transaction is not fully reimbursed', () => {
+    it('should return `pending` if the status is undefined and the transaction no reimbursement', () => {
       const t1 = {
         manualCategoryId: '400610',
         amount: -10
@@ -170,12 +170,24 @@ describe('getReimbursementStatus', () => {
         manualCategoryId: '400610',
         amount: -10,
         reimbursements: {
-          data: [{ amount: 5 }]
+          data: []
         }
       }
 
       expect(getReimbursementStatus(t1)).toBe(REIMBURSEMENTS_STATUS.pending)
       expect(getReimbursementStatus(t2)).toBe(REIMBURSEMENTS_STATUS.pending)
+    })
+
+    it('should return `reimbursed` if the status is undefined and the transaction has at least 1 reimbursement', () => {
+      const t2 = {
+        manualCategoryId: '400610',
+        amount: -10,
+        reimbursements: {
+          data: [{ amount: 5 }]
+        }
+      }
+
+      expect(getReimbursementStatus(t2)).toBe(REIMBURSEMENTS_STATUS.reimbursed)
     })
 
     it('should return `reimbursed` if the status is undefined and the transaction is fully reimbursed', () => {

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -1357,12 +1357,6 @@
           "amount": 17.5,
           "operationId": "remboursement_docteur_martin_ameli",
           "vendor": "ameli"
-        },
-        {
-          "billId": "io.cozy.bills:bill_harmonie_demo",
-          "amount": 7.5,
-          "operationId": "remboursement_docteur_martin_harmonie",
-          "vendor": "harmonie"
         }
       ]
     },

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -42,11 +42,25 @@ const ignoredWarnings = {
   }
 }
 
+const callAndThrow = (fn, errorMessage) => {
+  return function() {
+    fn.apply(this, arguments)
+    throw new Error(errorMessage)
+  }
+}
+
 // Ignore warnings that we think are not problematic, see
 // https://github.com/cozy/cozy-ui/issues/1318
 // eslint-disable-next-line no-console
 console.warn = ignoreOnConditions(
   // eslint-disable-next-line no-console
-  console.warn,
+  callAndThrow(console.warn, 'console.warn should not be called during tests'),
   Object.values(ignoredWarnings).map(x => x.matcher)
+)
+
+// eslint-disable-next-line no-console
+console.error = callAndThrow(
+  // eslint-disable-next-line no-console
+  console.error,
+  'console.error should not be called during tests'
 )


### PR DESCRIPTION
Previously, a transaction was considered reimbursed only it the sum
of its reimbursements was equal to its amount. This does not work
in practice since without additional health insurance connected,
a health expense is often only reimbursed until 70%.

This is why now, we consider a health expense as reimbursed when it
has at least 1 reimbursement.

This logic could be made more complex in the future, for example
considering the bill as fully reimbursed only if it has the same
number of reimbursements as the number of health insurances connected.