### PR TITLE
feat: Drop iOS 10 support

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -49,6 +49,7 @@
         <allow-intent href="market:*" />
     </platform>
     <platform name="ios">
+        <preference name="deployment-target" value="11.0" />
         <config-file overwrite="true" parent="FIREBASE_ANALYTICS_COLLECTION_DEACTIVATED" platform="ios" target="*-Info.plist">
             <true />
         </config-file>


### PR DESCRIPTION
Since we need to have access to Crypto Web APIs, we have to drop iOS 10 support. (see https://github.com/cozy/cozy-stack/pull/2310)