### PR TITLE
Fix bar color in accounts and group settings

### DIFF
--- a/src/components/BackButton/index.jsx
+++ b/src/components/BackButton/index.jsx
@@ -6,34 +6,39 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 import arrowLeft from 'assets/icons/icon-arrow-left.svg'
-import { getCssVariableValue } from 'cozy-ui/transpiled/react/utils/color'
 import cx from 'classnames'
 import { BarLeft } from 'components/Bar'
 
-export const BackIcon = ({ color }) => <Icon icon={arrowLeft} color={color} />
+export const BackIcon = () => {
+  const theme = useCozyTheme()
+  return (
+    <Icon
+      className={cx(
+        theme ? styles[`BackIcon--${theme}`] : null,
+        styles.BackIcon
+      )}
+      icon={arrowLeft}
+    />
+  )
+}
 
-export const BackLink = ({ className, color, onClick }) => (
+export const BackLink = ({ className, onClick }) => (
   <a className={cx(styles.BackArrow, className)} onClick={onClick}>
-    <BackIcon color={color} />
+    <BackIcon />
   </a>
 )
 
-export const BackButton = ({ className, color, onClick }) => (
+export const BackButton = ({ className, onClick }) => (
   <button className={cx(styles.BackArrow, className)} onClick={onClick}>
-    <BackIcon color={color} />
+    <BackIcon />
   </button>
 )
 
-BackButton.defaultProps = {
-  color: 'var(--coolGrey)'
-}
-
-export const BarBackButton = ({ onClick, color }) => {
+export const BarBackButton = ({ onClick }) => {
   const { isMobile } = useBreakpoints()
   return isMobile ? (
     <BarLeft>
       <BackButton
-        color={color}
         className={cx(styles.BackArrow, 'coz-bar-btn coz-bar-burger')}
         onClick={onClick}
       />
@@ -52,7 +57,6 @@ export const BarBackButton = ({ onClick, color }) => {
  */
 const MobileAwareBackButton = ({ onClick, to, router, arrow = false }) => {
   const { isMobile } = useBreakpoints()
-  const theme = useCozyTheme()
   const location = router.getCurrentLocation()
   if (!onClick && !to) {
     to = location.pathname
@@ -61,15 +65,11 @@ const MobileAwareBackButton = ({ onClick, to, router, arrow = false }) => {
       .join('/')
   }
 
-  const arrowColor =
-    theme === 'inverted'
-      ? getCssVariableValue('primaryContrastTextColor')
-      : getCssVariableValue('coolGrey')
   const handleClick = (onClick = onClick || (() => to && router.push(to)))
   return isMobile ? (
-    <BarBackButton onClick={handleClick} color={arrowColor} />
+    <BarBackButton onClick={handleClick} />
   ) : (
-    arrow && <BackLink onClick={handleClick} color={arrowColor} />
+    arrow && <BackLink onClick={handleClick} />
   )
 }
 

--- a/src/components/BackButton/style.styl
+++ b/src/components/BackButton/style.styl
@@ -14,6 +14,7 @@
     align-items center
     border 0
     background transparent
+    --iconColor: var(--coolGrey)
 
     +small-screen()
         &
@@ -25,3 +26,12 @@
     padding 0
     background none
     border 0
+
+.BackIcon
+    color var(--iconColor)
+
+.BackIcon--primary
+    --iconColor: white
+
+.BackIcon--inverted
+    --iconColor: white

--- a/src/components/BackButton/style.styl
+++ b/src/components/BackButton/style.styl
@@ -18,7 +18,7 @@
 
     +small-screen()
         &
-            margin-right 0.25rem
+            margin-right .5rem
 
 .BackArrow.BackArrow:active
     background rgba(255, 255, 255, 0.2)

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -6,6 +6,7 @@ import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Toggle from 'cozy-ui/transpiled/react/Toggle'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import { Media, Img } from 'cozy-ui/transpiled/react/Media'
 
 import BarTheme from 'ducks/bar/BarTheme'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
@@ -177,34 +178,38 @@ export class DumbGroupSettings extends Component {
           className={styles.GrpStg__form}
           onSubmit={e => e.preventDefault()}
         >
-          <p>
-            {!modifying ? (
-              getGroupLabel(group, t)
-            ) : (
-              <input
-                ref={this.saveInputRef}
-                autoFocus
-                type="text"
-                defaultValue={getGroupLabel(group, t)}
-              />
-            )}
-            {modifying ? (
-              <Button
-                className={styles['save-button']}
-                disabled={saving}
-                theme="regular"
-                onClick={this.handleRename}
-                label={t('Groups.save')}
-                busy={saving}
-              />
-            ) : (
-              <Button
-                theme="text"
-                onClick={this.modifyName}
-                label={t('Groups.rename')}
-              />
-            )}
-          </p>
+          <Media>
+            <Img>
+              {!modifying ? (
+                getGroupLabel(group, t)
+              ) : (
+                <input
+                  ref={this.saveInputRef}
+                  autoFocus
+                  type="text"
+                  defaultValue={getGroupLabel(group, t)}
+                />
+              )}
+            </Img>
+            <Img>
+              {modifying ? (
+                <Button
+                  className={styles['save-button']}
+                  disabled={saving}
+                  theme="regular"
+                  onClick={this.handleRename}
+                  label={t('Groups.save')}
+                  busy={saving}
+                />
+              ) : (
+                <Button
+                  theme="text"
+                  onClick={this.modifyName}
+                  label={t('Groups.rename')}
+                />
+              )}
+            </Img>
+          </Media>
         </form>
         <h3>{t('Groups.accounts')}</h3>
         <Query query={accountsConn.query} as={accountsConn.as}>

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -7,15 +7,16 @@ import Button from 'cozy-ui/transpiled/react/Button'
 import Toggle from 'cozy-ui/transpiled/react/Toggle'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 
+import BarTheme from 'ducks/bar/BarTheme'
+import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { GROUP_DOCTYPE, accountsConn } from 'doctypes'
+import { getGroupLabel, renamedGroup } from 'ducks/groups/helpers'
 import Loading from 'components/Loading'
 import BackButton from 'components/BackButton'
 import Table from 'components/Table'
 import { PageTitle } from 'components/Title'
 import { Padded } from 'components/Spacing'
-import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { logException } from 'lib/sentry'
-import { getGroupLabel, renamedGroup } from 'ducks/groups/helpers'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import styles from 'ducks/settings/GroupsSettings.styl'
@@ -248,9 +249,15 @@ const ExistingGroupSettings = enhance(props => (
   <Query query={client => client.get(GROUP_DOCTYPE, props.routeParams.groupId)}>
     {({ data: group, fetchStatus }) =>
       fetchStatus === 'loading' || fetchStatus === 'pending' ? (
-        <Loading />
+        <>
+          <BarTheme theme="primary" />
+          <Loading />
+        </>
       ) : (
-        <GroupSettings group={group} {...props} />
+        <>
+          <BarTheme theme="primary" />
+          <GroupSettings group={group} {...props} />
+        </>
       )
     }
   </Query>
@@ -267,6 +274,9 @@ export default ExistingGroupSettings
  */
 export const NewGroupSettings = enhance(
   translate()(props => (
-    <GroupSettings {...props} group={makeNewGroup(props.client, props.t)} />
+    <>
+      <BarTheme theme="primary" />
+      <GroupSettings {...props} group={makeNewGroup(props.client, props.t)} />
+    </>
   ))
 )

--- a/src/ducks/settings/GroupsSettings.styl
+++ b/src/ducks/settings/GroupsSettings.styl
@@ -14,11 +14,11 @@
     &__label
         maxed-flex-basis 25%
 
-    &__accounts
+    &__accounts&__accounts
         maxed-flex-basis 75%
 
         +small-screen()
-            flex-basis 100%
+            maxed-flex-basis 100%
 
 .GrpStg
     &__accntLabel

--- a/src/ducks/settings/NewAccountSettings.jsx
+++ b/src/ducks/settings/NewAccountSettings.jsx
@@ -1,36 +1,40 @@
-import React, { useState } from 'react'
-import BarTheme from 'ducks/bar/BarTheme'
-import { PageTitle } from 'components/Title'
-import BackButton from 'components/BackButton'
-import { Query, withClient } from 'cozy-client'
-import { ACCOUNT_DOCTYPE } from 'doctypes'
-import Loading from 'components/Loading'
-import {
-  getAccountLabel,
-  getAccountInstitutionLabel,
-  getAccountType,
-  getAccountOwners
-} from 'ducks/account/helpers'
-import { Padded } from 'components/Spacing'
-import Button from 'cozy-ui/transpiled/react/Button'
-import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
-import cx from 'classnames'
-import styles from 'ducks/settings/NewAccountSettings.styl'
-import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import Menu from 'cozy-ui/transpiled/react/MuiCozyTheme/Menus'
-import MenuItem from '@material-ui/core/MenuItem'
-import Modal from 'cozy-ui/transpiled/react/Modal'
-import { connect } from 'react-redux'
-import { getHomeURL } from 'ducks/apps/selectors'
 import { flowRight as compose, set } from 'lodash'
+import React, { useState } from 'react'
+import { connect } from 'react-redux'
+import MenuItem from '@material-ui/core/MenuItem'
+
+import { Query, withClient } from 'cozy-client'
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Menu from 'cozy-ui/transpiled/react/MuiCozyTheme/Menus'
 import { translate, useI18n } from 'cozy-ui/transpiled/react'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Field from 'cozy-ui/transpiled/react/Field'
 import CollectionField from 'cozy-ui/transpiled/react/Labs/CollectionField'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import BaseContactPicker from 'cozy-ui/transpiled/react/ContactPicker'
-import withFilters from 'components/withFilters'
 import { withBreakpoints } from 'cozy-ui/transpiled/react'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
+import Modal from 'cozy-ui/transpiled/react/Modal'
+
+import BarTheme from 'ducks/bar/BarTheme'
+import { ACCOUNT_DOCTYPE } from 'doctypes'
+import {
+  getAccountLabel,
+  getAccountInstitutionLabel,
+  getAccountType,
+  getAccountOwners
+} from 'ducks/account/helpers'
+import NarrowContent from 'cozy-ui/transpiled/react/NarrowContent'
+import cx from 'classnames'
+import styles from 'ducks/settings/NewAccountSettings.styl'
+import { getHomeURL } from 'ducks/apps/selectors'
+
+import { Padded } from 'components/Spacing'
+import { PageTitle } from 'components/Title'
+import BackButton from 'components/BackButton'
+import Loading from 'components/Loading'
+import withFilters from 'components/withFilters'
 import { BarRight } from 'components/Bar'
 
 const ContactPicker = props => {
@@ -279,7 +283,9 @@ const NewAccountSettings = props => {
             >
               {isMobile && (
                 <>
-                  <BackButton to="/settings/accounts" arrow theme="primary" />
+                  <CozyTheme theme="primary">
+                    <BackButton to="/settings/accounts" arrow theme="primary" />
+                  </CozyTheme>
                   <BarRight>
                     <Menu
                       position="right"
@@ -288,6 +294,7 @@ const NewAccountSettings = props => {
                           icon="dots"
                           iconOnly
                           label="click"
+                          theme="secondary"
                           extension="narrow"
                           className={styles.Menu__btn}
                         />

--- a/src/ducks/settings/NewAccountSettings.styl
+++ b/src/ducks/settings/NewAccountSettings.styl
@@ -46,3 +46,4 @@ right_padding = 2.5rem
 
 .Menu__btn
     height 100%
+    border 0

--- a/src/styles/main.styl
+++ b/src/styles/main.styl
@@ -21,7 +21,8 @@ h4
         z-index 90
 
 // TODO Move this directly to the cozy-bar
+// https://github.com/cozy/cozy-bar/issues/154
 :global
     +small-screen()
         [role=banner] .coz-bar-container
-            padding 0
+            padding 0 !important // @stylint ignore


### PR DESCRIPTION
BarTheme was not used in GroupSettings and AccountSettings
which broke colors (white title on blue background on a
white background bar).

Also fixed some little annoying things (border for menu
button, padding, ellipsis).