### PR TITLE
chore: Clean actions and bills in fixtures

### DIFF
--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -954,10 +954,7 @@
       "currency": "€",
       "amount": 80,
       "date": "{{ freshDate '2018-10-02T00:00:00Z' }}",
-      "_id": "c5d3364d147d8dc5da80fc9e354a88f5",
-      "bills": [
-        "io.cozy.bills:b3"
-      ]
+      "_id": "c5d3364d147d8dc5da80fc9e354a88f5"
     },
     {
       "_id": "446ae26d705b2eb461ca264d3849ab7a",
@@ -967,12 +964,6 @@
       "currency": "€",
       "date": "{{ freshDate '2018-10-02T00:00:00Z' }}",
       "label": "RETRAITE",
-      "action": {
-        "target": "_blank",
-        "trad": "Accéder au site Fnac",
-        "type": "url",
-        "url": "https://www.fnac.com/video.asp#bl=MMvi"
-      },
       "demo": false
     },
     {
@@ -1030,13 +1021,7 @@
       "currency": "€",
       "amount": -100,
       "date": "{{ freshDate '2018-10-04T00:00:00Z' }}",
-      "_id": "4bbfe1f845ad1231c7d07aa3e04f97d1",
-      "action": {
-        "target": "_blank",
-        "trad": "Accéder à votre paie",
-        "type": "url",
-        "url": "https://marvelapp.com/2ci574d/screen/30245778"
-      }
+      "_id": "4bbfe1f845ad1231c7d07aa3e04f97d1"
     },
     {
       "demo": false,
@@ -1098,13 +1083,7 @@
       "label": "KAISER BOULANGERIE",
       "currency": "€",
       "amount": -12.1,
-      "date": "{{ freshDate '2018-10-08T00:00:00Z' }}",
-      "action": {
-        "url": "https://www.fnac.com/video.asp#bl=MMvi",
-        "trad": "Accéder au site Fnac",
-        "type": "url",
-        "target": "_blank"
-      }
+      "date": "{{ freshDate '2018-10-08T00:00:00Z' }}"
     },
     {
       "demo": false,


### PR DESCRIPTION
Some transactions had an action or bill that was assigned to it but
shouldn't