### PR TITLE
fix: Support monde diplomatique with a space

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -276,7 +276,7 @@
   },
   {
     "name": "Le Monde Diplomatique",
-    "regexp": "\\bmonde-diplomatique\\b",
+    "regexp": "\\bmonde[\\-\\s]diplomatique\\b",
     "konnectorSlug": "mondediplo"
   },
   {


### PR DESCRIPTION
Banking transactions for "Le monde diplomatique" are
not necesarily formatted with a dash.

```
> a = new RegExp("\\bmonde[\\-\\s]diplomatique\\b", 'i')
/\bmonde[\-\s]diplomatique\b/i
> a.test('Le monde Diplomatique')
true
> a.test('Le monde-Diplomatique')
true
```