### PR TITLE
fix: No need to reload page when changing blur setting

### DIFF
--- a/src/utils/flag.js
+++ b/src/utils/flag.js
@@ -55,4 +55,10 @@ Figure.defaultProps = Object.assign({}, Figure.defaultProps, {
   blurred: flag('amount_blur') ? true : false
 })
 
+flag.store.on('change', function(flagName) {
+  if (flagName == 'amount_blur') {
+    Figure.defaultProps.blurred = flag('amount_blur')
+  }
+})
+
 window.flag = flag


### PR DESCRIPTION
Connect the flag store to Figure defaultProp "blurred" so that when
the flag amount_blur is changed, the default prop is changed. Before,
we needed to reload the page/app after changing the setting.