### PR TITLE
Use Q instead of client.all

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from 'components/KonnectorUpdateInfo/styles.styl'
 import { useI18n } from 'cozy-ui/transpiled/react'
-import { withClient } from 'cozy-client'
+import { withClient, Q } from 'cozy-client';
 import { flowRight as compose } from 'lodash'
 import { queryConnect } from 'cozy-client'
 import { KONNECTOR_DOCTYPE } from 'doctypes'
@@ -77,8 +77,7 @@ const KonnectorUpdateInfo = ({ outdatedKonnectors, client, breakpoints }) => {
 
 const outdatedKonnectors = {
   query: client =>
-    client
-      .all(KONNECTOR_DOCTYPE)
+    Q(KONNECTOR_DOCTYPE)
       .where({ available_version: { $exists: true } }),
   fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
   as: 'outdatedKonnectors'

--- a/src/components/KonnectorUpdateInfo/index.js
+++ b/src/components/KonnectorUpdateInfo/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styles from 'components/KonnectorUpdateInfo/styles.styl'
 import { useI18n } from 'cozy-ui/transpiled/react'
-import { withClient, Q } from 'cozy-client';
+import { withClient, Q } from 'cozy-client'
 import { flowRight as compose } from 'lodash'
 import { queryConnect } from 'cozy-client'
 import { KONNECTOR_DOCTYPE } from 'doctypes'
@@ -76,9 +76,8 @@ const KonnectorUpdateInfo = ({ outdatedKonnectors, client, breakpoints }) => {
 }
 
 const outdatedKonnectors = {
-  query: client =>
-    Q(KONNECTOR_DOCTYPE)
-      .where({ available_version: { $exists: true } }),
+  query: () =>
+    Q(KONNECTOR_DOCTYPE).where({ available_version: { $exists: true } }),
   fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
   as: 'outdatedKonnectors'
 }

--- a/src/components/SelectDates/scrollAware.js
+++ b/src/components/SelectDates/scrollAware.js
@@ -13,7 +13,7 @@ const getScrollingElement = node =>
  * a class only we are not at the top.
  */
 export default Wrapped =>
-  (class _ScrollAwareWrapper extends Component {
+  class _ScrollAwareWrapper extends Component {
     state = { scrolling: false }
 
     componentDidMount() {
@@ -42,4 +42,4 @@ export default Wrapped =>
       const { scrolling } = this.state
       return <Wrapped {...props} scrolling={scrolling} />
     }
-  })
+  }

--- a/src/components/SelectDates/scrollAware.js
+++ b/src/components/SelectDates/scrollAware.js
@@ -13,7 +13,7 @@ const getScrollingElement = node =>
  * a class only we are not at the top.
  */
 export default Wrapped =>
-  class _ScrollAwareWrapper extends Component {
+  (class _ScrollAwareWrapper extends Component {
     state = { scrolling: false }
 
     componentDidMount() {
@@ -42,4 +42,4 @@ export default Wrapped =>
       const { scrolling } = this.state
       return <Wrapped {...props} scrolling={scrolling} />
     }
-  }
+  })

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -1,5 +1,5 @@
 import fromPairs from 'lodash/fromPairs'
-import CozyClient, { QueryDefinition, HasManyInPlace } from 'cozy-client'
+import CozyClient, { QueryDefinition, HasManyInPlace, Q } from 'cozy-client';
 
 export const RECIPIENT_DOCTYPE = 'io.cozy.bank.recipients'
 export const ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -173,26 +173,25 @@ export const schema = {
 const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
 
 export const accountsConn = {
-  query: client => client.all(ACCOUNT_DOCTYPE).include(['owners']),
+  query: client => Q(ACCOUNT_DOCTYPE).include(['owners']),
   as: 'accounts',
   fetchPolicy: older30s
 }
 
 export const groupsConn = {
-  query: client => client.all(GROUP_DOCTYPE),
+  query: client => Q(GROUP_DOCTYPE),
   as: 'groups',
   fetchPolicy: older30s
 }
 
 export const triggersConn = {
-  query: client => client.all(TRIGGER_DOCTYPE),
+  query: client => Q(TRIGGER_DOCTYPE),
   as: 'triggers'
 }
 
 export const transactionsConn = {
   query: client =>
-    client
-      .all(TRANSACTION_DOCTYPE)
+    Q(TRANSACTION_DOCTYPE)
       .UNSAFE_noLimit()
       .include(['bills', 'account', 'reimbursements']),
   as: 'transactions',
@@ -200,24 +199,24 @@ export const transactionsConn = {
 }
 
 export const appsConn = {
-  query: client => client.all(APP_DOCTYPE),
+  query: client => Q(APP_DOCTYPE),
   as: 'apps'
 }
 
 export const billsConn = {
-  query: client => client.all(BILLS_DOCTYPE),
+  query: client => Q(BILLS_DOCTYPE),
   as: 'bills',
   fetchPolicy: older30s
 }
 
 export const settingsConn = {
-  query: client => client.all(SETTINGS_DOCTYPE),
+  query: client => Q(SETTINGS_DOCTYPE),
   as: 'settings',
   fetchPolicy: older30s
 }
 
 export const recipientsConn = {
-  query: client => client.all(RECIPIENT_DOCTYPE),
+  query: client => Q(RECIPIENT_DOCTYPE),
   as: 'recipients',
   fetchPolicy: older30s
 }

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -1,5 +1,5 @@
 import fromPairs from 'lodash/fromPairs'
-import CozyClient, { QueryDefinition, HasManyInPlace, Q } from 'cozy-client';
+import CozyClient, { QueryDefinition, HasManyInPlace, Q } from 'cozy-client'
 
 export const RECIPIENT_DOCTYPE = 'io.cozy.bank.recipients'
 export const ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -173,24 +173,24 @@ export const schema = {
 const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
 
 export const accountsConn = {
-  query: client => Q(ACCOUNT_DOCTYPE).include(['owners']),
+  query: () => Q(ACCOUNT_DOCTYPE).include(['owners']),
   as: 'accounts',
   fetchPolicy: older30s
 }
 
 export const groupsConn = {
-  query: client => Q(GROUP_DOCTYPE),
+  query: () => Q(GROUP_DOCTYPE),
   as: 'groups',
   fetchPolicy: older30s
 }
 
 export const triggersConn = {
-  query: client => Q(TRIGGER_DOCTYPE),
+  query: () => Q(TRIGGER_DOCTYPE),
   as: 'triggers'
 }
 
 export const transactionsConn = {
-  query: client =>
+  query: () =>
     Q(TRANSACTION_DOCTYPE)
       .UNSAFE_noLimit()
       .include(['bills', 'account', 'reimbursements']),
@@ -199,24 +199,24 @@ export const transactionsConn = {
 }
 
 export const appsConn = {
-  query: client => Q(APP_DOCTYPE),
+  query: () => Q(APP_DOCTYPE),
   as: 'apps'
 }
 
 export const billsConn = {
-  query: client => Q(BILLS_DOCTYPE),
+  query: () => Q(BILLS_DOCTYPE),
   as: 'bills',
   fetchPolicy: older30s
 }
 
 export const settingsConn = {
-  query: client => Q(SETTINGS_DOCTYPE),
+  query: () => Q(SETTINGS_DOCTYPE),
   as: 'settings',
   fetchPolicy: older30s
 }
 
 export const recipientsConn = {
-  query: client => Q(RECIPIENT_DOCTYPE),
+  query: () => Q(RECIPIENT_DOCTYPE),
   as: 'recipients',
   fetchPolicy: older30s
 }

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -27,7 +27,7 @@ import {
 } from 'ducks/filters'
 import styles from 'ducks/account/AccountSwitch.styl'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
-import { queryConnect } from 'cozy-client'
+import { queryConnect, Q } from 'cozy-client';
 
 import { getGroupLabel } from 'ducks/groups/helpers'
 import { getVirtualGroups } from 'selectors'
@@ -422,8 +422,8 @@ const mapDispatchToProps = dispatch => ({
 
 export default compose(
   queryConnect({
-    accounts: { query: client => client.all(ACCOUNT_DOCTYPE), as: 'accounts' },
-    groups: { query: client => client.all(GROUP_DOCTYPE), as: 'groups' }
+    accounts: { query: client => Q(ACCOUNT_DOCTYPE), as: 'accounts' },
+    groups: { query: client => Q(GROUP_DOCTYPE), as: 'groups' }
   }),
   translate(),
   withBreakpoints(),

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -27,7 +27,7 @@ import {
 } from 'ducks/filters'
 import styles from 'ducks/account/AccountSwitch.styl'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
-import { queryConnect, Q } from 'cozy-client';
+import { queryConnect, Q } from 'cozy-client'
 
 import { getGroupLabel } from 'ducks/groups/helpers'
 import { getVirtualGroups } from 'selectors'
@@ -422,8 +422,8 @@ const mapDispatchToProps = dispatch => ({
 
 export default compose(
   queryConnect({
-    accounts: { query: client => Q(ACCOUNT_DOCTYPE), as: 'accounts' },
-    groups: { query: client => Q(GROUP_DOCTYPE), as: 'groups' }
+    accounts: { query: () => Q(ACCOUNT_DOCTYPE), as: 'accounts' },
+    groups: { query: () => Q(GROUP_DOCTYPE), as: 'groups' }
   }),
   translate(),
   withBreakpoints(),

--- a/src/ducks/account/services.js
+++ b/src/ducks/account/services.js
@@ -6,6 +6,8 @@ import set from 'lodash/set'
 import mergeSets from 'utils/mergeSets'
 import { addOwnerToAccount } from './helpers'
 
+import { Q } from "cozy-client";
+
 const log = logger.namespace('link-myself-to-accounts')
 
 const fetchMyself = async client => {
@@ -26,7 +28,7 @@ const fetchMyself = async client => {
 
 export const linkMyselfToAccounts = async ({ client }) => {
   const settings = await fetchSettings(client)
-  const accounts = await client.queryAll(client.all(ACCOUNT_DOCTYPE))
+  const accounts = await client.queryAll(Q(ACCOUNT_DOCTYPE))
 
   const alreadyProcessed = new Set(
     settings.linkMyselfToAccounts.processedAccounts
@@ -77,7 +79,7 @@ export const unlinkMyselfFromAccounts = async ({ client }) => {
     return
   }
 
-  const accounts = await client.queryAll(client.all(ACCOUNT_DOCTYPE))
+  const accounts = await client.queryAll(Q(ACCOUNT_DOCTYPE))
 
   for (const account of accounts) {
     const currentOwners = get(account, 'relationships.owners.data', [])

--- a/src/ducks/account/services.js
+++ b/src/ducks/account/services.js
@@ -6,7 +6,7 @@ import set from 'lodash/set'
 import mergeSets from 'utils/mergeSets'
 import { addOwnerToAccount } from './helpers'
 
-import { Q } from "cozy-client";
+import { Q } from 'cozy-client'
 
 const log = logger.namespace('link-myself-to-accounts')
 

--- a/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
+++ b/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
@@ -14,7 +14,7 @@ import { buildNotificationData } from './service'
 
 import logger from 'cozy-logger'
 
-import { Q } from "cozy-client";
+import { Q } from 'cozy-client'
 
 const log = logger.namespace('category-budgets')
 

--- a/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
+++ b/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
@@ -14,10 +14,12 @@ import { buildNotificationData } from './service'
 
 import logger from 'cozy-logger'
 
+import { Q } from "cozy-client";
+
 const log = logger.namespace('category-budgets')
 
 const fetchDoctypeById = async (client, doctype) => {
-  const { data } = await client.query(client.all(doctype))
+  const { data } = await client.query(Q(doctype))
   return keyBy(data, x => x._id)
 }
 

--- a/src/ducks/budgetAlerts/index.js
+++ b/src/ducks/budgetAlerts/index.js
@@ -6,13 +6,15 @@ import sumBy from 'lodash/sumBy'
 import { fetchCategoryAlerts } from 'ducks/settings/helpers'
 import { startOfMonth, endOfMonth, addDays, format } from 'date-fns'
 
+import { Q } from "cozy-client";
+
 const log = logger.namespace('category-alerts')
 
 const copyAlert = alert => ({ ...alert })
 
 const fetchGroup = async (client, groupId) => {
   const { data: group } = await client.query(
-    client.all(GROUP_DOCTYPE).getById(groupId)
+    Q(GROUP_DOCTYPE).getById(groupId)
   )
   return group
 }
@@ -77,7 +79,7 @@ export const fetchExpensesForAlert = async (client, alert, currentDate) => {
     })`
   )
   const { data: monthExpenses } = await client.query(
-    client.all(TRANSACTION_DOCTYPE).where(selector)
+    Q(TRANSACTION_DOCTYPE).where(selector)
   )
 
   const categoryExpenses = monthExpenses.filter(tr =>

--- a/src/ducks/budgetAlerts/index.js
+++ b/src/ducks/budgetAlerts/index.js
@@ -6,16 +6,14 @@ import sumBy from 'lodash/sumBy'
 import { fetchCategoryAlerts } from 'ducks/settings/helpers'
 import { startOfMonth, endOfMonth, addDays, format } from 'date-fns'
 
-import { Q } from "cozy-client";
+import { Q } from 'cozy-client'
 
 const log = logger.namespace('category-alerts')
 
 const copyAlert = alert => ({ ...alert })
 
 const fetchGroup = async (client, groupId) => {
-  const { data: group } = await client.query(
-    Q(GROUP_DOCTYPE).getById(groupId)
-  )
+  const { data: group } = await client.query(Q(GROUP_DOCTYPE).getById(groupId))
   return group
 }
 

--- a/src/ducks/groups/services.js
+++ b/src/ducks/groups/services.js
@@ -12,12 +12,14 @@ import {
   getGroupAccountType
 } from 'ducks/groups/helpers'
 
+import { Q } from "cozy-client";
+
 const log = logger.namespace('auto-groups')
 
 export const createAutoGroups = async ({ client }) => {
   const settings = await fetchSettings(client)
-  const groups = await client.queryAll(client.all(GROUP_DOCTYPE))
-  const accounts = await client.queryAll(client.all(ACCOUNT_DOCTYPE))
+  const groups = await client.queryAll(Q(GROUP_DOCTYPE))
+  const accounts = await client.queryAll(Q(ACCOUNT_DOCTYPE))
 
   const alreadyProcessed = new Set(settings.autogroups.processedAccounts)
 
@@ -90,7 +92,7 @@ export const createAutoGroups = async ({ client }) => {
 }
 
 export const listAutoGroups = async ({ client }) => {
-  const groups = await client.queryAll(client.all(GROUP_DOCTYPE))
+  const groups = await client.queryAll(Q(GROUP_DOCTYPE))
 
   const autogroups = groups.filter(isAutoGroup)
 
@@ -108,7 +110,7 @@ export const listAutoGroups = async ({ client }) => {
 
 export const purgeAutoGroups = async ({ client }) => {
   const { data: groups } = await client.query(
-    client.all(GROUP_DOCTYPE, { limit: null })
+    Q(GROUP_DOCTYPE, { limit: null })
   )
   let autogroups = groups.filter(isAutoGroup)
 

--- a/src/ducks/groups/services.js
+++ b/src/ducks/groups/services.js
@@ -12,7 +12,7 @@ import {
   getGroupAccountType
 } from 'ducks/groups/helpers'
 
-import { Q } from "cozy-client";
+import { Q } from 'cozy-client'
 
 const log = logger.namespace('auto-groups')
 
@@ -109,9 +109,7 @@ export const listAutoGroups = async ({ client }) => {
 }
 
 export const purgeAutoGroups = async ({ client }) => {
-  const { data: groups } = await client.query(
-    Q(GROUP_DOCTYPE, { limit: null })
-  )
+  const { data: groups } = await client.query(Q(GROUP_DOCTYPE, { limit: null }))
   let autogroups = groups.filter(isAutoGroup)
 
   autogroups = autogroups.map(x => omit(x, '_type'))

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -1,5 +1,5 @@
 import logger from 'cozy-logger'
-import CozyClient, { Q } from 'cozy-client';
+import CozyClient, { Q } from 'cozy-client'
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n/translation'
 
 import BalanceLower from './BalanceLower'

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -1,5 +1,5 @@
 import logger from 'cozy-logger'
-import CozyClient from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client';
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n/translation'
 
 import BalanceLower from './BalanceLower'
@@ -51,7 +51,7 @@ export const fetchTransactionAccounts = async transactions => {
 }
 
 export const fetchGroups = async client => {
-  const groups = await client.query(client.all(GROUP_DOCTYPE))
+  const groups = await client.query(Q(GROUP_DOCTYPE))
   return groups
 }
 

--- a/src/ducks/pin/queries.js
+++ b/src/ducks/pin/queries.js
@@ -2,8 +2,10 @@ import { SETTINGS_DOCTYPE } from 'doctypes'
 import { connect } from 'react-redux'
 import mapValues from 'lodash/mapValues'
 
+import { Q } from "cozy-client";
+
 const getOne = (doctype, id) => client => {
-  const queryDef = client.all(doctype)
+  const queryDef = Q(doctype)
   queryDef.id = id
   return queryDef
 }

--- a/src/ducks/pin/queries.js
+++ b/src/ducks/pin/queries.js
@@ -2,9 +2,9 @@ import { SETTINGS_DOCTYPE } from 'doctypes'
 import { connect } from 'react-redux'
 import mapValues from 'lodash/mapValues'
 
-import { Q } from "cozy-client";
+import { Q } from 'cozy-client'
 
-const getOne = (doctype, id) => client => {
+const getOne = (doctype, id) => () => {
   const queryDef = Q(doctype)
   queryDef.id = id
   return queryDef

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -26,7 +26,7 @@ import {
   getAccountType
 } from 'ducks/account/helpers'
 import { getHomeURL } from 'ducks/apps/selectors'
-import { Query } from 'cozy-client'
+import { Query, Q } from 'cozy-client';
 import { queryConnect, withClient } from 'cozy-client'
 import { ACCOUNT_DOCTYPE, APP_DOCTYPE } from 'doctypes'
 import { Padded } from 'components/Spacing'
@@ -232,7 +232,7 @@ const mapStateToProps = state => ({
 const GeneralSettings = compose(
   withRouter,
   queryConnect({
-    apps: { query: client => client.all(APP_DOCTYPE), as: 'apps' }
+    apps: { query: client => Q(APP_DOCTYPE), as: 'apps' }
   }),
   withClient,
   withDispatch,

--- a/src/ducks/settings/AccountSettings.jsx
+++ b/src/ducks/settings/AccountSettings.jsx
@@ -26,7 +26,7 @@ import {
   getAccountType
 } from 'ducks/account/helpers'
 import { getHomeURL } from 'ducks/apps/selectors'
-import { Query, Q } from 'cozy-client';
+import { Query, Q } from 'cozy-client'
 import { queryConnect, withClient } from 'cozy-client'
 import { ACCOUNT_DOCTYPE, APP_DOCTYPE } from 'doctypes'
 import { Padded } from 'components/Spacing'
@@ -232,7 +232,7 @@ const mapStateToProps = state => ({
 const GeneralSettings = compose(
   withRouter,
   queryConnect({
-    apps: { query: client => Q(APP_DOCTYPE), as: 'apps' }
+    apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }
   }),
   withClient,
   withDispatch,

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -7,7 +7,7 @@ import { withBreakpoints } from 'cozy-ui/transpiled/react'
 import { groupBy, flowRight as compose, sortBy } from 'lodash'
 import Table from 'components/Table'
 import Loading from 'components/Loading'
-import { queryConnect, Q } from 'cozy-client';
+import { queryConnect, Q } from 'cozy-client'
 import plus from 'assets/icons/16/plus.svg'
 import styles from 'ducks/settings/AccountsSettings.styl'
 import btnStyles from 'styles/buttons.styl'
@@ -182,7 +182,7 @@ class AccountsSettings extends Component {
 export default compose(
   queryConnect({
     accountsCollection: accountsConn,
-    apps: { query: client => Q(APP_DOCTYPE), as: 'apps' }
+    apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }
   }),
   translate()
 )(AccountsSettings)

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -7,7 +7,7 @@ import { withBreakpoints } from 'cozy-ui/transpiled/react'
 import { groupBy, flowRight as compose, sortBy } from 'lodash'
 import Table from 'components/Table'
 import Loading from 'components/Loading'
-import { queryConnect } from 'cozy-client'
+import { queryConnect, Q } from 'cozy-client';
 import plus from 'assets/icons/16/plus.svg'
 import styles from 'ducks/settings/AccountsSettings.styl'
 import btnStyles from 'styles/buttons.styl'
@@ -182,7 +182,7 @@ class AccountsSettings extends Component {
 export default compose(
   queryConnect({
     accountsCollection: accountsConn,
-    apps: { query: client => client.all(APP_DOCTYPE), as: 'apps' }
+    apps: { query: client => Q(APP_DOCTYPE), as: 'apps' }
   }),
   translate()
 )(AccountsSettings)

--- a/test/client.js
+++ b/test/client.js
@@ -1,4 +1,4 @@
-import CozyClient from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 import { schema } from 'doctypes'
 import { receiveQueryResult, initQuery } from 'cozy-client/dist/store'
 import { normalizeDoc } from 'cozy-stack-client/dist/DocumentCollection'
@@ -39,7 +39,7 @@ export const createClientWithData = ({ queries, data, clientOptions }) => {
     client.store.dispatch(
       initQuery(
         queryName,
-        queryOptions.definition || client.all(queryOptions.doctype)
+        queryOptions.definition || Q(queryOptions.doctype)
       )
     )
     client.store.dispatch(


### PR DESCRIPTION
Client.all is deprecated, we prefer to use Q that does not
induce us in errror.