### PR TITLE
fix: Do not crash when spanish locale is chosen

### DIFF
--- a/config/webpack.config.plugins.js
+++ b/config/webpack.config.plugins.js
@@ -20,11 +20,11 @@ module.exports = {
     // ChartJS uses moment :( To remove when we do not use it anymore
     new webpack.ContextReplacementPlugin(
       /moment[/\\]locale$/,
-      /(en|fr)\/index\.js/
+      /(en|fr|es)\/index\.js/
     ),
     new webpack.ContextReplacementPlugin(
       /date-fns[/\\]locale$/,
-      /(en|fr)\/index\.js/
+      /(en|fr|es)\/index\.js/
     ),
     new webpack.IgnorePlugin({
       resourceRegExp: /preact-portal/

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -30,6 +30,7 @@ import Figure from 'cozy-ui/transpiled/react/Figure'
 
 import frLocale from 'date-fns/locale/fr'
 import enLocale from 'date-fns/locale/en'
+import esLocale from 'date-fns/locale/es'
 
 import styles from './styles.styl'
 import {
@@ -49,7 +50,8 @@ const BundleFrequency = ({ bundle }) => {
 
 const dateFnsLocales = {
   en: enLocale,
-  fr: frLocale
+  fr: frLocale,
+  es: esLocale
 }
 
 const BundleDistance = ({ bundle }) => {
@@ -58,7 +60,7 @@ const BundleDistance = ({ bundle }) => {
     () =>
       distanceInWords(Date.now(), bundle.latestDate, {
         addSuffix: true,
-        locale: dateFnsLocales[lang]
+        locale: dateFnsLocales[lang] || dateFnsLocales.en
       }),
     [bundle, lang]
   )

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -18,7 +18,7 @@ import {
 } from 'ducks/client'
 import 'utils/flag'
 import FastClick from 'fastclick'
-import * as d3 from 'utils/d3'
+import { setupLocale as setupD3Locale } from 'utils/d3'
 import 'cozy-ui/transpiled/react/stylesheet.css'
 import 'cozy-ui/dist/cozy-ui.utils.min.css'
 
@@ -27,12 +27,6 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import flag from 'cozy-flags'
 import { makeItShine } from 'utils/display.debug'
 import PinPlugin from 'ducks/pin/plugin'
-
-const D3_LOCALES_MAP = {
-  fr: require('d3-time-format/locale/fr-FR.json'),
-  en: require('d3-time-format/locale/en-GB.json'),
-  es: require('d3-time-format/locale/es-ES.json')
-}
 
 if (__TARGET__ === 'mobile') {
   require('styles/mobile.styl')
@@ -61,7 +55,7 @@ const setupApp = async persistedState => {
       ? navigator.language.slice(0, 2)
       : data.cozyLocale || 'en'
 
-  d3.timeFormatDefaultLocale(D3_LOCALES_MAP[lang] || D3_LOCALES_MAP.en)
+  setupD3Locale(lang)
 
   history = setupHistory()
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -30,7 +30,8 @@ import PinPlugin from 'ducks/pin/plugin'
 
 const D3_LOCALES_MAP = {
   fr: require('d3-time-format/locale/fr-FR.json'),
-  en: require('d3-time-format/locale/en-GB.json')
+  en: require('d3-time-format/locale/en-GB.json'),
+  es: require('d3-time-format/locale/es-ES.json')
 }
 
 if (__TARGET__ === 'mobile') {
@@ -60,7 +61,7 @@ const setupApp = async persistedState => {
       ? navigator.language.slice(0, 2)
       : data.cozyLocale || 'en'
 
-  d3.timeFormatDefaultLocale(D3_LOCALES_MAP[lang])
+  d3.timeFormatDefaultLocale(D3_LOCALES_MAP[lang] || D3_LOCALES_MAP.en)
 
   history = setupHistory()
 

--- a/src/utils/d3.js
+++ b/src/utils/d3.js
@@ -7,6 +7,19 @@ import { easeExpInOut, easeLinear, easeExpIn } from 'd3-ease'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { axisBottom } from 'd3-axis'
 import { transition } from 'd3-transition'
+
+import d3FrTimeFormat from 'd3-time-format/locale/fr-FR.json'
+import d3EnTimeFormat from 'd3-time-format/locale/en-GB.json'
+
+const D3_LOCALES_MAP = {
+  fr: d3FrTimeFormat,
+  en: d3EnTimeFormat
+}
+
+const setupLocale = lang => {
+  timeFormatDefaultLocale(D3_LOCALES_MAP[lang] || D3_LOCALES_MAP.en)
+}
+
 export {
   timeFormatDefaultLocale,
   timeFormat,
@@ -24,5 +37,6 @@ export {
   scaleLinear,
   scaleTime,
   axisBottom,
-  transition
+  transition,
+  setupLocale
 }

--- a/src/utils/d3.spec.js
+++ b/src/utils/d3.spec.js
@@ -1,0 +1,15 @@
+import { setupLocale, timeFormat } from './d3'
+
+describe('setupLocale', () => {
+  it('should work if locale is loaded', () => {
+    expect(() => setupLocale('fr')).not.toThrow()
+    const formatTime = timeFormat('%B %d, %Y')
+    expect(formatTime(new Date(2020, 5, 1))).toBe('juin 01, 2020')
+  })
+
+  it('should not crash if the locale is not loaded', () => {
+    expect(() => setupLocale('zh')).not.toThrow()
+    const formatTime = timeFormat('%B %d, %Y')
+    expect(formatTime(new Date(2020, 5, 1))).toBe('June 01, 2020')
+  })
+})


### PR DESCRIPTION
When choosing spanish, Banks would crash and show a blank page.

1. Spanish is added in builds
2. We do not crash if an unknown locale is chosen