### PR TITLE
Recurrence UI 6 : Ability to create a new recurrence

### DIFF
--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -290,7 +290,7 @@ const BundleInfo = withRouter(({ bundle, router }) => {
               <Img className="u-flex">
                 <ActionMenuHelper
                   opener={
-                    <Button iconOnly extension="narrow" theme="secondary">
+                    <Button extension="narrow" theme="secondary">
                       {t(`Recurrence.status.${getStatus(bundle)}`)}
                       <Icon className="u-ml-half" icon="bottom" />
                     </Button>

--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -345,6 +345,14 @@ const BundleMobileWrapper = ({ children }) => {
   return <div className={styles.RecurrencesMobileContent}>{children}</div>
 }
 
+const BundleDesktopWrapper = ({ children }) => {
+  return (
+    <Table>
+      <tbody>{children}</tbody>
+    </Table>
+  )
+}
+
 const BundleTransactions = ({ bundle }) => {
   const transactionsConn = bundleTransactionsQueryConn({ bundle })
   const { isMobile } = useBreakpoints()
@@ -358,7 +366,7 @@ const BundleTransactions = ({ bundle }) => {
   }
 
   const TransactionRow = isMobile ? TransactionRowMobile : TransactionRowDesktop
-  const Wrapper = isMobile ? BundleMobileWrapper : Table
+  const Wrapper = isMobile ? BundleMobileWrapper : BundleDesktopWrapper
   return (
     <>
       <Wrapper>

--- a/src/ducks/recurrence/utils.js
+++ b/src/ducks/recurrence/utils.js
@@ -1,6 +1,10 @@
 import startCase from 'lodash/startCase'
 import maxBy from 'lodash/maxBy'
 import groupBy from 'lodash/groupBy'
+import { getLabel as getTransactionLabel } from 'ducks/transactions/helpers'
+import { getCategoryId } from 'ducks/categories/helpers'
+
+const RECURRENCE_DOCTYPE = 'io.cozy.bank.recurrence'
 
 export const prettyLabel = label => {
   return label ? startCase(label.toLowerCase()) : ''
@@ -56,4 +60,18 @@ export const getAmount = bundle => {
 
 export const getCurrency = () => {
   return '€'
+}
+
+export const makeRecurrenceFromTransaction = transaction => {
+  return {
+    _type: RECURRENCE_DOCTYPE,
+    automaticLabel: getTransactionLabel(transaction),
+    stats: {
+      deltas: {
+        median: 30
+      }
+    },
+    amount: transaction.amount,
+    categoryId: getCategoryId(transaction)
+  }
 }

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -53,7 +53,10 @@ import TransactionCategoryEditor from './TransactionCategoryEditor'
 import TransactionApplicationDateEditor from './TransactionApplicationDateEditor'
 import TransactionRecurrenceEditor from 'ducks/transactions/TransactionRecurrenceEditor'
 
-import { getLabel as getRecurrenceLabel } from 'ducks/recurrence/utils'
+import {
+  getLabel as getRecurrenceLabel,
+  getFrequency
+} from 'ducks/recurrence/utils'
 import TransactionModalRow, {
   TransactionModalRowIcon,
   TransactionModalRowMedia,
@@ -167,7 +170,7 @@ const RecurrenceRow = withRouter(({ transaction, onClick, router }) => {
               <br />
               <Caption>
                 {t('Recurrence.frequency', {
-                  frequency: Math.floor(recurrence.stats.deltas.mean)
+                  frequency: Math.floor(getFrequency(recurrence))
                 })}
               </Caption>
               {router.location.pathname !== recurrenceRoute ? (

--- a/src/ducks/transactions/TransactionRecurrenceEditor.styl
+++ b/src/ducks/transactions/TransactionRecurrenceEditor.styl
@@ -1,0 +1,3 @@
+.NewRecurrenceIcon
+    width 2rem // Corresponding to the width of a CategoryIcon
+    color var(--slateGrey)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -825,7 +825,8 @@
     "title": "Recurring payments",
     "choice": {
       "not-recurrent": "Occasional transaction",
-      "recurrent": "Recurrent transaction"
+      "recurrent": "Recurrent transaction",
+      "new-recurrence": "New recurrence"
     },
     "action-menu": {
       "open-button": "Act on recurrence",
@@ -835,7 +836,7 @@
       "finished": "Finished"
     },
     "rename": {
-      "modal-title": "Rename recurrence group",
+      "modal-title": "Rename recurrence",
       "save": "Save",
       "cancel": "Cancel",
       "save-success": "Saved!",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -836,7 +836,8 @@
     "title": "Paiements récurrents",
     "choice": {
       "not-recurrent": "Opération occasionelle",
-      "recurrent": "Opération récurrente"
+      "recurrent": "Opération récurrente",
+      "new-recurrence": "Nouvelle récurrence"
     },
     "action-menu": {
       "open-button": "Actions sur la récurrence",


### PR DESCRIPTION
When editing a transaction's recurrence through the modal, a new
choice is added : "New recurrence". When selected, this will

- create a new recurrence with information from the transaction. The
frequency is set to 30 days.

- attach the transaction to the newly created recurrence