### PR TITLE
Make buttons on BalancePage + settings overridable

### DIFF
--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import PropTypes from 'prop-types'
 import GroupPanel from 'ducks/balance/components/GroupPanel'
 import { flowRight as compose } from 'lodash'
 import { translate } from 'cozy-ui/transpiled/react'
-import ButtonAction from 'cozy-ui/transpiled/react/ButtonAction'
+import { Button } from 'cozy-ui/transpiled/react/Button'
 import { withRouter } from 'react-router'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
 import { translateAndSortGroups } from 'ducks/groups/helpers'
@@ -69,23 +70,27 @@ class BalancePanels extends React.PureComponent {
         <Delayed delay={groupsSorted.length * GROUP_PANEL_RENDER_DELAY}>
           <div className={styles.BalancePanels__actions}>
             <AddAccountLink>
-              <ButtonAction
-                type="new"
-                label={t('Accounts.add_bank')}
-                className={styles.BalancePanels__action}
-              />
+              <AddAccountButton />
             </AddAccountLink>
-            <ButtonAction
+            <Button
               onClick={this.goToGroupsSettings}
-              type="normal"
+              theme="secondary"
               label={t('Balance.manage_accounts')}
-              className={styles.BalancePanels__action}
             />
           </div>
         </Delayed>
       </div>
     )
   }
+}
+
+export const AddAccountButton = ({ theme }) => {
+  const { t } = useI18n()
+  return <Button theme={theme} label={t('Accounts.add_bank')} />
+}
+
+AddAccountButton.defaultProps = {
+  theme: 'ghost'
 }
 
 export default compose(

--- a/src/ducks/balance/BalancePanels.styl
+++ b/src/ducks/balance/BalancePanels.styl
@@ -14,36 +14,3 @@
         padding-left 0
         padding-right 0
         justify-content flex-end
-
-.BalancePanels__action.BalancePanels__action
-    flex 1
-    text-align center
-    max-width none
-    min-height 3rem
-    padding-right 1rem
-    padding: 0.375rem 1rem
-    border-radius 4px
-    font-size 12px
-    font-weight bold
-    text-transform uppercase
-    line-height 1.5
-
-    > span
-        justify-content center
-
-        > span
-            padding-right 0
-            white-space normal
-
-            +small-screen('min')
-                white-space nowrap
-
-    +small-screen('min')
-        flex-grow 0
-        min-width unset
-
-        &:first-child
-            margin-left 0
-
-        &:last-child
-            margin-right 0

--- a/src/ducks/settings/AddRuleButton.jsx
+++ b/src/ducks/settings/AddRuleButton.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import styles from './Rules.styl'
+import cx from 'classnames'
+import Button from 'cozy-ui/transpiled/react/Button'
+
+const AddRuleButton = ({ label, busy, onClick }) => (
+  <Button
+    className={cx('u-ml-1 u-mb-0', styles.AddRuleButton)}
+    theme="subtle"
+    icon="plus"
+    size="small"
+    label={label}
+    busy={busy}
+    onClick={onClick}
+  />
+)
+
+export default AddRuleButton

--- a/src/ducks/settings/Rules.jsx
+++ b/src/ducks/settings/Rules.jsx
@@ -1,22 +1,11 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import { Stack, Button, useI18n } from 'cozy-ui/transpiled/react'
+import { Stack, useI18n } from 'cozy-ui/transpiled/react'
 import useList from './useList'
 import { getRuleId, getNextRuleId } from './ruleUtils'
-import cx from 'classnames'
-import styles from './Rules.styl'
+import AddRuleButton from 'ducks/settings/AddRuleButton'
 
-export const AddRuleButton = ({ label, busy, onClick }) => (
-  <Button
-    className={cx('u-ml-1 u-mb-0', styles.AddRuleButton)}
-    theme="subtle"
-    icon="plus"
-    size="small"
-    label={label}
-    busy={busy}
-    onClick={onClick}
-  />
-)
+export { AddRuleButton }
 
 const Rules = ({
   rules,


### PR DESCRIPTION
Using an overridable file for AddRule button since the
component changes completely

Export a component with theme overridable via defaultProps
for AddAccountButton since only the theme should be overridable.