### PR TITLE
Fix virtual accounts switches state

### DIFF
--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -177,6 +177,7 @@ const buildReimbursementsVirtualAccount = specs => transactions => {
   const account = {
     _id: specs.id,
     _type: ACCOUNT_DOCTYPE,
+    id: specs.id,
     label: `Data.virtualAccounts.${specs.translationKey}`,
     balance,
     type: 'Reimbursements',

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -169,6 +169,8 @@ describe('buildHealthReimbursementsVirtualAccount', () => {
   it('should return a well formed account', () => {
     const expected = {
       _id: 'health_reimbursements',
+      _type: 'io.cozy.bank.accounts',
+      id: 'health_reimbursements',
       virtual: true,
       balance: expect.any(Number),
       label: 'Data.virtualAccounts.healthReimbursements',
@@ -309,6 +311,8 @@ describe('buildProfessionalReimbursementsVirtualAccount', () => {
   it('should return a well formed account', () => {
     const expected = {
       _id: 'professional_reimbursements',
+      _type: 'io.cozy.bank.accounts',
+      id: 'professional_reimbursements',
       virtual: true,
       balance: expect.any(Number),
       label: 'Data.virtualAccounts.professionalReimbursements',
@@ -381,6 +385,8 @@ describe('buildOthersReimbursementsVirtualAccount', () => {
   it('should return a well formed account', () => {
     const expected = {
       _id: 'others_reimbursements',
+      _type: 'io.cozy.bank.accounts',
+      id: 'others_reimbursements',
       virtual: true,
       balance: expect.any(Number),
       label: 'Data.virtualAccounts.othersReimbursements',

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -55,6 +55,26 @@ const REALTIME_DOCTYPES = [
   TRANSACTION_DOCTYPE
 ]
 
+const isLoading = props => {
+  const {
+    accounts: accountsCollection,
+    groups: groupsCollection,
+    settings: settingsCollection,
+    triggers: triggersCollection
+  } = props
+
+  const collections = [
+    accountsCollection,
+    groupsCollection,
+    triggersCollection,
+    settingsCollection
+  ]
+
+  return collections.some(
+    col => isCollectionLoading(col) && !hasBeenLoaded(col)
+  )
+}
+
 class Balance extends PureComponent {
   constructor(props) {
     super(props)
@@ -80,20 +100,9 @@ class Balance extends PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const {
-      groups,
-      accounts,
-      settings: settingsCollection,
-      virtualGroups
-    } = props
+    const { groups, settings: settingsCollection, virtualGroups } = props
 
-    const isLoading =
-      (isCollectionLoading(groups) && !hasBeenLoaded(groups)) ||
-      (isCollectionLoading(accounts) && !hasBeenLoaded(accounts)) ||
-      (isCollectionLoading(settingsCollection) &&
-        !hasBeenLoaded(settingsCollection))
-
-    if (isLoading) {
+    if (isLoading(props)) {
       return null
     }
 
@@ -314,21 +323,11 @@ class Balance extends PureComponent {
     const {
       accounts: accountsCollection,
       groups: groupsCollection,
-      settings: settingsCollection,
       triggers: triggersCollection,
       virtualGroups
     } = this.props
 
-    const collections = [
-      accountsCollection,
-      groupsCollection,
-      triggersCollection,
-      settingsCollection
-    ]
-
-    if (
-      collections.some(col => isCollectionLoading(col) && !hasBeenLoaded(col))
-    ) {
+    if (isLoading(this.props)) {
       return (
         <Fragment>
           <BarTheme theme="primary" />

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -75,6 +75,12 @@ const isLoading = props => {
   )
 }
 
+const getAllGroups = props => {
+  const { groups, virtualGroups } = props
+
+  return [...groups.data, ...virtualGroups]
+}
+
 class Balance extends PureComponent {
   constructor(props) {
     super(props)
@@ -100,14 +106,13 @@ class Balance extends PureComponent {
   }
 
   static getDerivedStateFromProps(props, state) {
-    const { groups, settings: settingsCollection, virtualGroups } = props
-
     if (isLoading(props)) {
       return null
     }
 
+    const { settings: settingsCollection } = props
     const settings = getDefaultedSettingsFromCollection(settingsCollection)
-    const allGroups = [...groups.data, ...virtualGroups]
+    const allGroups = getAllGroups(props)
     const currentPanelsState = state.panels || settings.panelsState || {}
     const newPanelsState = getPanelsState(allGroups, currentPanelsState)
 
@@ -324,12 +329,6 @@ class Balance extends PureComponent {
   }
 
   render() {
-    const {
-      groups: groupsCollection,
-      triggers: triggersCollection,
-      virtualGroups
-    } = this.props
-
     if (isLoading(this.props)) {
       return (
         <Fragment>
@@ -340,6 +339,7 @@ class Balance extends PureComponent {
       )
     }
 
+    const { triggers: triggersCollection } = this.props
     const accounts = this.getAllAccounts()
     const triggers = triggersCollection.data
 
@@ -383,7 +383,7 @@ class Balance extends PureComponent {
       return <NoAccount />
     }
 
-    const groups = [...groupsCollection.data, ...virtualGroups]
+    const groups = getAllGroups(this.props)
     const checkedAccounts = this.getCheckedAccounts()
     const accountsBalance = sumBy(checkedAccounts, getAccountBalance)
     const subtitleParams =

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -382,9 +382,7 @@ class Balance extends PureComponent {
 
     const groups = [...groupsCollection.data, ...virtualGroups]
     const checkedAccounts = this.getCheckedAccounts()
-    const accountsBalance = isCollectionLoading(accounts)
-      ? 0
-      : sumBy(checkedAccounts, getAccountBalance)
+    const accountsBalance = sumBy(checkedAccounts, getAccountBalance)
     const subtitleParams =
       checkedAccounts.length === accounts.length
         ? undefined

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -169,9 +169,13 @@ class Balance extends PureComponent {
       .filter(Boolean)
   }
 
+  getAllAccounts() {
+    const { accounts: accountsCollection, virtualAccounts } = this.props
+    return [...accountsCollection.data, ...virtualAccounts]
+  }
+
   getCheckedAccounts() {
-    const { accounts: accountsCollection } = this.props
-    const accounts = accountsCollection.data
+    const accounts = this.getAllAccounts()
 
     return accounts.filter(account => {
       const occurrences = this.getAccountOccurrencesInState(account)
@@ -278,12 +282,12 @@ class Balance extends PureComponent {
   _ensureListenersProperlyConfigured() {
     const { accounts: accountsCollection } = this.props
 
-    const accounts = accountsCollection.data
-
     const collections = [accountsCollection]
     if (collections.some(isCollectionLoading)) {
       return
     }
+
+    const accounts = this.getAllAccounts()
 
     if (accounts.length > 0) {
       this.stopRealtime()
@@ -321,7 +325,6 @@ class Balance extends PureComponent {
 
   render() {
     const {
-      accounts: accountsCollection,
       groups: groupsCollection,
       triggers: triggersCollection,
       virtualGroups
@@ -337,7 +340,7 @@ class Balance extends PureComponent {
       )
     }
 
-    const accounts = accountsCollection.data
+    const accounts = this.getAllAccounts()
     const triggers = triggersCollection.data
 
     if (

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -27,6 +27,7 @@ describe('Balance page', () => {
     root = shallow(
       <DumbBalance
         accounts={fakeCollection('io.cozy.bank.accounts', accountsData || [])}
+        virtualAccounts={[]}
         groups={fakeCollection('io.cozy.bank.groups')}
         virtualGroups={[]}
         settings={fakeCollection('io.cozy.bank.settings', [settingDoc])}

--- a/src/ducks/balance/helpers.js
+++ b/src/ducks/balance/helpers.js
@@ -171,7 +171,7 @@ export const getPanelsState = (groups, currentPanelsState) => {
         acc2[account._id] = {
           checked: get(
             currentPanelsState,
-            `[${group._id}].accounts[${account.id}].checked`,
+            `[${group._id}].accounts[${account._id}].checked`,
             true
           ),
           disabled: !groupChecked


### PR DESCRIPTION
In this PR, the main commit is a6008601. It's the intended fix. The problem was that when we tried to check or uncheck a virtual reimbursements account, it did nothing.
The reason is that the getPanelsState function was looking for a property called `id`. On
regular accounts it exists, but not on virtual accounts. Since in the same
function we use `_id` for groups, I updated it to also use `_id` on
accounts. But I also added an `id` property on virtual accounts, so they
have the same shape as a real account from the stack.

The others commits are things I saw along the debugging process and that I did so the code looked clearer.