### PR TITLE
Release 1.12.0

### DIFF
--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -1,4 +1,4 @@
-import { groupBy, sortBy, deburr, sumBy, get } from 'lodash'
+import { groupBy, sortBy, deburr, sumBy, get, every } from 'lodash'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import { associateDocuments } from 'ducks/client/utils'
 import { getAccountType, getAccountBalance } from 'ducks/account/helpers'
@@ -136,16 +136,11 @@ export const isFormerAutoGroup = group => group.accountType === null
 export const isAutoGroup = group => group.accountType !== undefined
 export const getGroupAccountType = group => group.accountType
 
-export const isLoanGroup = group => {
-  for (const account of group.accounts.data) {
-    if (getAccountType(account) !== 'Loan') {
-      return false
-    }
-  }
-
-  return true
-}
-
+export const isLoanAccount = account => getAccountType(account) == 'Loan'
+export const isLoanGroup = group =>
+  group.accounts && group.accounts.data
+    ? every(group.accounts.data, isLoanAccount)
+    : false
 /**
  * Returns a group balance (all its accounts balance sumed)
  * @param {Object} group

--- a/src/ducks/groups/helpers.js
+++ b/src/ducks/groups/helpers.js
@@ -136,11 +136,13 @@ export const isFormerAutoGroup = group => group.accountType === null
 export const isAutoGroup = group => group.accountType !== undefined
 export const getGroupAccountType = group => group.accountType
 
-export const isLoanAccount = account => getAccountType(account) == 'Loan'
-export const isLoanGroup = group =>
-  group.accounts && group.accounts.data
+export const isLoanAccount = account =>
+  account ? getAccountType(account) == 'Loan' : false
+export const isLoanGroup = group => {
+  return group.accounts && group.accounts.data
     ? every(group.accounts.data, isLoanAccount)
     : false
+}
 /**
  * Returns a group balance (all its accounts balance sumed)
  * @param {Object} group

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -3,7 +3,8 @@ import {
   getGroupLabel,
   translateAndSortGroups,
   renamedGroup,
-  getGroupBalance
+  getGroupBalance,
+  isLoanGroup
 } from './helpers'
 import { associateDocuments } from 'ducks/client/utils'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
@@ -216,5 +217,46 @@ describe('getGroupBalance', () => {
     const group = { accounts: { data: [] } }
 
     expect(getGroupBalance(group)).toBe(0)
+  })
+})
+
+describe('isLoanGroup', () => {
+  it('should return false if group is not yet hydrated', () => {
+    expect(
+      isLoanGroup({
+        accounts: ['1', '2', '3']
+      })
+    ).toBe(false)
+  })
+
+  it('should return true if every account is a loan', () => {
+    expect(
+      isLoanGroup({
+        accounts: {
+          data: [
+            {
+              type: 'ConsumerCredit'
+            }
+          ]
+        }
+      })
+    ).toBe(true)
+  })
+
+  it('should return false if one account is not a loan', () => {
+    expect(
+      isLoanGroup({
+        accounts: {
+          data: [
+            {
+              type: 'ConsumerCredit'
+            },
+            {
+              type: 'CreditCard'
+            }
+          ]
+        }
+      })
+    ).toBe(false)
   })
 })

--- a/src/ducks/groups/helpers.spec.js
+++ b/src/ducks/groups/helpers.spec.js
@@ -253,7 +253,8 @@ describe('isLoanGroup', () => {
             },
             {
               type: 'CreditCard'
-            }
+            },
+            null
           ]
         }
       })

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -3,7 +3,7 @@
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>
-    <preference name="AppendUserAgent" value="io.cozy.banks.mobile-1.11.0" />
+    <preference name="AppendUserAgent" value="io.cozy.banks.mobile-1.12.0" />
     <content src="index.html" />
     <access origin="*" />
     <allow-intent href="http://*/*" />

--- a/static-files.txt
+++ b/static-files.txt
@@ -2,4 +2,4 @@
 # See the Jenkins job for more information
 # The files will be copied via rsync so be sure to check
 # its man for the behavior of the trailing slash
-src/ducks/notifications/html/assets/ email-assets/
+src/ducks/notifications/assets/ email-assets/


### PR DESCRIPTION
- [ ] Run E2E tests (`yarn test:e2e`)
- [x] Create branch and the PR with the following content
- [x] Bump `package.json`, `config.xml`. Check the details below for Android's `versionCode`, `ios-CFBundleVersion` and `AppendUserAgent`.
- [x] Bump version in master for beta/prod versions not to shadow the next versions
- [ ] Commit and tag with a beta tag (X.Y.Z-beta.M)
- [ ] Push the tag and wait for the CI to push the beta version to the registry
- [ ] Push and check with a cozy from production (which has to be on the beta track for Banks)
- [ ] Release the app on Testflight for iOS. `yarn ios:publish`
- [ ] Release the app on Play Store on `beta` track. `yarn android:publish`
- [ ] Upload the APK (`src/targets/mobile/build/android/cozy-banks.apk`) on [the APK card in Trello](https://trello.com/c/wtToK7IN/1192-apks)
- [ ] Test well on the 3 platforms
- [ ] Tag the branch as prod (X.Y.Z)
- [ ] Push the tag, wait for the CI to push the build to the registry
- [ ] [Promote Android app][playstore] to the production track
- [ ] [Promote iOS app][itunesconnect] to the production track.

<details>
<summary>How to check CI</summary>
In Travis <a href="https://travis-ci.org/cozy/cozy-banks/builds/">logs</a>, you should see

```
Attempting to publish banks (version 0.7.6-beta.0) from https://downcloud.cozycloud.cc/upload/cozy-banks/0.7.6-8f932d80f510e1942fa09865ce3526c166b00b0e/cozy-banks.tar.gz (sha256 dd42d7b55ff3992893cc2432f23a813ded6b6766a880bdf24184d35060150fe7) to https://apps-registry.cozycloud.cc (space: banks)
Application published!
```
To check that the registry has the right version:

```curl "https://apps-registry.cozycloud.cc/banks/registry/banks" | jq '.'```
</details>

<details>
<summary>How to update a Cozy on the beta version of the registry</summary>

```
cozy-stack apps update banks registry://banks/beta --domain drazik2.mycozy.cloud
```

</details>

<details>
<summary>How to deploy on Testflight</summary>

```
yarn ios:publish
```

</details>

<details>
<summary>Managing versions</summary>

#### How to bump versions

At the **start** of the release process

1. Bump the `version` number in `package.json` and `config.xml` according to semver.
2. Copy this version to the `ios-CFBundleVersion` attribute and add a fourth number `.1` (then `.2` for the next beta version etc..)
3. For `android-versionCode`, follow this formula `beta + patch*100 + minor * 10000 + major * 1000000`.
4. Update the version number for the `AppendUserAgent` preference in `config.xml`.

At the **end** of the release process

For iOS you can simply remove the suffix and rebuild/reupload.
For Android, you have nothing to do, and can simply promote the build to the production track.

#### Why not let Cordova manage this automatically ?

The difficulty is that for stores (both PlayStore and iTunesConnect), you cannot have build with the same versionCode (for
Android) or ios-CFBundleVersion (for iOS). Normally those two numbers are managed by Cordova automatically (computed from the `version` attribute) but this
does not work well if during the release process (after having pushed a beta build in Testflight/PlayStore), you want to put a new version (because you have detected bug). If you let Cordova manage this, you would have to change the `version` from your config.xml and your `package.json`, and your production users would see a jump of version.

#### Android versionCode

The android-versionCode has to be a integer. But it has to be related to the `versionName` for debugging/understand purposes. Cordova does patch + minor *100 + major * 10000 but it does not leave space for beta versions (that have the same `versionName`). This is why we go one step further : `beta + patch *100 + minor * 10000 * major * 1000000). 0.7.6-beta1 is then `700601`. This number is not visible to the users, it's `android-versionName` that is visible and it's copied from `version` automatically Cordova.

#### ios-CFBundleVersion

For iOS, this is a little bit better since `ios-CFBundleVersion` can be a string with a fourth number at the end. Add a fourth number `.1` (and then `.2`, `.3` etc..) to your version number while developing, until you are sure that the build is completely ready. Then you can remove the suffix and `ios-CFBundleVersion` will be the same as `version`.

Cordova doc : https://cordova.apache.org/docs/fr/latest/config_ref/
iOS doc : https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-102364
Android doc : https://developer.android.com/google/play/publishing/multiple-apks#VersionCodes
</details>

[playstore]: https://play.google.com/apps/publish/?pli=1&account=7424624102327137158#ManageReleasesPlace:p=io.cozy.banks.mobile&appid=4975496102553953948
[itunesconnect]: https://itunesconnect.apple.com/WebObjects/iTunesConnect.woa/ra/ng/app/1349814380