### PR TITLE
Blank emails

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -4,7 +4,6 @@ const path = require('path')
 const webpack = require('webpack')
 const { production } = require('./webpack.vars')
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin')
-const TerserPlugin = require('terser-webpack-plugin')
 
 const SRC_DIR = path.resolve(__dirname, '../src')
 
@@ -43,17 +42,6 @@ module.exports = {
   output: {
     path: path.resolve(__dirname, '../build'),
     filename: '[name].js'
-  },
-  optimization: {
-    minimizer: [
-      // We have to disable the mangle options otherwise we have a problem with mjml:
-      // "Element mj-column doesn't exist or is not registered"
-      new TerserPlugin({
-        terserOptions: {
-          mangle: false // Note `mangle.properties` is `false` by default.
-        }
-      })
-    ]
   },
   module: {
     rules: [

--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -39,6 +39,7 @@ module.exports = {
   entry: entries,
   mode: production ? 'production' : 'development',
   target: 'node',
+  devtool: false,
   output: {
     path: path.resolve(__dirname, '../build'),
     filename: '[name].js'

--- a/src/ducks/notifications/BaseNotificationView.js
+++ b/src/ducks/notifications/BaseNotificationView.js
@@ -4,6 +4,10 @@ import { generateUniversalLink } from 'cozy-ui/transpiled/react/AppLinker'
 import bankLayout from './bank-layout.hbs'
 import { helpers } from './index'
 
+/**
+ * Provides common data, helpers and partials to all notification views
+ * used in banks
+ */
 class BaseNotificationView extends NotificationView {
   constructor(options) {
     super(options)

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -93,6 +93,10 @@ export const getEnabledNotificationClasses = config => {
 
 const isKlassSupportingSeveralRules = Klass => Klass.supportsMultipleRules
 
+/**
+ * Given a notification class, sends a notification according to the
+ * corresponding rules
+ */
 export const sendNotificationForClass = async (
   Klass,
   { config, client, data, lang }


### PR DESCRIPTION
Since the introduction of cozy-scripts in the banks repository, we use
the TerserPlugin from cozy-scripts. Previously, we would configure this
plugin not to mangle function names in the webpack.target.services file.
Now, we need to directly tweak the options of cozy-scripts to achieve
the same goal.
