### PR TITLE
Updates on reimbursements details page

### DIFF
--- a/src/components/Section/Section.jsx
+++ b/src/components/Section/Section.jsx
@@ -4,7 +4,7 @@ import { Title as BaseTitle } from 'cozy-ui/transpiled/react/Text'
 import styles from 'components/Section/Section.styl'
 import { Padded } from 'components/Spacing'
 
-const SectionTitle = props => {
+export const SectionTitle = props => {
   const { className, children, ...rest } = props
 
   return (
@@ -14,12 +14,15 @@ const SectionTitle = props => {
   )
 }
 
+export const SectionSeparator = ({ className, ...props }) => {
+  return <div className={cx(styles.SectionSeparator, className)} {...props} />
+}
+
 const Section = props => {
-  const { className, title, children, ...rest } = props
+  const { className, children, ...rest } = props
 
   return (
     <section className={cx(styles.Section, className)} {...rest}>
-      {title && <SectionTitle>{title}</SectionTitle>}
       {children}
     </section>
   )

--- a/src/components/Section/Section.styl
+++ b/src/components/Section/Section.styl
@@ -26,7 +26,9 @@
 .SectionTitle
     font-size 18px
     line-height 56px
-    border-bottom 1px solid var(--silver)
 
     +small-screen()
         font-size 16px
+
+.SectionSeparator
+    border-bottom 1px solid var(--silver)

--- a/src/components/Section/index.js
+++ b/src/components/Section/index.js
@@ -1,1 +1,5 @@
-export { default as Section } from 'components/Section/Section'
+export {
+  default as Section,
+  SectionTitle,
+  SectionSeparator
+} from 'components/Section/Section'

--- a/src/ducks/reimbursements/Reimbursements.jsx
+++ b/src/ducks/reimbursements/Reimbursements.jsx
@@ -12,7 +12,7 @@ import styles from 'ducks/reimbursements/Reimbursements.styl'
 import Loading from 'components/Loading'
 import { KonnectorChip } from 'components/KonnectorChip'
 import { StoreLink } from 'components/StoreLink'
-import { Section } from 'components/Section'
+import { Section, SectionTitle, SectionSeparator } from 'components/Section'
 import withFilters from 'components/withFilters'
 import { getYear } from 'date-fns'
 import TransactionActionsProvider from 'ducks/transactions/TransactionActionsProvider'
@@ -108,23 +108,24 @@ export class DumbReimbursements extends Component {
       currentPeriod.length === 4 ? 'YYYY' : 'MMMM YYYY'
     )
 
+    const hasPendingExpenses = pendingExpenses && pendingExpenses.length > 0
+    const hasReimbursedExpenses =
+      reimbursedExpenses && reimbursedExpenses.length > 0
+
     return (
       <TransactionActionsProvider>
         <div className={styles.Reimbursements}>
-          <Section
-            title={
-              <>
-                {t('Reimbursements.pending')}
-                <Figure
-                  symbol="€"
-                  total={pendingAmount}
-                  className={styles.Reimbursements__figure}
-                  signed
-                />{' '}
-              </>
-            }
-          >
-            {pendingExpenses && pendingExpenses.length > 0 ? (
+          <Section>
+            <SectionTitle>
+              {t('Reimbursements.pending')}
+              <Figure
+                symbol="€"
+                total={pendingAmount}
+                className={styles.Reimbursements__figure}
+                signed
+              />{' '}
+            </SectionTitle>
+            {hasPendingExpenses ? (
               <TransactionList
                 transactions={pendingExpenses}
                 withScroll={false}
@@ -132,14 +133,18 @@ export class DumbReimbursements extends Component {
                 showTriggerErrors={false}
               />
             ) : (
-              <NoPendingReimbursements
-                period={formattedPeriod}
-                doc={filteringDoc}
-              />
+              <>
+                <SectionSeparator />
+                <NoPendingReimbursements
+                  period={formattedPeriod}
+                  doc={filteringDoc}
+                />
+              </>
             )}
           </Section>
-          <Section title={t('Reimbursements.alreadyReimbursed')}>
-            {reimbursedExpenses && reimbursedExpenses.length > 0 ? (
+          <Section>
+            <SectionTitle>{t('Reimbursements.alreadyReimbursed')}</SectionTitle>
+            {hasReimbursedExpenses ? (
               <TransactionList
                 transactions={reimbursedExpenses}
                 withScroll={false}
@@ -147,10 +152,13 @@ export class DumbReimbursements extends Component {
                 showTriggerErrors={false}
               />
             ) : (
-              <NoReimbursedExpenses
-                hasHealthBrands={hasHealthBrands}
-                doc={filteringDoc}
-              />
+              <>
+                <SectionSeparator />
+                <NoReimbursedExpenses
+                  hasHealthBrands={hasHealthBrands}
+                  doc={filteringDoc}
+                />
+              </>
             )}
           </Section>
         </div>

--- a/src/ducks/reimbursements/Reimbursements.jsx
+++ b/src/ducks/reimbursements/Reimbursements.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { queryConnect } from 'cozy-client'
-import { transactionsConn } from 'doctypes'
+import { transactionsConn, GROUP_DOCTYPE } from 'doctypes'
 import { flowRight as compose, sumBy } from 'lodash'
 import cx from 'classnames'
 import { TransactionList } from 'ducks/transactions/Transactions'
@@ -47,9 +47,15 @@ const NoReimbursedExpenses = ({ hasHealthBrands, doc }) => {
   const { t } = useI18n()
 
   const categoryName = doc.categoryId ? getCategoryName(doc.categoryId) : null
-  const message = categoryName
-    ? t(`Reimbursements.noReimbursed.${categoryName}`)
-    : t('Reimbursements.noReimbursed.generic')
+
+  let message
+  if (doc._type === GROUP_DOCTYPE) {
+    message = t('Reimbursements.noReimbursed.group')
+  } else if (categoryName) {
+    message = t(`Reimbursements.noReimbursed.${categoryName}`)
+  } else {
+    message = t('Reimbursements.noReimbursed.generic')
+  }
 
   return (
     <Padded className="u-pv-0">

--- a/src/ducks/reimbursements/Reimbursements.spec.jsx
+++ b/src/ducks/reimbursements/Reimbursements.spec.jsx
@@ -275,7 +275,7 @@ describe('Reimbursements', () => {
 
         expect(
           getByText(
-            'Manually add some pending reimbursements on expenses to follow their reimbursements'
+            'Manually add an awaiting reimbursement on expenses to follow their reimbursement, or categorize it with "out of budget / professional expenses" or "health expenses" to have an automatic tracking'
           )
         ).toBeDefined()
       })

--- a/src/ducks/reimbursements/ReimbursementsPage.jsx
+++ b/src/ducks/reimbursements/ReimbursementsPage.jsx
@@ -11,12 +11,20 @@ import { ConnectedSelectDates } from 'components/SelectDates'
 import Reimbursements from 'ducks/reimbursements/Reimbursements'
 import styles from 'ducks/reimbursements/ReimbursementsPage.styl'
 import { getCategoryName } from 'ducks/categories/categoriesMap'
+import { GROUP_DOCTYPE } from 'doctypes'
 
 const getTitleTranslationKey = doc => {
   const base = 'Reimbursements.title'
-  const lastPart = doc.categoryId
-    ? getCategoryName(doc.categoryId)
-    : 'othersExpenses'
+  let lastPart
+
+  if (doc._type === GROUP_DOCTYPE) {
+    lastPart = 'group'
+  } else if (doc.categoryId) {
+    lastPart = getCategoryName(doc.categoryId)
+  } else {
+    lastPart = 'othersExpenses'
+  }
+
   const key = [base, lastPart].join('.')
 
   return key

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -664,7 +664,8 @@
     "noReimbursed": {
       "generic": "Manually add some pending reimbursements on expenses to follow their reimbursements",
       "healthExpenses": "Automatically detect your health reimbursements by connecting your health insurance to your Cozy.",
-      "professionalExpenses": "Categorize some expenses to « professional expense » to follow their reimbursements"
+      "professionalExpenses": "Categorize some expenses to « professional expense » to follow their reimbursements",
+      "group": "Manually add an awaiting reimbursement on expenses to follow their reimbursement, or categorize it with \"out of budget / professional expenses\" or \"health expenses\" to have an automatic tracking"
     }
   },
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -651,7 +651,8 @@
     "title": {
       "healthExpenses": "Health reimbursements",
       "professionalExpenses": "Professional reimbursements",
-      "othersExpenses": "Others reimbursements"
+      "othersExpenses": "Others reimbursements",
+      "group": "All awaiting reimbursements"
     },
     "pending": "Pending reimbursements: ",
     "alreadyReimbursed": "Already reimbursed",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -674,7 +674,8 @@
     "noReimbursed": {
       "generic": "Ajoutez un remboursement en attente manuellement sur des dépenses pour suivre leur remboursement.",
       "healthExpenses": "Détecter automatiquement vos remboursements en connectant votre assurance santé à votre Cozy.",
-      "professionalExpenses": "Categorisez des dépenses en « note de frais » pour suivre leur remboursement."
+      "professionalExpenses": "Categorisez des dépenses en « note de frais » pour suivre leur remboursement.",
+      "group": "Ajoutez un remboursement en attente manuellement sur des dépenses pour suivre leur remboursement, ou catégorizez les en \"hors budget / notes de frais\" ou \"frais de santé\" pour avoir un suivi automatique."
     }
   },
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -661,7 +661,8 @@
     "title": {
       "healthExpenses": "Rembours. santé",
       "professionalExpenses": "Rembours. notes de frais",
-      "othersExpenses": "Autres remboursements"
+      "othersExpenses": "Autres remboursements",
+      "group": "Tous les remb. en attente"
     },
     "pending": "Remboursements en attente : ",
     "alreadyReimbursed": "Déjà remboursés",


### PR DESCRIPTION
* Use a specific title when the reimbursements group is selected
* Use a specific empty message for the reimbursements group
* Avoid a double border