### PR TITLE
Improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "cozy-realtime": "3.9.0",
     "cozy-scripts": "4.1.0",
     "cozy-stack-client": "13.8.3",
-    "cozy-ui": "35.30.0",
+    "cozy-ui": "35.31.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -1,8 +1,8 @@
-import React, { PureComponent, Fragment } from 'react'
+import React, { PureComponent, Fragment, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
+import Switch from 'components/Switch'
 import RawBreadcrumb from 'cozy-ui/transpiled/react/Breadcrumbs'
 import { AccountSwitch } from 'ducks/account'
 import BackButton from 'components/BackButton'
@@ -36,9 +36,22 @@ const stTableCategory = catStyles['bnk-table-category']
 const IncomeToggle = ({ withIncome, onToggle }) => {
   const theme = useCozyTheme()
   const { t } = useI18n()
+
+  const handleClick = useCallback(
+    ev => {
+      return onToggle(ev.target.checked)
+    },
+    [onToggle]
+  )
   return (
     <div className={cx(styles.CategoriesHeader__Toggle, styles[theme])}>
-      <Toggle id="withIncome" checked={withIncome} onToggle={onToggle} />
+      <Switch
+        id="withIncome"
+        disableRipple
+        checked={withIncome}
+        color="primary"
+        onClick={handleClick}
+      />
       <label htmlFor="withIncome">{t('Categories.filter.includeIncome')}</label>
     </div>
   )

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -50,7 +50,6 @@
         margin-right 1em
     > label
         font-size .8em
-        position absolute
         line-height 1.5rem
 
     &.normal

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react'
+import React, { Component, useCallback } from 'react'
 import { withRouter } from 'react-router'
 import { sortBy, flowRight as compose } from 'lodash'
 import { Query, withClient } from 'cozy-client'
 import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
 import Button from 'cozy-ui/transpiled/react/Button'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { Media, Img } from 'cozy-ui/transpiled/react/Media'
 
@@ -12,6 +11,7 @@ import BarTheme from 'ducks/bar/BarTheme'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { GROUP_DOCTYPE, accountsConn } from 'doctypes'
 import { getGroupLabel, renamedGroup } from 'ducks/groups/helpers'
+import Switch from 'components/Switch'
 import Loading from 'components/Loading'
 import BackButton from 'components/BackButton'
 import Table from 'components/Table'
@@ -31,6 +31,13 @@ const makeNewGroup = (client, t) => {
 export const AccountLine = props => {
   const { account, group, toggleAccount } = props
 
+  const handleClickSwitch = useCallback(
+    ev => {
+      return toggleAccount.bind(account._id, group, ev.target.checked)
+    },
+    [toggleAccount, account, group]
+  )
+
   return (
     <tr>
       <td className={styles.GrpStg__accntLabel}>
@@ -42,13 +49,15 @@ export const AccountLine = props => {
       <td className={styles.GrpStg__accntNumber}>{account.number}</td>
       <td className={styles.GrpStg__accntToggle}>
         {group ? (
-          <Toggle
+          <Switch
+            disableRipple
+            color="primary"
             id={account._id}
             checked={group.accounts.existsById(account._id)}
-            onToggle={toggleAccount.bind(null, account._id, group)}
+            onClick={handleClickSwitch}
           />
         ) : (
-          <Toggle id={account._id} disabled />
+          <Switch id={account._id} disabled />
         )}
       </td>
     </tr>

--- a/src/ducks/settings/GroupSettings.spec.jsx
+++ b/src/ducks/settings/GroupSettings.spec.jsx
@@ -3,7 +3,7 @@ import {
   DumbGroupSettings as GroupSettings,
   AccountLine
 } from './GroupSettings'
-import Toggle from 'cozy-ui/transpiled/react/Toggle'
+import Switch from 'components/Switch'
 import { mount } from 'enzyme'
 import AppLike from 'test/AppLike'
 import fixtures from 'test/fixtures'
@@ -89,8 +89,8 @@ describe('GroupSettings', () => {
       </AppLike>
     )
 
-    const toggles = root.find(Toggle)
-    toggles.at(0).simulate('click')
+    const switches = root.find(Switch)
+    switches.at(0).simulate('click')
 
     expect(existsById).toHaveBeenCalledWith(account._id)
   })

--- a/src/ducks/settings/GroupsSettings.styl
+++ b/src/ducks/settings/GroupsSettings.styl
@@ -21,18 +21,6 @@
             maxed-flex-basis 100%
 
 .GrpStg
-    &__accntLabel
-        maxed-flex-basis 25%
-
-    &__accntBank
-        maxed-flex-basis 25%
-
-    &__accntNumber
-        maxed-flex-basis 30%
-
-    &__accntToggle
-        maxed-flex-basis 20%
-
     &__table
         @extend $full-width-table
 
@@ -50,3 +38,16 @@
                 margin-top 0.25rem
             input[type=text]
                 width 100%
+
+    &__accntLabel
+        maxed-flex-basis 25%
+
+    &__accntBank
+        maxed-flex-basis 25%
+
+    &__accntNumber
+        maxed-flex-basis 30%
+
+    &__accntToggle
+        maxed-flex-basis 20%
+

--- a/src/ducks/settings/GroupsSettings.styl
+++ b/src/ducks/settings/GroupsSettings.styl
@@ -51,3 +51,9 @@
     &__accntToggle
         maxed-flex-basis 20%
 
+    // Increase specificity to override properties applied to table &__table td
+    &__table &__accntToggle
+        // Do not let the switch extend vertically the cell
+        max-height 2rem
+        align-items center
+        display flex

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -71,7 +71,7 @@ export class DumbBillChip extends React.PureComponent {
       <Wrapper fileId={invoiceId} key={invoiceId} transaction={transaction}>
         <Chip component="button" size="small" variant="outlined">
           <FileIcon
-            color={bill.isRefund ? 'var(--emerald)' : undefined}
+            color={bill.isRefund ? 'var(--validColor)' : undefined}
             className="u-flex-shrink-0"
           />
           {bill.isRefund ? (

--- a/src/ducks/transactions/scroll/InfiniteScroll.jsx
+++ b/src/ducks/transactions/scroll/InfiniteScroll.jsx
@@ -77,6 +77,9 @@ class InfiniteScroll extends React.Component {
   }
 
   handleScroll = () => {
+    if (this.unmounted) {
+      return
+    }
     if (this.props.onScroll) {
       this.props.onScroll(this.getScrollInfo)
     }

--- a/src/ducks/transfers/steps/TransferState.jsx
+++ b/src/ducks/transfers/steps/TransferState.jsx
@@ -17,7 +17,7 @@ const TransferState = ({
   <Padded className={styles.TransferState}>
     <Title className="u-mb-1-half">{title}</Title>
     {Img}
-    <Text className="u-mb-1-half">{description}</Text>
+    <Text className="u-mb-1-half u-ta-center">{description}</Text>
     <Button
       extension="full"
       className="u-mb-half"

--- a/test/fixtures/demo.json
+++ b/test/fixtures/demo.json
@@ -2298,7 +2298,12 @@
       "categoryId": "200110",
       "manualLabel": "Salaire",
       "automaticLabel": "Salaire",
-      "amount": 3870.54
+      "amount": 3870.54,
+      "stats": {
+        "deltas": {
+          "median": 30
+	}
+      }
     },
     {
       "_id": "recurrence-bouygues-isa",
@@ -2306,7 +2311,12 @@
       "categoryId": "200110",
       "manualLabel": "Bouygues",
       "automaticLabel": "Bouygues Telecom",
-      "amount": -44.9
+      "amount": -44.9,
+      "stats": {
+        "deltas": {
+          "median": 30
+        }
+      }
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5532,10 +5532,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@35.30.0:
-  version "35.30.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.30.0.tgz#20a2620cee9e2213dddbfcd4dc4bcacab289b2db"
-  integrity sha512-JqOFogeV+17+iYISAvOLndqLP7F8lEA6RnOoATvEdEz4AarCZie5BgyBjtP01DkBW7rh8XKkHXY0x+CB90KSFQ==
+cozy-ui@35.31.0:
+  version "35.31.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.31.0.tgz#bced6f6f0387a5840c1e58768dfee1c5b1b86f25"
+  integrity sha512-1ks0cZ1kg4lvFzyli4aZwLGBH30AllLVe4VwkevOchgfFBlQyvNc+l/PlHRVO+9WOilf+/BP7dDPY5S9SaBxRg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     body-scroll-lock "^2.5.8"
@@ -11850,11 +11850,6 @@ lodash@4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 lodash@^3.3.1, lodash@^3.5.0:
   version "3.10.1"


### PR DESCRIPTION
Several unrelated improvements

- Remove the presence of cozy-ui's Toggle to use Material UI's Switch

We had already begun the transition work, the Switch had been used on
the account panels. Now, the group settings and categories page's
IncomeToggle use Switches.

- Defensive programming for a case that should not happen for the
  onScroll handler. This callback is throttled, so it can
  happen that it is called while the component has been unmounted.

- Add missing stats object in recurrence objects inside fixtures. This
  would cause the transactions page to crash. This is turn would cause
  the transactions to be unmounted while the scroll was happening leading
  to the bug fixed above (handleScroll does nothing when component is
  unmounted).

- Use validColor instead of emerald for theming