### PR TITLE
Improvements

### DIFF
--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -234,6 +234,9 @@ export const buildOthersReimbursementsVirtualAccount = buildReimbursementsVirtua
 )
 
 export const buildVirtualAccounts = transactions => {
+  if (transactions.length === 0) {
+    return []
+  }
   return [
     buildHealthReimbursementsVirtualAccount(transactions),
     flag('balance.professional-reimb-account') &&

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -12,6 +12,7 @@ import {
 import { getCategoryIdFromName } from 'ducks/categories/helpers'
 import { CONTACT_DOCTYPE } from 'doctypes'
 import MockDate from 'mockdate'
+import fixtures from 'test/fixtures/unit-tests'
 import flag from 'cozy-flags'
 
 jest.mock('cozy-flags')
@@ -190,8 +191,10 @@ describe('buildVirtualAccounts', () => {
     flag.mockReset()
   })
 
+  const mockTransactions = fixtures['io.cozy.bank.operations'].slice(0, 5)
+
   it('should contain a health reimbursements virtual account', () => {
-    const virtualAccounts = buildVirtualAccounts([])
+    const virtualAccounts = buildVirtualAccounts(mockTransactions)
     const healthReimbursementsAccount = virtualAccounts.find(
       a => a._id === 'health_reimbursements'
     )
@@ -200,7 +203,7 @@ describe('buildVirtualAccounts', () => {
 
   it('should contain a professional expenses virtual account', () => {
     flag.mockReturnValue(true)
-    const virtualAccounts = buildVirtualAccounts([])
+    const virtualAccounts = buildVirtualAccounts(mockTransactions)
     const professionalExpenseAccount = virtualAccounts.find(
       a => a._id === 'professional_reimbursements'
     )
@@ -209,11 +212,17 @@ describe('buildVirtualAccounts', () => {
 
   it('should contain a others expenses virtual account', () => {
     flag.mockReturnValue(true)
-    const virtualAccounts = buildVirtualAccounts([])
+    const virtualAccounts = buildVirtualAccounts(mockTransactions)
     const othersExpenseAccount = virtualAccounts.find(
       a => a._id === 'others_reimbursements'
     )
     expect(othersExpenseAccount).toBeDefined()
+  })
+
+  it('should not build virtual accounts if there are no transactions', () => {
+    flag.mockReturnValue(true)
+    const virtualAccounts = buildVirtualAccounts([])
+    expect(virtualAccounts.length).toBe(0)
   })
 })
 

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react'
 import { withRouter, Link } from 'react-router'
 import cx from 'classnames'
+import orderBy from 'lodash/orderBy'
 
 import { useQuery } from 'cozy-client'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
@@ -166,10 +167,20 @@ const BundlesTable = ({ children }) => {
   )
 }
 
+const sortBundlesForViewing = bundles => {
+  return orderBy(
+    bundles,
+    [bundle => getCategories(bundle)[0], bundle => bundle.latestDate],
+    ['desc', 'desc']
+  )
+}
+
 const RecurrencesPage = ({ router }) => {
   const { isMobile } = useBreakpoints()
   const bundleCol = useQuery(recurrenceConn.query, recurrenceConn)
-  const { data: bundles } = bundleCol
+  const { data: rawBundles } = bundleCol
+  const bundles = sortBundlesForViewing(rawBundles)
+
   const { t } = useI18n()
   const BundlesWrapper = isMobile ? BundleMobileWrapper : BundlesTable
 

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -87,7 +87,7 @@
     </platform>
     <preference name="StatusBarBackgroundColor" value="#95999D" />
     <engine name="android" spec="7.1.4" />
-    <engine name="ios" spec="4.5.5" />
+    <engine name="ios" spec="^5.1.1" />
     <plugin name="cordova-plugin-whitelist" spec="1" />
     <plugin name="cordova-plugin-inappbrowser" spec="1.7.1" />
     <plugin name="cordova-ios-plugin-no-export-compliance" spec="0.0.5" />


### PR DESCRIPTION
2 unrelated small improvements

- fix: Do not create virtual accounts if there are no transactions

   If we have virtual accounts we do not display the special Empty page that
   is shown if the user has no data

- feat: Sort bundles by category then by recency

In the recurrence page, we want the recurrence bundles
grouped by category and then sorted by date.