### PR TITLE
fix: Humanis konnector slug was the wrong one in brands

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -232,7 +232,7 @@ Array [
   Object {
     "health": true,
     "isInstalled": false,
-    "konnectorSlug": "\\\\bhumanis\\\\b",
+    "konnectorSlug": "humanis",
     "name": "Humanis",
     "regexp": "\\\\bhumanis\\\\b",
   },
@@ -775,7 +775,7 @@ Array [
   Object {
     "health": true,
     "isInstalled": false,
-    "konnectorSlug": "\\\\bhumanis\\\\b",
+    "konnectorSlug": "humanis",
     "name": "Humanis",
     "regexp": "\\\\bhumanis\\\\b",
   },

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -198,7 +198,7 @@
   {
     "name": "Humanis",
     "regexp": "\\bhumanis\\b",
-    "konnectorSlug": "\\bhumanis\\b",
+    "konnectorSlug": "humanis",
     "health": true
   },
   {


### PR DESCRIPTION
This led to an io.cozy.app.suggestions containing the wrong slug, which
led to the suggestion of the humanis connector even if it was already
installed.

https://trello.com/c/uyYGL72O/339-%F0%9F%92%B6-pfm-suggestion-de-connecteur-en-double