### PR TITLE
feat: Add search icon in balance page and back button in search page

### DIFF
--- a/src/ducks/balance/components/BalanceHeader.jsx
+++ b/src/ducks/balance/components/BalanceHeader.jsx
@@ -12,8 +12,26 @@ import HeaderTitle from 'ducks/balance/components/HeaderTitle'
 import Delayed from 'components/Delayed'
 import { queryConnect } from 'cozy-client'
 import flag from 'cozy-flags'
+import { Icon } from 'cozy-ui/transpiled/react'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
+import { BarRight } from 'components/Bar'
 import styles from 'ducks/balance/components/BalanceHeader.styl'
+
+const SearchIcon = () => {
+  const { isMobile } = useBreakpoints()
+  return isMobile ? (
+    <BarRight>
+      <a className={styles.SearchIcon} href="#/search">
+        <Icon icon="magnifier" />
+      </a>
+    </BarRight>
+  ) : (
+    <a className={styles.SearchIcon} href="#/search">
+      <Icon icon="magnifier" />
+    </a>
+  )
+}
 
 const BalanceHeader = ({
   breakpoints: { isMobile },
@@ -36,6 +54,7 @@ const BalanceHeader = ({
           <PageTitle>{t('Balance.title')}</PageTitle>
         </Padded>
       )}
+      {flag('banks.search') ? <SearchIcon /> : null}
       <HeaderTitle
         balance={accountsBalance}
         subtitle={subtitle}

--- a/src/ducks/balance/components/BalanceHeader.styl
+++ b/src/ducks/balance/components/BalanceHeader.styl
@@ -12,3 +12,18 @@
         flex-basis 159px
         padding-top: .5rem
         padding-bottom 0
+
+.SearchIcon
+    position absolute
+    right 2rem
+    color white
+    z-index 1
+
+    +small-screen()
+        right inherit
+        position static
+        width 3rem
+        height 3rem
+        display flex
+        justify-content center
+        align-items center

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -12,6 +12,7 @@ import TransactionTableHead from 'ducks/transactions/header/TableHead'
 import Header from 'components/Header'
 import Padded from 'components/Spacing/Padded'
 import { PageTitle } from 'components/Title'
+import BackButton from 'components/BackButton'
 
 const makeSearch = searchStr => op => {
   return op.label.toLowerCase().includes(searchStr.toLowerCase())
@@ -44,7 +45,10 @@ const SearchPage = ({ router }) => {
       <Header theme="inverted" fixed>
         <Padded>
           <Stack spacing="l">
-            <PageTitle className="u-lh-tiny">{t('Search.title')}</PageTitle>
+            <div>
+              <BackButton to="/balances" arrow={true} />
+              <PageTitle className="u-lh-tiny">{t('Search.title')}</PageTitle>
+            </div>
             <Input
               placeholder={t('Search.input-placeholder')}
               type="text"


### PR DESCRIPTION
Add a way to go to search page from balance page.

The goal is to have a 1st version of the search available for internal
use.