### PR TITLE
Repair push notifications

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -87,6 +87,12 @@ module.exports = {
 
   resolve: {
     alias: {
+      // We are building with target: node as webpack options. This causes webpack
+      // to consider the "module" entrypoint from node-fetch. This does not work properly
+      // as require('node-fetch') returns a module object (with the default property).
+      // Here, we force the resolution to take the commonJS file.
+      // TODO See if it is necessary to integrate in cozy-scripts
+      'node-fetch': 'node-fetch/lib/index.js',
       // Unminified Handlebars uses `require.extensions` and this causes
       // warnings on Webpack. We should think of a way to precompile
       // our Handlebars template. At the moment it is not possible

--- a/scripts/ci/mattermost_comment.sh
+++ b/scripts/ci/mattermost_comment.sh
@@ -11,4 +11,5 @@ else
   FROM="master"
 fi
 
-curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"gangsters\"}" $MATTERMOST_HOOK_URL
+MATTERMOST_CHANNEL=${MATTERMOST_CHANNEL:-"gangsters"}
+curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"$MATTERMOST_CHANNEL\"}" $MATTERMOST_HOOK_URL

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -201,5 +201,5 @@ const main = async () => {
 
 main().catch(e => {
   log('critical', e)
-  process.exit(e)
+  process.exit(1)
 })


### PR DESCRIPTION
- A bug in the bundling of node-fetch would make the service fail.
- The failure was not appearing on our dashboards since the exit 1 was not reported