### PR TITLE
Correctly toggle an account in a group

### DIFF
--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -34,9 +34,7 @@ export const AccountLine = props => {
   const { account, group, toggleAccount } = props
 
   const handleClickSwitch = useCallback(
-    ev => {
-      return toggleAccount.bind(account._id, group, ev.target.checked)
-    },
+    ev => toggleAccount(account._id, group, ev.target.checked),
     [toggleAccount, account, group]
   )
 

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -2,16 +2,19 @@ import React, { Component, useCallback } from 'react'
 import { withRouter } from 'react-router'
 import { sortBy, flowRight as compose } from 'lodash'
 import { Query, withClient } from 'cozy-client'
+
 import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { Media, Img } from 'cozy-ui/transpiled/react/Media'
+import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import BarTheme from 'ducks/bar/BarTheme'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { GROUP_DOCTYPE, accountsConn } from 'doctypes'
 import { getGroupLabel, renamedGroup } from 'ducks/groups/helpers'
-import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
+
 import Loading from 'components/Loading'
 import BackButton from 'components/BackButton'
 import Table from 'components/Table'
@@ -19,7 +22,6 @@ import { PageTitle } from 'components/Title'
 import { Padded } from 'components/Spacing'
 import { logException } from 'lib/sentry'
 
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import styles from 'ducks/settings/GroupsSettings.styl'
 
 const makeNewGroup = (client, t) => {

--- a/src/ducks/settings/GroupSettings.spec.jsx
+++ b/src/ducks/settings/GroupSettings.spec.jsx
@@ -64,17 +64,7 @@ describe('GroupSettings', () => {
     expect(router.push).not.toHaveBeenCalled()
   })
 
-  it('Should call existsById with an id when rendering an account line', () => {
-    const group = fixtures['io.cozy.bank.groups'][0]
-    const accountsById = keyBy(fixtures['io.cozy.bank.accounts'], '_id')
-    const existsById = jest.fn()
-    group.accounts = {
-      data: group.accounts.map(accountId => accountsById[accountId]),
-      existsById
-    }
-    const account = fixtures['io.cozy.bank.accounts'][0]
-    const toggleAccount = jest.fn()
-
+  const setupAccountLine = ({ account, group, toggleAccount }) => {
     const root = mount(
       <AppLike>
         <table>
@@ -89,9 +79,37 @@ describe('GroupSettings', () => {
       </AppLike>
     )
 
+    return { root }
+  }
+
+  it('Should call existsById with an id when rendering an account line', () => {
+    const group = fixtures['io.cozy.bank.groups'][0]
+    const accountsById = keyBy(fixtures['io.cozy.bank.accounts'], '_id')
+    const existsById = jest.fn()
+    group.accounts = {
+      data: group.accounts.map(accountId => accountsById[accountId]),
+      existsById
+    }
+    const account = fixtures['io.cozy.bank.accounts'][0]
+    const toggleAccount = jest.fn()
+    const { root } = setupAccountLine({
+      account,
+      group,
+      toggleAccount
+    })
+
     const switches = root.find(Switch)
-    switches.at(0).simulate('click')
+    switches.props().onClick({
+      target: {
+        checked: true
+      }
+    })
 
     expect(existsById).toHaveBeenCalledWith(account._id)
+    expect(toggleAccount).toHaveBeenCalledWith(
+      'compteisa4',
+      expect.objectContaining({ _id: 'familleelargie' }),
+      true
+    )
   })
 })


### PR DESCRIPTION
When I refactored to use the new switch, I left a bind()
that kept the function from being called on click.