### PR TITLE
feat: Activate recurrence flag

### DIFF
--- a/src/ducks/analysis/AnalysisTabs.jsx
+++ b/src/ducks/analysis/AnalysisTabs.jsx
@@ -3,7 +3,6 @@ import { withRouter } from 'react-router'
 import { Tabs, TabList, Tab } from 'cozy-ui/transpiled/react/Tabs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import styles from 'components/Tabs.styl'
-import flag from 'cozy-flags'
 
 const AnalysisTabs = ({ router, location }) => {
   const { t } = useI18n()
@@ -23,13 +22,13 @@ const AnalysisTabs = ({ router, location }) => {
     </Tab>
   ))
 
-  return flag('banks.recurrence') ? (
+  return (
     <Tabs className={styles['Tabs']} initialActiveTab={activeTab}>
       <TabList inverted className={styles['TabList']}>
         {tabs}
       </TabList>
     </Tabs>
-  ) : null
+  )
 }
 
 export default withRouter(AnalysisTabs)

--- a/src/ducks/commons/Nav.jsx
+++ b/src/ducks/commons/Nav.jsx
@@ -97,22 +97,18 @@ export const Nav = () => {
             label: t('Nav.analysis'),
             rx: analysisRoute
           },
-          flag('banks.recurrence')
-            ? {
-                to: '/categories',
-                label: t('Nav.categories'),
-                rx: categoriesRoute,
-                secondary: true
-              }
-            : null,
-          flag('banks.recurrence')
-            ? {
-                to: '/recurrence',
-                label: t('Nav.recurrence'),
-                rx: recurrenceRoute,
-                secondary: true
-              }
-            : null,
+          {
+            to: '/categories',
+            label: t('Nav.categories'),
+            rx: categoriesRoute,
+            secondary: true
+          },
+          {
+            to: '/recurrence',
+            label: t('Nav.recurrence'),
+            rx: recurrenceRoute,
+            secondary: true
+          },
           flag('banks.transfers')
             ? {
                 to: '/transfers',

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -365,12 +365,10 @@ const TransactionModalInfoContent = withTransaction(props => {
           <RowArrow />
         </Img>
       </TransactionModalRowMedia>
-      {flag('banks.recurrence') ? (
-        <RecurrenceRow
-          transaction={transaction}
-          onClick={handleShowRecurrenceChoice}
-        />
-      ) : null}
+      <RecurrenceRow
+        transaction={transaction}
+        onClick={handleShowRecurrenceChoice}
+      />
       <TransactionActions
         transaction={transaction}
         {...restProps}

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -14,15 +14,6 @@ import { format } from 'date-fns'
 import Polyglot from 'node-polyglot'
 import en from 'locales/en.json'
 
-jest.mock('cozy-flags', () => flagName => {
-  const activeFlags = ['banks.recurrence']
-  if (activeFlags.includes(flagName)) {
-    return true
-  } else {
-    return false
-  }
-})
-
 jest.mock('cozy-ui/transpiled/react/Alerter', () => ({
   success: jest.fn()
 }))

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -167,7 +167,7 @@ class _RowDesktop extends React.PureComponent {
                 {applicationDate ? (
                   <ApplicationDateCaption f={f} transaction={transaction} />
                 ) : null}
-                {recurrence && showRecurrence && flag('banks.recurrence') ? (
+                {recurrence && showRecurrence ? (
                   <RecurrenceCaption recurrence={recurrence} />
                 ) : null}
               </List.Content>
@@ -270,7 +270,7 @@ class _RowMobile extends React.PureComponent {
               coloredPositive
               signed
             />
-            {recurrence && showRecurrence && flag('banks.recurrence') ? (
+            {recurrence && showRecurrence ? (
               <RecurrenceCaption recurrence={recurrence} />
             ) : null}
           </Img>


### PR DESCRIPTION
Now that it has been tested on our prod, we can remove the flag. This
way, self-hosted cozynautes will be able to use recurrence
functionality.