### PR TITLE
fix(CategoriesHeader): Show income toggle again

### DIFF
--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -131,14 +131,17 @@ class CategoriesHeader extends PureComponent {
           </Header>
           {accountSwitch}
           {hasAccount ? (
-            <Header color="default">
+            <Header color="default" className="u-mt-3">
               <Padded>
                 {incomeToggle}
                 {chart}
               </Padded>
             </Header>
           ) : (
-            <Header color="default" className={styles.NoAccount_container}>
+            <Header
+              color="default"
+              className={cx(styles.NoAccount_container, 'u-mt-3')}
+            >
               <Padded className={styles.NoAccount_box}>
                 {chart}
                 <AddAccountButton absolute label={t('Accounts.add_bank')} />


### PR DESCRIPTION
The income toggle was hidden behind the fixed header with the date
select. Adding a top margin is a quick way to fix this, but we may have
a look at how to automatically add a margin when we have an additional fixed header
like this one

Before:

![image](https://user-images.githubusercontent.com/1606068/75460582-eb351800-5981-11ea-989a-694f23dee983.png)

After:
![image](https://user-images.githubusercontent.com/1606068/75460619-f8520700-5981-11ea-869a-6856babe15a6.png)
