### PR TITLE
chore: Change ENV name var for HMR

### DIFF
--- a/config/webpack.config.hot-reload.js
+++ b/config/webpack.config.hot-reload.js
@@ -1,20 +1,15 @@
 const webpack = require('webpack')
 const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin')
 
-const HOST = process.env.DEV_SERVER_HOST || 'localhost'
-const PORT = process.env.DEV_SERVER_PORT
-  ? parseInt(process.env.DEV_SERVER_PORT, 10)
-  : 8282
+const HOST = process.env.DEV_HOST || 'localhost'
+const PORT = process.env.DEV_PORT ? parseInt(process.env.DEV_PORT, 10) : 8282
 
 module.exports = {
   output: {
     filename: 'app.js',
     publicPath: `http://${HOST}:${PORT}/`
   },
-  plugins: [
-    new webpack.NamedModulesPlugin(),
-    new HtmlWebpackHarddiskPlugin()
-  ],
+  plugins: [new webpack.NamedModulesPlugin(), new HtmlWebpackHarddiskPlugin()],
   devServer: {
     host: HOST,
     port: PORT,

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -133,9 +133,9 @@ $ yarn ios:run:emulator
 
 ```
 # Replace the host with your own host (find it with ifconfig)
-$ env DEV_SERVER_HOST=192.168.1.36 yarn build:mobile:hot
+$ env DEV_HOST=192.168.1.36 yarn build:mobile:hot
 $ yarn ios:run # at this point the app is blank since it cannot access the files from your host
-$ env DEV_SERVER_HOST=192.168.1.36 yarn watch:mobile:hot # launch a webpack-dev-server
+$ env DEV_HOST=192.168.1.36 yarn watch:mobile:hot # launch a webpack-dev-server
 ```
 
 ⚠️⚠️⚠️ If you watch a production build, you must edit the webpack config to have

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch": "npm run watch:browser",
     "watch:browser": "NODE_ENV=browser:development npm run commons:watch:hot",
     "watch:mobile:cold": "NODE_ENV=mobile:development npm run commons:watch -- --env.target=mobile",
-    "util:check-dev-server": "[[ $DEV_SERVER_HOST == '' ]] && echo 'Please set DEV_SERVER_HOST for hot reload on mobile (ex: export DEV_SERVER_HOST=192.168.1.36)' && exit 1 || exit 0",
+    "util:check-dev-server": "[[ $DEV_HOST == '' ]] && echo 'Please set DEV_HOST for hot reload on mobile (ex: export DEV_HOST=192.168.1.36)' && exit 1 || exit 0",
     "watch:mobile": "npm run util:check-dev-server && NODE_ENV=mobile:development npm run commons:watch:hot",
     "watch:mobile:production": "NODE_ENV=mobile:production npm run commons:watch -- --env.target=mobile",
     "serve:mobile": "(cd src/targets/mobile/www && http-server -p 8005)",


### PR DESCRIPTION
I'm a cozy-scripts user so I'm a bit biased. But I can affirm that changing from Drive to Banks and not having the HMR working it's not very convenient... Fixed by using the same env var name. 

https://github.com/cozy/create-cozy-app/blob/v1.12.x/packages/cozy-scripts/utils/constants.js#L9

