### PR TITLE
feat: NoAccount background colors takes header inverted color

### DIFF
--- a/src/components/Header/Header.styl
+++ b/src/components/Header/Header.styl
@@ -16,8 +16,8 @@
     background-color var(--headerDefaultBackgroundColor)
 
 .HeaderColor_inverted
-    background-color var(--headerPrimaryBackgroundColor)
-    color var(--white)
+    background-color var(--headerInvertedBackgroundColor)
+    color var(--headerInvertedTextColor)
 
 .HeaderColor_inverted.HeaderFixed
     box-shadow 0 2px 4px 0 rgba(0, 0, 0, 0.24), 0 0 4px 0 rgba(0, 0, 0, 0.16)

--- a/src/ducks/balance/Balance.styl
+++ b/src/ducks/balance/Balance.styl
@@ -10,7 +10,7 @@
         left 0
         right 0
         height 44px
-        background-color var(--headerPrimaryBackgroundColor)
+        background-color var(--headerInvertedBackgroundColor)
 
     +small-screen()
         padding-left 0.5rem

--- a/src/ducks/balance/NoAccount.styl
+++ b/src/ducks/balance/NoAccount.styl
@@ -1,8 +1,8 @@
 @require 'settings/breakpoints'
 
 .NoAccount
-    background var(--primaryColor)
-    color var(--primaryContrastTextColor)
+    background var(--headerInvertedBackgroundColor)
+    color var(--headerInvertedTextColor)
     text-align center
     position relative
     height calc(50vh - 24px) // 24 is cozy-bar size / 2

--- a/src/styles/palette.styl
+++ b/src/styles/palette.styl
@@ -3,7 +3,8 @@ body
     --primaryColorDark #0d60d1 // darken(dodgerBlue, 12)
 
     --headerDefaultBackgroundColor var(--white)
-    --headerPrimaryBackgroundColor var(--primaryColor)
+    --headerInvertedBackgroundColor var(--primaryColor)
+    --headerInvertedTextColor var(--primaryContrastTextColor)
 
     --historyTooltipBackgroundColor var(--white)
     --historyTooltipTextColor var(--primaryColor)


### PR DESCRIPTION
While theming, we want the no account special page to have a background
that is the same as the header color. Since in some themes, the header
is not the same color as the primary color, we cannot use the primary
color in the NoAccount styles, we use the inverse header color.

I renamed some variables with headerPrimary to headerInverted to better
make the distinction between the primary color and the "inverted" color.