### PR TITLE
feat: Add brand Viasanté to dictionnary

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -550,6 +550,12 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "konnectorSlug": "viasante",
+    "name": "Viasanté",
+    "regexp": "\\\\bVIASANTE\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "vinciautoroute",
     "name": "Vinci autoroute télépéage",
     "regexp": "\\\\b(vinci|escota)\\\\b",
@@ -1135,6 +1141,12 @@ Array [
     "konnectorSlug": "veoliaeau",
     "name": "Veolia Eau",
     "regexp": "\\\\bveolia\\\\b",
+  },
+  Object {
+    "isInstalled": false,
+    "konnectorSlug": "viasante",
+    "name": "Viasanté",
+    "regexp": "\\\\bVIASANTE\\\\b",
   },
   Object {
     "isInstalled": false,

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -467,6 +467,11 @@
     "konnectorSlug": "veoliaeau"
   },
   {
+    "name": "Viasanté",
+    "regexp": "\\bVIASANTE\\b",
+    "konnectorSlug": "viasante"
+  },
+  {
     "name": "Vinci autoroute télépéage",
     "regexp": "\\b(vinci|escota)\\b",
     "konnectorSlug": "vinciautoroute"


### PR DESCRIPTION
I think this PR is still needed to advertise the connector in banks if needed.

I updated the unit testing snapshots.

Seems good to me.