### PR TITLE
Merge pull request #1764 from cozy/fix-rule-creation

### DIFF
--- a/src/ducks/settings/Rules.jsx
+++ b/src/ducks/settings/Rules.jsx
@@ -46,6 +46,7 @@ const Rules = ({
       setSaving(false)
     }
   }
+
   return (
     <>
       {items.length > 0 ? (

--- a/src/ducks/settings/Rules.jsx
+++ b/src/ducks/settings/Rules.jsx
@@ -53,15 +53,14 @@ const Rules = ({
           {items
             ? items.map((item, i) => children(item, i, createOrUpdate, remove))
             : null}
-
-          {creating ? (
-            <ItemEditionModal
-              onDismiss={() => setCreating(false)}
-              initialDoc={makeNewItem()}
-              onEdit={handleCreateItem}
-            />
-          ) : null}
         </Stack>
+      ) : null}
+      {creating ? (
+        <ItemEditionModal
+          onDismiss={() => setCreating(false)}
+          initialDoc={makeNewItem()}
+          onEdit={handleCreateItem}
+        />
       ) : null}
       <AddRuleButton
         label={t(addButtonLabelKey)}

--- a/src/ducks/settings/Rules.spec.jsx
+++ b/src/ducks/settings/Rules.spec.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import CategoryAlertCard from 'ducks/settings/CategoryAlerts/CategoryAlertCard'
+import CategoryAlertEditModal from 'ducks/settings/CategoryAlerts/CategoryAlertEditModal'
+
+import { makeNewAlert } from 'ducks/budgetAlerts'
+import Rules, { AddRuleButton } from 'ducks/settings/Rules'
+import AppLike from 'test/AppLike'
+import { act } from 'react-dom/test-utils'
+
+describe('Rules', () => {
+  const setup = ({ initialRules }) => {
+    const root = mount(
+      <AppLike>
+        <Rules
+          rules={initialRules}
+          onUpdate={() => {}}
+          onError={() => {}}
+          addButtonLabelKey="Settings.rules.create"
+          makeNewItem={makeNewAlert}
+          ItemEditionModal={CategoryAlertEditModal}
+        >
+          {(alert, i, createOrUpdateAlert, removeAlert) => (
+            <div key={i}>
+              <CategoryAlertCard
+                updateAlert={createOrUpdateAlert}
+                removeAlert={removeAlert}
+                alert={alert}
+              />
+            </div>
+          )}
+        </Rules>
+      </AppLike>
+    )
+    return { root }
+  }
+
+  it('should be possible to create a rule', () => {
+    const { root } = setup({ initialRules: [] })
+    act(() => {
+      root
+        .find(AddRuleButton)
+        .props()
+        .onClick()
+    })
+    root.update()
+    const modal = root.find(CategoryAlertEditModal)
+    expect(modal.props().initialDoc).toEqual({
+      accountOrGroup: null,
+      categoryId: '400110',
+      maxThreshold: 100
+    })
+  })
+})

--- a/src/ducks/settings/Rules.spec.jsx
+++ b/src/ducks/settings/Rules.spec.jsx
@@ -1,3 +1,4 @@
+import { mount } from 'enzyme'
 import React from 'react'
 import CategoryAlertCard from 'ducks/settings/CategoryAlerts/CategoryAlertCard'
 import CategoryAlertEditModal from 'ducks/settings/CategoryAlerts/CategoryAlertEditModal'

--- a/test/client.js
+++ b/test/client.js
@@ -37,10 +37,7 @@ export const createClientWithData = ({ queries, data, clientOptions }) => {
   client.ensureStore()
   for (let [queryName, queryOptions] of Object.entries(queries || {})) {
     client.store.dispatch(
-      initQuery(
-        queryName,
-        queryOptions.definition || Q(queryOptions.doctype)
-      )
+      initQuery(queryName, queryOptions.definition || Q(queryOptions.doctype))
     )
     client.store.dispatch(
       receiveQueryResult(queryName, {


### PR DESCRIPTION
Since the modal was wrapped in the stack component that was displayed
only when there were rules, the creation modal was not displayed when
there were no rules.