### PR TITLE
fix: Moment should be present in stat service

### DIFF
--- a/config/webpack.config.manual-resolves.js
+++ b/config/webpack.config.manual-resolves.js
@@ -1,4 +1,6 @@
 const path = require('path')
+const removeFalsyProperties = require('lodash/pickBy')
+const { target } = require('./webpack.vars')
 
 const mapToNodeModules = packages => {
   const res = {}
@@ -10,12 +12,15 @@ const mapToNodeModules = packages => {
 
 module.exports = {
   resolve: {
-    alias: {
+    alias: removeFalsyProperties({
       // Chart.js has moment as dependency for backward compatibility but it can
       // survive without it. We do not use date related functionality in chart.js
       // so it is safe to remove moment.
       // https://github.com/chartjs/Chart.js/blob/master/docs/getting-started/integration.md#bundlers-webpack-rollup-etc
-      moment: path.resolve(__dirname, '../src/utils/empty'),
+      moment:
+        target !== 'services'
+          ? path.resolve(__dirname, '../src/utils/empty')
+          : null,
 
       // This way, we do not inadvertently use non transpiled files
       'cozy-ui/react': 'cozy-ui/transpiled/react',
@@ -62,6 +67,6 @@ module.exports = {
 
       // We do not need mime-db (used in cozy-stack-client::FileCollection) so we fake it
       'mime-db': path.resolve(__dirname, '../src/utils/empty-mime-db')
-    }
+    })
   }
 }


### PR DESCRIPTION
We should not mock moment as empty in services, 
otherwise the stat service fails