### PR TITLE
Fix recurrence service

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -25,7 +25,8 @@ const entries = {
   stats: path.resolve(serviceDir, './stats.js'),
   autogroups: path.resolve(serviceDir, './autogroups.js'),
   budgetAlerts: path.resolve(serviceDir, './budgetAlerts.js'),
-  linkMyselfToAccounts: path.resolve(serviceDir, './linkMyselfToAccounts.js')
+  linkMyselfToAccounts: path.resolve(serviceDir, './linkMyselfToAccounts.js'),
+  recurrence: path.resolve(serviceDir, './recurrence.js')
 }
 
 if (process.env.TEST_TEMPLATES) {

--- a/docs/services.md
+++ b/docs/services.md
@@ -5,19 +5,40 @@ Banks application.
 
 <!-- MarkdownTOC autolink=true -->
 
-- [Categorization](#categorization)
-- [onOperationOrBillCreate](#onoperationorbillcreate)
-- [Account stats](#account-stats)
-- [Automatic groups](#automatic-groups)
-- [Budget alerts](#budget-alerts)
-- [I am writing a banking konnector, what should I do?](#i-am-writing-a-banking-konnector-what-should-i-do)
-- [Recurrences](#recurrences)
 - [Developing](#developing)
+- [Services](#services)
+  - [Categorization](#categorization)
+  - [onOperationOrBillCreate](#onoperationorbillcreate)
+  - [Account stats](#account-stats)
+  - [Automatic groups](#automatic-groups)
+  - [Budget alerts](#budget-alerts)
+  - [Recurrences](#recurrences)
+- [I am writing a banking konnector, what should I do?](#i-am-writing-a-banking-konnector-what-should-i-do)
 
 <!-- /MarkdownTOC -->
 
+## Developing
 
-## Categorization
+You can manually create an app token and launch the built service.
+
+```
+# Watch services
+$ env NODE_ENV=services:production yarn run webpack --config webpack.config.js --bail --watch
+# In another terminal
+$ export COZY_URL='http://cozy.tools:8080'
+$ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.tools:8080 banks)
+$ node build/budgetAlerts.js
+```
+
+Some services like the "budgetAlerts" one expose a CLI that can perform service related tasks.
+
+```
+yarn run services:budgetAlerts --help
+```
+
+## Services
+
+### Categorization
 
 This service role is to categorize transactions. It is bound to no event at
 all, so it's not automatically triggered and needs to be explicitly called by a
@@ -33,7 +54,7 @@ finish the work. If all transactions have been categorized, it calls the
 
 See the [categorization documentation](https://github.com/cozy/cozy-banks/blob/master/docs/categorization.md) for more details about the categorization implementation.
 
-## onOperationOrBillCreate
+### onOperationOrBillCreate
 
 This service has many roles. It does:
 
@@ -47,17 +68,17 @@ service. See [the next
 section](#i-am-writing-a-banking-konnector-what-should-i-do) for more precise
 informations about that.
 
-## Account stats
+### Account stats
 
 Computes statistics on bank accounts and save the results in `io.cozy.bank.accounts.stats` doctype.
 
-## Automatic groups
+### Automatic groups
 
 Whenever an `io.cozy.bank.accounts` is created, we check if it could belong in an automatic group based
 on its type (checkings, savings, credit cards). These `io.cozy.bank.groups` documents are created with
 the `auto: true` attributes.
 
-## Budget alerts
+### Budget alerts
 
 A user can configure alerts to be alerted whenever the sum of its expenses has
 gone past a maximum threshold per month. The notification is sent as part of the
@@ -69,6 +90,14 @@ date and amount are saved.
 A debug service is built to be able to only run this particular part and not the
 whole onOperationOrBillCreate service. It is possible to run it from the Debug
 tab in the application (or via Bender).
+
+### Recurrences
+
+A service tries to find recurrence groups when new operations are inserted
+in the Cozy. It either creates new recurrence groups or attaches transactions
+to existing recurrence groups.
+
+See Paper "Paiements recurrents" for more information on the service.
 
 ## I am writing a banking konnector, what should I do?
 
@@ -113,30 +142,3 @@ following permission to your `manifest.konnector`:
 
 With this, the transactions you created will be categorized, then the
 `onOperationOrBillCreate` service will be launched and do its work.
-
-## Recurrences
-
-A service tries to find recurrence groups when new operations are inserted
-in the Cozy. It either creates new recurrence groups or attaches transactions
-to existing recurrence groups.
-
-See Paper "Paiements recurrents" for more information on the service.
-
-## Developing
-
-You can manually create an app token and launch the built service.
-
-```
-# Watch services
-$ env NODE_ENV=services:production yarn run webpack --config webpack.config.js --bail --watch
-# In another terminal
-$ export COZY_URL='http://cozy.tools:8080'
-$ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.tools:8080 banks)
-$ node build/budgetAlerts.js
-```
-
-Some services like the "budgetAlerts" one expose a CLI that can perform service related tasks.
-
-```
-yarn run services:budgetAlerts --help
-```

--- a/docs/services.md
+++ b/docs/services.md
@@ -128,7 +128,7 @@ You can manually create an app token and launch the built service.
 
 ```
 # Watch services
-$ env NODE_ENV=services:development yarn run webpack --config webpack.config.js --bail --watch
+$ env NODE_ENV=services:production yarn run webpack --config webpack.config.js --bail --watch
 # In another terminal
 $ export COZY_URL='http://cozy.tools:8080'
 $ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.tools:8080 banks)

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -81,6 +81,12 @@
       "trigger": "@event io.cozy.bank.operations:CREATED,UPDATED",
       "debounce": "1m"
     },
+    "recurrence": {
+      "type": "node",
+      "file": "recurrence.js",
+      "trigger": "@event io.cozy.bank.operations:CREATED,UPDATED",
+      "debounce": "1m"
+    },
     "autogroups": {
       "type": "node",
       "file": "autogroups.js",

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -257,6 +257,9 @@ const RecurrencePage = () => {
 
   const updatedBundles = useMemo(() => {
     let curBundles = bundles
+
+    // To mimic as much as possible the entry of new operations per day
+    // (a connector is run per day), we update bundles day per day
     const byDay = groupBy(newTransactions, x => x.date.slice(0, 10))
     const days = sortBy(Object.keys(byDay), x => x)
     for (let day of days) {

--- a/src/ducks/recurrence/api.js
+++ b/src/ducks/recurrence/api.js
@@ -1,3 +1,14 @@
+/**
+ * TODO Handle pagination
+ *
+ * As of now, paginations for recurrence bundles and for transactions inside
+ * recurrence has not been dealt with, both in the API and on the UI side
+ * of things. Since having more than 100 hundred recurrences is infrequent,
+ * we do not think it is a major hurdle if users only see their 100 most recent
+ * recurrences, or only the most recent 100 transactions inside this recurrence
+ * bundle.
+ */
+
 import set from 'lodash/set'
 import flatten from 'lodash/flatten'
 import omit from 'lodash/omit'

--- a/src/ducks/recurrence/service.js
+++ b/src/ducks/recurrence/service.js
@@ -13,12 +13,16 @@ import { getLabel } from './utils'
 import addDays from 'date-fns/add_days'
 
 const NB_MONTH_LOOKBACK = 3
+const DAYS_IN_MONTH = 30.5
 
 const makeQueryForTransactions = recurrences => {
   if (recurrences.length === 0) {
     return Q(TRANSACTION_DOCTYPE)
   } else {
-    const lookbackDateLimit = addDays(new Date(), -NB_MONTH_LOOKBACK * 30.5)
+    const lookbackDateLimit = addDays(
+      new Date(),
+      -NB_MONTH_LOOKBACK * DAYS_IN_MONTH
+    )
     const query = Q(TRANSACTION_DOCTYPE).where({
       date: {
         $gt: lookbackDateLimit.toISOString().slice(0, 10)

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -11,7 +11,6 @@ import { sendNotifications } from 'ducks/notifications/services'
 import matchFromBills from 'ducks/billsMatching/matchFromBills'
 import matchFromTransactions from 'ducks/billsMatching/matchFromTransactions'
 import { logResult } from 'ducks/billsMatching/utils'
-import { doRecurrenceMatching } from 'ducks/recurrence/service'
 
 import { Transaction, Bill, Settings } from 'models'
 import isCreatedDoc from 'utils/isCreatedDoc'
@@ -168,12 +167,6 @@ const onOperationOrBillCreate = async (client, options) => {
   if (options.transactionsMatching !== false) {
     await doTransactionsMatching(setting, options.transactionsMatching)
     setting = await updateSettings(setting)
-  } else {
-    log('info', 'Skip transactions matching')
-  }
-
-  if (options.recurrenceMatching !== false) {
-    await doRecurrenceMatching(client)
   } else {
     log('info', 'Skip transactions matching')
   }

--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -1,0 +1,4 @@
+import { runService } from './service'
+import { doRecurrenceMatching } from 'ducks/recurrence/service'
+
+runService(({ client }) => doRecurrenceMatching(client))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -17,27 +17,32 @@ if (target !== 'mobile') {
   provided['cozy.bar'] = 'cozy-bar/dist/cozy-bar.js'
 }
 
+const barConfig = {
+  plugins: [new ProvidePlugin(provided)],
+  module: {
+    rules: [
+      {
+        test: /cozy-bar\/dist\/cozy-bar\.js$/,
+        loader: 'imports-loader?css=./cozy-bar.css'
+      }
+    ]
+  }
+}
+
+const appOnlyConfigs = [
+  require('cozy-scripts/config/webpack.config.react'),
+  require('cozy-scripts/config/webpack.config.cozy-ui'),
+  require('cozy-scripts/config/webpack.config.cozy-ui.react'),
+  require('cozy-scripts/config/webpack.config.css-modules'),
+  require('cozy-scripts/config/webpack.config.pictures'),
+  barConfig
+]
+
 const common = mergeAppConfigs(
   [
     require('cozy-scripts/config/webpack.config.eslint'),
     require('cozy-scripts/config/webpack.config.base'),
-    require('cozy-scripts/config/webpack.config.react'),
-    require('cozy-scripts/config/webpack.config.cozy-ui'),
-    require('cozy-scripts/config/webpack.config.cozy-ui.react'),
-    {
-      plugins: [new ProvidePlugin(provided)],
-      module: {
-        rules: [
-          {
-            test: /cozy-bar\/dist\/cozy-bar\.js$/,
-            loader: 'imports-loader?css=./cozy-bar.css'
-          }
-        ]
-      }
-    },
-    require('cozy-scripts/config/webpack.config.css-modules'),
-    require('cozy-scripts/config/webpack.config.pictures'),
-
+    ...(target !== 'services' ? appOnlyConfigs : []),
     addAnalyzer ? require('cozy-scripts/config/webpack.config.analyzer') : null,
     require('./config/webpack.config.base'),
     require('./config/webpack.config.manual-resolves'),


### PR DESCRIPTION
- Repair service build

Since the use of cozy-scripts, the build of services was broken.
App related configs were used even if we were in a service which
led to unexpected things like process.env being set to `{ USE_REACT: true }`.

This prevented services to run correctly as they rely on
environment variables to get COZY_URL and COZY_CREDENTIALS.

Now, app related configs are not used when building services.

- Extract recurrence service from onOperationOrBillCreate

At first, recurrence matching was made part of onOperationOrBillCreate
but this was a bad idea since other services have already been
isolated into their own services. For metrology and isolation purposes,
it is better to have each service function on its own.