### PR TITLE
Harvest in banks

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -208,7 +208,7 @@
       "verbs": ["GET"]
     },
     "triggers": {
-      "description": "Used to configure bank account triggers through Harvest",
+      "description": "Used to configure bank accounts",
       "type": "io.cozy.triggers"
     },
     "settings": {
@@ -241,7 +241,7 @@
       "type": "io.cozy.jobs"
     },
     "accounts": {
-      "description": "Used to create a temporary account for transfers and to configure accounts through Harvest",
+      "description": "Used to create a temporary account for transfers and to configure accounts",
       "type": "io.cozy.accounts"
     },
     "contacts": {

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -208,9 +208,8 @@
       "verbs": ["GET"]
     },
     "triggers": {
-      "description": "Used to add CTA to collect",
-      "type": "io.cozy.triggers",
-      "verbs": ["GET", "POST"]
+      "description": "Used to configure bank account triggers through Harvest",
+      "type": "io.cozy.triggers"
     },
     "settings": {
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",
@@ -242,9 +241,8 @@
       "type": "io.cozy.jobs"
     },
     "accounts": {
-      "description": "Used to create a temporary account for transfers",
-      "type": "io.cozy.accounts",
-      "verbs": ["POST", "DELETE", "GET"]
+      "description": "Used to create a temporary account for transfers and to configure accounts through Harvest",
+      "type": "io.cozy.accounts"
     },
     "contacts": {
       "description": "Used to link accounts to contacts",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.2.5",
-    "cozy-harvest-lib": "2.3.1",
+    "cozy-harvest-lib": "2.5.0",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "cozy-realtime": "3.9.0",
     "cozy-scripts": "4.1.0",
     "cozy-stack-client": "13.16.0",
-    "cozy-ui": "35.37.0",
+    "cozy-ui": "35.40.2",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.2.5",
-    "cozy-harvest-lib": "2.0.0",
+    "cozy-harvest-lib": "2.3.1",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/src/components/AccountIcon/index.jsx
+++ b/src/components/AccountIcon/index.jsx
@@ -4,12 +4,7 @@ import { getAccountInstitutionSlug } from 'ducks/account/helpers'
 import styles from './styles.styl'
 import cx from 'classnames'
 
-/** Displays a konnector icon for an io.cozy.bank.accounts */
-const _AccountIcon = ({ account, className, size }) => {
-  const institutionSlug = getAccountInstitutionSlug(account)
-  if (!institutionSlug) {
-    return null
-  }
+export const AccountIconContainer = ({ size, children }) => {
   return (
     <span
       className={cx(styles.AccountIconContainer, {
@@ -17,8 +12,21 @@ const _AccountIcon = ({ account, className, size }) => {
         [styles['AccountIconContainer--large']]: size === 'large'
       })}
     >
-      <KonnectorIcon slug={institutionSlug} className={className} />
+      {children}
     </span>
+  )
+}
+
+/** Displays a konnector icon for an io.cozy.bank.accounts */
+const _AccountIcon = ({ account, className, size }) => {
+  const institutionSlug = getAccountInstitutionSlug(account)
+  if (!institutionSlug) {
+    return null
+  }
+  return (
+    <AccountIconContainer size={size}>
+      <KonnectorIcon slug={institutionSlug} className={className} />
+    </AccountIconContainer>
   )
 }
 

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import ReactHintFactory from 'react-hint'
 import 'react-hint/css/index.css'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -22,7 +22,9 @@ const ReactHint = ReactHintFactory(React)
 
 const App = props => {
   const settings = getDefaultedSettingsFromCollection(props.settingsCollection)
-  flag('local-model-override', settings.community.localModelOverride.enabled)
+  useEffect(() => {
+    flag('local-model-override', settings.community.localModelOverride.enabled)
+  }, [settings.community.localModelOverride.enabled])
 
   return (
     <BreakpointsProvider>

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { IndexRoute, Route, Redirect } from 'react-router'
 import App from 'components/App'
 import { isWebApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 
 import { TransactionsPageWithBackButton } from 'ducks/transactions'
 import { CategoriesPage } from 'ducks/categories'
@@ -15,6 +16,7 @@ import {
   Configuration,
   Debug
 } from 'ducks/settings'
+import OldAccountSettings from 'ducks/settings/OldAccountSettings'
 import { Balance, BalanceDetailsPage } from 'ducks/balance'
 import {
   DebugRecurrencePage,
@@ -71,7 +73,14 @@ const AppRoute = () => (
         />
         <Route component={scrollToTopOnMount(Settings)}>
           <IndexRoute component={Configuration} />
-          <Route path="accounts" component={AccountsSettings} />
+          <Route
+            path="accounts"
+            component={
+              flag('banks.harvest-accounts-settings')
+                ? AccountsSettings
+                : OldAccountSettings
+            }
+          />
           <Route path="groups" component={GroupsSettings} />
           <Route path="configuration" component={Configuration} />
           <Route path="debug" component={Debug} />

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -8,8 +8,8 @@ import { TransactionsPageWithBackButton } from 'ducks/transactions'
 import { CategoriesPage } from 'ducks/categories'
 import {
   Settings,
-  AccountSettings,
   AccountsSettings,
+  AccountSettings,
   GroupsSettings,
   GroupSettings,
   NewGroupSettings,
@@ -67,10 +67,17 @@ const AppRoute = () => (
           path="groups/:groupId"
           component={scrollToTopOnMount(GroupSettings)}
         />
+
+        {/* This route will be removed after finishing transition to Harvest for account settings */}
         <Route
-          path="accounts/:accountId"
+          path={
+            flag('banks.harvest-accounts-settings')
+              ? 'old-accounts/:accountId'
+              : 'accounts/:accountId'
+          }
           component={scrollToTopOnMount(AccountSettings)}
         />
+        <Redirect from="accounts/:accountId" to="accounts" />
         <Route component={scrollToTopOnMount(Settings)}>
           <IndexRoute component={Configuration} />
           <Route

--- a/src/components/Spacing/Padded.jsx
+++ b/src/components/Spacing/Padded.jsx
@@ -24,7 +24,7 @@ const _Unpadded = ({ horizontal, vertical, className, ...restProps }) => {
   )
 }
 
-const Unpadded = React.memo(_Unpadded)
+export const Unpadded = React.memo(_Unpadded)
 
 _Padded.propTypes = {
   children: PropTypes.node.isRequired,

--- a/src/components/__snapshots__/AppRoute.spec.jsx.snap
+++ b/src/components/__snapshots__/AppRoute.spec.jsx.snap
@@ -63,6 +63,10 @@ exports[`App route should be a function returning a route 1`] = `
         component={[Function]}
         path="accounts/:accountId"
       />
+      <Redirect
+        from="accounts/:accountId"
+        to="accounts"
+      />
       <Route
         component={[Function]}
       >
@@ -177,6 +181,10 @@ exports[`App route should have renderExtraRoutes 1`] = `
       <Route
         component={[Function]}
         path="accounts/:accountId"
+      />
+      <Redirect
+        from="accounts/:accountId"
+        to="accounts"
       />
       <Route
         component={[Function]}

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -135,6 +135,10 @@ export const schema = {
       owners: {
         type: 'has-many',
         doctype: CONTACT_DOCTYPE
+      },
+      connection: {
+        type: 'has-one',
+        doctype: COZY_ACCOUNT_DOCTYPE
       }
     }
   },
@@ -178,7 +182,7 @@ export const schema = {
 const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
 
 export const accountsConn = {
-  query: () => Q(ACCOUNT_DOCTYPE).include(['owners']),
+  query: () => Q(ACCOUNT_DOCTYPE).include(['owners', 'connection']),
   as: 'accounts',
   fetchPolicy: older30s
 }

--- a/src/ducks/balance/KonnectorIcon.jsx
+++ b/src/ducks/balance/KonnectorIcon.jsx
@@ -1,27 +1,3 @@
-import React from 'react'
-import UIAppIcon from 'cozy-ui/transpiled/react/AppIcon'
-import { withClient } from 'cozy-client'
+import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 
-// TODO: Move this in cozy-ui
-class KonnectorIcon extends React.PureComponent {
-  constructor(props) {
-    super(props)
-    this.fetchIcon = this.fetchIcon.bind(this)
-  }
-
-  fetchIcon() {
-    const { client, slug, app } = this.props
-    return client.stackClient.getIconURL({
-      type: 'konnector',
-      slug: slug || app.slug
-    })
-  }
-
-  render() {
-    const { className } = this.props
-
-    return <UIAppIcon fetchIcon={this.fetchIcon} className={className} />
-  }
-}
-
-export default withClient(KonnectorIcon)
+export default KonnectorIcon

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -123,7 +123,7 @@ const AccountsSettings = props => {
   const myAccounts = accountBySharingDirection[true]
 
   return (
-    <div>
+    <>
       {myAccounts ? (
         <AccountsList accounts={myAccounts} t={t} />
       ) : (
@@ -136,7 +136,7 @@ const AccountsSettings = props => {
           label={t('Accounts.add_bank')}
         />
       </AddAccountLink>
-    </div>
+    </>
   )
 }
 export default queryConnect({

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { withRouter } from 'react-router'
 import { groupBy, sortBy } from 'lodash'
 
@@ -24,6 +24,8 @@ import { Contact } from 'cozy-doctypes'
 import { accountsConn, APP_DOCTYPE } from 'doctypes'
 import { Row, Cell } from 'components/Table'
 
+import HarvestBankAccountSettings from './HarvestBankAccountSettings'
+
 // See comment below about sharings
 // import { ACCOUNT_DOCTYPE } from 'doctypes'
 // import { fetchSharingInfo } from 'modules/SharingStatus'
@@ -41,37 +43,43 @@ const AccountOwners = ({ account }) => {
   ) : null
 }
 
-const _AccountLine = ({ account, router }) => {
+const _AccountLine = ({ account }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
+  const [showHarvestSettings, setShowHarvestSettings] = useState(false)
+
   return (
-    <Row
-      nav
-      key={account.id}
-      onClick={() => router.push(`/settings/accounts/${account.id}`)}
-    >
-      <Cell main className={styles.AcnsStg__libelle}>
-        <div className={styles.AcnsStg__libelleInner}>
-          <div>{account.shortLabel || account.label}</div>
-          {isMobile ? <AccountOwners account={account} /> : null}
-        </div>
-      </Cell>
-      <Cell className={styles.AcnsStg__bank}>
-        {getAccountInstitutionLabel(account)}
-      </Cell>
-      <Cell className={styles.AcnsStg__number}>{account.number}</Cell>
-      <Cell className={styles.AcnsStg__type}>
-        {t(`Data.accountTypes.${getAccountType(account)}`, {
-          _: t('Data.accountTypes.Other')
-        })}
-      </Cell>
-      <Cell className={styles.AcnsStg__owner}>
-        {getAccountOwners(account)
-          .map(Contact.getDisplayName)
-          .join(' - ')}
-      </Cell>
-      <Cell className={styles.AcnsStg__actions} />
-    </Row>
+    <>
+      <Row nav key={account.id} onClick={() => setShowHarvestSettings(true)}>
+        <Cell main className={styles.AcnsStg__libelle}>
+          <div className={styles.AcnsStg__libelleInner}>
+            <div>{account.shortLabel || account.label}</div>
+            {isMobile ? <AccountOwners account={account} /> : null}
+          </div>
+        </Cell>
+        <Cell className={styles.AcnsStg__bank}>
+          {getAccountInstitutionLabel(account)}
+        </Cell>
+        <Cell className={styles.AcnsStg__number}>{account.number}</Cell>
+        <Cell className={styles.AcnsStg__type}>
+          {t(`Data.accountTypes.${getAccountType(account)}`, {
+            _: t('Data.accountTypes.Other')
+          })}
+        </Cell>
+        <Cell className={styles.AcnsStg__owner}>
+          {getAccountOwners(account)
+            .map(Contact.getDisplayName)
+            .join(' - ')}
+        </Cell>
+        <Cell className={styles.AcnsStg__actions} />
+      </Row>
+      {showHarvestSettings ? (
+        <HarvestBankAccountSettings
+          onDismiss={() => setShowHarvestSettings(false)}
+          bankAccount={account}
+        />
+      ) : null}
+    </>
   )
 }
 

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -29,7 +29,7 @@ import HarvestBankAccountSettings from './HarvestBankAccountSettings'
 
 const AccountsList_ = ({ accounts }) => {
   const connections = uniqBy(
-    accounts.map(acc => acc.connection.data),
+    accounts.map(acc => acc.connection.data).filter(Boolean),
     connection => connection._id
   )
 

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,13 +1,15 @@
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
-import { translate, useI18n } from 'cozy-ui/transpiled/react'
+import { groupBy, flowRight as compose, sortBy } from 'lodash'
+
+import { translate, useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import { withBreakpoints } from 'cozy-ui/transpiled/react'
-import { groupBy, flowRight as compose, sortBy } from 'lodash'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { queryConnect, Q } from 'cozy-client'
+
 import Table from 'components/Table'
 import Loading from 'components/Loading'
-import { queryConnect, Q } from 'cozy-client'
 import plus from 'assets/icons/16/plus.svg'
 import styles from 'ducks/settings/AccountsSettings.styl'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
@@ -39,9 +41,9 @@ const AccountOwners = ({ account }) => {
   ) : null
 }
 
-const _AccountLine = ({ account, router, breakpoints: { isMobile } }) => {
+const _AccountLine = ({ account, router }) => {
   const { t } = useI18n()
-
+  const { isMobile } = useBreakpoints()
   return (
     <Row
       nav
@@ -73,11 +75,7 @@ const _AccountLine = ({ account, router, breakpoints: { isMobile } }) => {
   )
 }
 
-const AccountLine = compose(
-  translate(),
-  withRouter,
-  withBreakpoints()
-)(_AccountLine)
+const AccountLine = withRouter(_AccountLine)
 
 const renderAccount = account => (
   <AccountLine account={account} key={account._id} />

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -129,7 +129,6 @@ const AccountsSettings = props => {
   })
 
   const myAccounts = accountBySharingDirection[true]
-  const sharedAccounts = accountBySharingDirection[false]
 
   return (
     <div>
@@ -145,28 +144,9 @@ const AccountsSettings = props => {
       ) : (
         <p>{t('Accounts.no-accounts')}</p>
       )}
-
-      <h4>{t('Accounts.shared-accounts')}</h4>
-
-      {sharedAccounts ? (
-        <AccountsTable accounts={sharedAccounts} t={t} />
-      ) : (
-        <p>{t('Accounts.no-shared-accounts')}</p>
-      )}
     </div>
   )
 }
-
-// TODO reactivate when we understand how sharings work
-// const fetchAccountsSharingInfo = props => {
-//   return Promise.resolve([])
-// const { accounts } = props
-// with cozy-client
-// return Promise.all(accounts.data.map(account => {
-//   return props.dispatch(fetchSharingInfo(ACCOUNT_DOCTYPE, account._id))
-// }))
-// }
-
 export default queryConnect({
   accountsCollection: accountsConn,
   apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,8 +1,8 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { withRouter } from 'react-router'
-import { groupBy, flowRight as compose, sortBy } from 'lodash'
+import { groupBy, sortBy } from 'lodash'
 
-import { translate, useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
@@ -77,10 +77,6 @@ const _AccountLine = ({ account, router }) => {
 
 const AccountLine = withRouter(_AccountLine)
 
-const renderAccount = account => (
-  <AccountLine account={account} key={account._id} />
-)
-
 const AccountsTable = ({ accounts }) => {
   const { t } = useI18n()
 
@@ -96,58 +92,61 @@ const AccountsTable = ({ accounts }) => {
           <th className={styles.AcnsStg__actions} />
         </tr>
       </thead>
-      <tbody>{accounts.map(renderAccount)}</tbody>
+      <tbody>
+        {accounts.map(account => (
+          <AccountLine account={account} key={account._id} />
+        ))}
+      </tbody>
     </Table>
   )
 }
 
-class AccountsSettings extends Component {
-  render() {
-    const { t, accountsCollection } = this.props
+const AccountsSettings = props => {
+  const { t } = useI18n()
+  const { accountsCollection } = props
 
-    if (
-      isCollectionLoading(accountsCollection) &&
-      !hasBeenLoaded(accountsCollection)
-    ) {
-      return <Loading />
-    }
-
-    const sortedAccounts = sortBy(accountsCollection.data, [
-      'institutionLabel',
-      'label'
-    ])
-    const accountBySharingDirection = groupBy(sortedAccounts, account => {
-      return account.shared === undefined
-    })
-
-    const myAccounts = accountBySharingDirection[true]
-    const sharedAccounts = accountBySharingDirection[false]
-
-    return (
-      <div>
-        <AddAccountLink>
-          <Button
-            theme="text"
-            icon={<Icon icon={plus} className="u-mr-half" />}
-            label={t('Accounts.add_bank')}
-          />
-        </AddAccountLink>
-        {myAccounts ? (
-          <AccountsTable accounts={myAccounts} t={t} />
-        ) : (
-          <p>{t('Accounts.no-accounts')}</p>
-        )}
-
-        <h4>{t('Accounts.shared-accounts')}</h4>
-
-        {sharedAccounts ? (
-          <AccountsTable accounts={sharedAccounts} t={t} />
-        ) : (
-          <p>{t('Accounts.no-shared-accounts')}</p>
-        )}
-      </div>
-    )
+  if (
+    isCollectionLoading(accountsCollection) &&
+    !hasBeenLoaded(accountsCollection)
+  ) {
+    return <Loading />
   }
+
+  const sortedAccounts = sortBy(accountsCollection.data, [
+    'institutionLabel',
+    'label'
+  ])
+  const accountBySharingDirection = groupBy(sortedAccounts, account => {
+    return account.shared === undefined
+  })
+
+  const myAccounts = accountBySharingDirection[true]
+  const sharedAccounts = accountBySharingDirection[false]
+
+  return (
+    <div>
+      <AddAccountLink>
+        <Button
+          theme="text"
+          icon={<Icon icon={plus} className="u-mr-half" />}
+          label={t('Accounts.add_bank')}
+        />
+      </AddAccountLink>
+      {myAccounts ? (
+        <AccountsTable accounts={myAccounts} t={t} />
+      ) : (
+        <p>{t('Accounts.no-accounts')}</p>
+      )}
+
+      <h4>{t('Accounts.shared-accounts')}</h4>
+
+      {sharedAccounts ? (
+        <AccountsTable accounts={sharedAccounts} t={t} />
+      ) : (
+        <p>{t('Accounts.no-shared-accounts')}</p>
+      )}
+    </div>
+  )
 }
 
 // TODO reactivate when we understand how sharings work
@@ -160,10 +159,7 @@ class AccountsSettings extends Component {
 // }))
 // }
 
-export default compose(
-  queryConnect({
-    accountsCollection: accountsConn,
-    apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }
-  }),
-  translate()
-)(AccountsSettings)
+export default queryConnect({
+  accountsCollection: accountsConn,
+  apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }
+})(AccountsSettings)

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -31,6 +31,10 @@ const HarvestLoader = ({ connectionId, children }) => {
       fetchPolicy={fetchPolicy}
     >
       {({ data: account, fetchStatus, lastUpdate }) => {
+        // Can happen for a short while when the account is deleted
+        if (!account) {
+          return null
+        }
         if (fetchStatus === 'loading' && !lastUpdate) {
           return <HarvestSpinner />
         } else {

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import CozyClient, { Q, Query } from 'cozy-client'
 
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
@@ -15,6 +16,11 @@ const HarvestSpinner = () => {
       <Spinner size="xxlarge" />
     </div>
   )
+}
+
+const HarvestError = () => {
+  const { t } = useI18n()
+  return <div className="u-m-2 u-error">{t('Loading.error')}</div>
 }
 
 const fetchPolicy = CozyClient.fetchPolicies.olderThan(30 * 1000)
@@ -37,6 +43,8 @@ const HarvestLoader = ({ connectionId, children }) => {
         }
         if (fetchStatus === 'loading' && !lastUpdate) {
           return <HarvestSpinner />
+        } else if (fetchStatus === 'error') {
+          return <HarvestError />
         } else {
           const konnectorSlug = account.account_type
           return (
@@ -54,6 +62,10 @@ const HarvestLoader = ({ connectionId, children }) => {
                   return <HarvestSpinner />
                 }
 
+                if (fetchStatus === 'error') {
+                  return <HarvestError />
+                }
+
                 // We do not query directly the triggers for the connection as
                 // we need to use the /jobs/triggers route. This route is only
                 // used by cozy-client when all triggers are fetched
@@ -69,6 +81,8 @@ const HarvestLoader = ({ connectionId, children }) => {
                       })
                       if (fetchStatus === 'loading' && !lastUpdate) {
                         return <HarvestSpinner />
+                      } else if (fetchStatus === 'error') {
+                        return <HarvestError />
                       } else {
                         const accountsAndTriggers = [account]
                           .map(account => ({

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -115,6 +115,10 @@ const HarvestBankAccountSettings = ({ connectionId, onDismiss }) => {
                       triggers={triggers}
                       konnector={konnector}
                       accountsAndTriggers={accountsAndTriggers}
+                      onDismiss={() => {
+                        onDismiss()
+                      }}
+                      showAccountSelection={false}
                     />
                   )
                 }}

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -23,9 +23,9 @@ const HarvestSpinner = () => {
   )
 }
 
-const HarvestLoader = ({ accountId, children }) => {
+const HarvestLoader = ({ connectionId, children }) => {
   return (
-    <Query query={Q('io.cozy.accounts').getById(accountId)}>
+    <Query query={Q('io.cozy.accounts').getById(connectionId)}>
       {({ data: account, fetchStatus }) => {
         if (fetchStatus === 'loading') {
           return <HarvestSpinner />
@@ -37,7 +37,9 @@ const HarvestLoader = ({ accountId, children }) => {
                 if (fetchStatus === 'loading') {
                   return <HarvestSpinner />
                 }
-                const triggerQuery = makeQuerySpecForAccountTriggers(accountId)
+                const triggerQuery = makeQuerySpecForAccountTriggers(
+                  connectionId
+                )
                 return (
                   <Query query={triggerQuery.query} as={triggerQuery.as}>
                     {({ data: triggers }) => {
@@ -72,11 +74,10 @@ const HarvestLoader = ({ accountId, children }) => {
  * Shows a modal displaying the AccountModal from Harvest
  * Fetches all the data necessary through HarvestLoader
  */
-const HarvestBankAccountSettings = ({ bankAccount, onDismiss }) => {
-  const accountId = bankAccount.relationships.connection._id
+const HarvestBankAccountSettings = ({ connectionId, onDismiss }) => {
   return (
     <Modal mobileFullscreen size="large" dismissAction={onDismiss}>
-      <HarvestLoader accountId={accountId}>
+      <HarvestLoader connectionId={connectionId}>
         {({ triggers, konnector, accountsAndTriggers }) => {
           if (!accountsAndTriggers.length) {
             return null
@@ -84,7 +85,7 @@ const HarvestBankAccountSettings = ({ bankAccount, onDismiss }) => {
           return (
             <MountPointContext.Provider value={{}}>
               <AccountModal
-                accountId={accountId}
+                accountId={connectionId}
                 konnector={konnector}
                 triggers={triggers}
                 accountsAndTriggers={accountsAndTriggers}

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -53,6 +53,7 @@ const HarvestLoader = ({ connectionId, children }) => {
                 // We do not query directly the triggers for the connection as
                 // we need to use the /jobs/triggers route. This route is only
                 // used by cozy-client when all triggers are fetched
+                // Related issue : https://github.com/cozy/cozy-client/issues/767
                 return (
                   <Query query={Q('io.cozy.triggers')} as="triggers">
                     {({ data: allTriggers, fetchStatus, lastUpdate }) => {

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -62,7 +62,7 @@ const HarvestLoader = ({ connectionId, children }) => {
                 )
                 return (
                   <Query query={triggerQuery.query} as={triggerQuery.as}>
-                    {({ data: triggers }) => {
+                    {({ data: triggers, fetchStatus, lastUpdate }) => {
                       if (fetchStatus === 'loading' && !lastUpdate) {
                         return <HarvestSpinner />
                       } else {

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { Q, Query } from 'cozy-client'
+
+import Modal from 'cozy-ui/transpiled/react/Modal'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import AccountModal from 'cozy-harvest-lib/dist/components/AccountModal'
+import { MountPointContext } from 'cozy-harvest-lib/dist/components/MountPointContext'
+
+const makeQuerySpecForAccountTriggers = accountId => ({
+  query: () =>
+    Q('io.cozy.triggers').where({
+      'message.account': accountId
+    }),
+  as: `account/${accountId}/triggers`
+})
+
+const HarvestSpinner = () => {
+  return (
+    <div className="u-m-2 u-ta-center">
+      <Spinner size="xxlarge" />
+    </div>
+  )
+}
+
+const HarvestLoader = ({ accountId, children }) => {
+  return (
+    <Query query={Q('io.cozy.accounts').getById(accountId)}>
+      {({ data: account, fetchStatus }) => {
+        if (fetchStatus === 'loading') {
+          return <HarvestSpinner />
+        } else {
+          const konnectorSlug = account.account_type
+          return (
+            <Query query={Q('io.cozy.konnectors').getById(konnectorSlug)}>
+              {({ data: { attributes: konnector }, fetchStatus }) => {
+                if (fetchStatus === 'loading') {
+                  return <HarvestSpinner />
+                }
+                const triggerQuery = makeQuerySpecForAccountTriggers(accountId)
+                return (
+                  <Query query={triggerQuery.query} as={triggerQuery.as}>
+                    {({ data: triggers }) => {
+                      if (fetchStatus === 'loading') {
+                        return <HarvestSpinner />
+                      } else {
+                        const accountsAndTriggers = [account]
+                          .map(account => ({
+                            account,
+                            trigger: triggers[0]
+                          }))
+                          .filter(x => x.trigger)
+                        return children({
+                          triggers,
+                          konnector,
+                          accountsAndTriggers
+                        })
+                      }
+                    }}
+                  </Query>
+                )
+              }}
+            </Query>
+          )
+        }
+      }}
+    </Query>
+  )
+}
+
+/**
+ * Shows a modal displaying the AccountModal from Harvest
+ * Fetches all the data necessary through HarvestLoader
+ */
+const HarvestBankAccountSettings = ({ bankAccount, onDismiss }) => {
+  const accountId = bankAccount.relationships.connection._id
+  return (
+    <Modal mobileFullscreen size="large" dismissAction={onDismiss}>
+      <HarvestLoader accountId={accountId}>
+        {({ triggers, konnector, accountsAndTriggers }) => {
+          if (!accountsAndTriggers.length) {
+            return null
+          }
+          return (
+            <MountPointContext.Provider value={{}}>
+              <AccountModal
+                accountId={accountId}
+                konnector={konnector}
+                triggers={triggers}
+                accountsAndTriggers={accountsAndTriggers}
+              />
+            </MountPointContext.Provider>
+          )
+        }}
+      </HarvestLoader>
+    </Modal>
+  )
+}
+
+export default HarvestBankAccountSettings

--- a/src/ducks/settings/HarvestSwitch.jsx
+++ b/src/ducks/settings/HarvestSwitch.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { MountPointContext } from 'cozy-harvest-lib/dist/components/MountPointContext'
+
+// Extracted from Backbone
+const optionalParam = /\((.*?)\)/g
+const namedParam = /(\(\?)?:\w+/g
+const splatParam = /\*\w+/g
+
+// eslint-disable-next-line no-useless-escape
+const escapeRegExp = /[\-{}\[\]+?.,\\\^$|#\s]/g
+
+/**
+ * Transforms a route containing params (eg: /accounts/:id) into
+ * a regex that can be used to match a fragment
+ *
+ * Extracted from Backbone
+ */
+export const routeToRegExp = function(route) {
+  route = route
+    .replace(escapeRegExp, '\\$&')
+    .replace(optionalParam, '(?:$1)?')
+    .replace(namedParam, function(match, optional) {
+      return optional ? match : '([^/?]+)'
+    })
+    .replace(splatParam, '([^?]*?)')
+  return new RegExp('^' + route + '(?:\\?([\\s\\S]*))?$')
+}
+
+/**
+ * Given a generic route with params and a fragment, will
+ * extract the params from the fragment as an array
+ */
+export const extractParameters = function(route, fragment) {
+  var params = route.exec(fragment).slice(1)
+  return params.map(function(param, i) {
+    if (i === params.length - 1) return param || null
+    return param ? decodeURIComponent(param) : null
+  })
+}
+
+/**
+ * Simili Switch, this component is here to facilitate the usage of Harvest
+ * routes inside Banks. It should be removed when we update to react-router@5.
+ *
+ * Since Banks does not have react-router@5, we cannot use directly the Routes
+ * from cozy-harvest-lib. To circumvent this problem, we rely on the fact that
+ * Harvest components use a context provided pushHistory to navigate between
+ * different parts of Harvest. This pushHistory is provided via the context,
+ * which lets us override it with our own function, which stores the current
+ * fragment inside the Switch state. The Switch then has its own logic to
+ * match the current state fragment which its routes passed via props.
+ *
+ * It extracts the params from the fragment and passes it to the second
+ * parameter of props.routes item, which is a render function which gets
+ * passed the params.
+ */
+class Switch extends React.Component {
+  constructor(props, context) {
+    super(props, context)
+
+    // Transform routes into regexes
+    this.routes = props.routes.map(([route, render]) => {
+      return [routeToRegExp(route), render]
+    })
+    this.state = {
+      fragment: props.initialFragment
+    }
+
+    this.pushHistory = this.pushHistory.bind(this)
+    this.mountPointContext = { pushHistory: this.pushHistory }
+  }
+
+  pushHistory(fragment) {
+    this.setState({ fragment })
+  }
+
+  render() {
+    const { fragment } = this.state
+
+    for (let [route, render] of this.routes) {
+      if (fragment.match(route)) {
+        const params = extractParameters(route, fragment)
+        const el = render(...params)
+        return (
+          <MountPointContext.Provider value={this.mountPointContext}>
+            {el}
+          </MountPointContext.Provider>
+        )
+      }
+    }
+    return <div>No match for {fragment}</div>
+  }
+}
+
+Switch.propTypes = {
+  routes: PropTypes.array.isRequired
+}
+
+export default Switch

--- a/src/ducks/settings/HarvestSwitch.spec.jsx
+++ b/src/ducks/settings/HarvestSwitch.spec.jsx
@@ -1,0 +1,15 @@
+import { routeToRegExp, extractParameters } from './HarvestSwitch'
+
+describe('helpers', () => {
+  it('should work', () => {
+    const route = '/accounts/:accountId/edit'
+    const fragment = '/accounts/deadbeef/edit'
+    const rx = routeToRegExp(route)
+    expect(Array.from(rx.exec(fragment))).toEqual([
+      '/accounts/deadbeef/edit',
+      'deadbeef',
+      undefined
+    ])
+    expect(extractParameters(rx, fragment)).toEqual(['deadbeef', null])
+  })
+})

--- a/src/ducks/settings/OldAccountSettings.jsx
+++ b/src/ducks/settings/OldAccountSettings.jsx
@@ -24,13 +24,6 @@ import { Contact } from 'cozy-doctypes'
 import { accountsConn, APP_DOCTYPE } from 'doctypes'
 import { Row, Cell } from 'components/Table'
 
-// See comment below about sharings
-// import { ACCOUNT_DOCTYPE } from 'doctypes'
-// import { fetchSharingInfo } from 'modules/SharingStatus'
-// import fetchData from 'components/fetchData'
-
-// TODO react-router v4
-
 const AccountOwners = ({ account }) => {
   const owners = getAccountOwners(account)
   return owners.length > 0 ? (
@@ -148,16 +141,6 @@ const OldAccountSettings = props => {
     </div>
   )
 }
-
-// TODO reactivate when we understand how sharings work
-// const fetchAccountsSharingInfo = props => {
-//   return Promise.resolve([])
-// const { accounts } = props
-// with cozy-client
-// return Promise.all(accounts.data.map(account => {
-//   return props.dispatch(fetchSharingInfo(ACCOUNT_DOCTYPE, account._id))
-// }))
-// }
 
 export default queryConnect({
   accountsCollection: accountsConn,

--- a/src/ducks/settings/OldAccountSettings.jsx
+++ b/src/ducks/settings/OldAccountSettings.jsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import { withRouter } from 'react-router'
+import { groupBy, sortBy } from 'lodash'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Button'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { queryConnect, Q } from 'cozy-client'
+
+import Table from 'components/Table'
+import Loading from 'components/Loading'
+import plus from 'assets/icons/16/plus.svg'
+import styles from 'ducks/settings/AccountsSettings.styl'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
+import {
+  getAccountInstitutionLabel,
+  getAccountType,
+  getAccountOwners
+} from 'ducks/account/helpers'
+import { isCollectionLoading, hasBeenLoaded } from 'ducks/client/utils'
+import { Contact } from 'cozy-doctypes'
+
+import { accountsConn, APP_DOCTYPE } from 'doctypes'
+import { Row, Cell } from 'components/Table'
+
+// See comment below about sharings
+// import { ACCOUNT_DOCTYPE } from 'doctypes'
+// import { fetchSharingInfo } from 'modules/SharingStatus'
+// import fetchData from 'components/fetchData'
+
+// TODO react-router v4
+
+const AccountOwners = ({ account }) => {
+  const owners = getAccountOwners(account)
+  return owners.length > 0 ? (
+    <>
+      <div className="u-ph-half">-</div>
+      <div>{owners.map(Contact.getDisplayName).join(' - ')}</div>
+    </>
+  ) : null
+}
+
+const _AccountLine = ({ account, router }) => {
+  const { t } = useI18n()
+  const { isMobile } = useBreakpoints()
+  return (
+    <Row
+      nav
+      key={account.id}
+      onClick={() => router.push(`/settings/accounts/${account.id}`)}
+    >
+      <Cell main className={styles.AcnsStg__libelle}>
+        <div className={styles.AcnsStg__libelleInner}>
+          <div>{account.shortLabel || account.label}</div>
+          {isMobile ? <AccountOwners account={account} /> : null}
+        </div>
+      </Cell>
+      <Cell className={styles.AcnsStg__bank}>
+        {getAccountInstitutionLabel(account)}
+      </Cell>
+      <Cell className={styles.AcnsStg__number}>{account.number}</Cell>
+      <Cell className={styles.AcnsStg__type}>
+        {t(`Data.accountTypes.${getAccountType(account)}`, {
+          _: t('Data.accountTypes.Other')
+        })}
+      </Cell>
+      <Cell className={styles.AcnsStg__owner}>
+        {getAccountOwners(account)
+          .map(Contact.getDisplayName)
+          .join(' - ')}
+      </Cell>
+      <Cell className={styles.AcnsStg__actions} />
+    </Row>
+  )
+}
+
+const AccountLine = withRouter(_AccountLine)
+
+const AccountsTable = ({ accounts }) => {
+  const { t } = useI18n()
+
+  return (
+    <Table className={styles.AcnsStg__accounts}>
+      <thead>
+        <tr>
+          <th className={styles.AcnsStg__libelle}>{t('Accounts.label')}</th>
+          <th className={styles.AcnsStg__bank}>{t('Accounts.bank')}</th>
+          <th className={styles.AcnsStg__number}>{t('Accounts.account')}</th>
+          <th className={styles.AcnsStg__type}>{t('Accounts.type')}</th>
+          <th className={styles.AcnsStg__owner}>{t('Accounts.owner')}</th>
+          <th className={styles.AcnsStg__actions} />
+        </tr>
+      </thead>
+      <tbody>
+        {accounts.map(account => (
+          <AccountLine account={account} key={account._id} />
+        ))}
+      </tbody>
+    </Table>
+  )
+}
+
+const OldAccountSettings = props => {
+  const { t } = useI18n()
+  const { accountsCollection } = props
+
+  if (
+    isCollectionLoading(accountsCollection) &&
+    !hasBeenLoaded(accountsCollection)
+  ) {
+    return <Loading />
+  }
+
+  const sortedAccounts = sortBy(accountsCollection.data, [
+    'institutionLabel',
+    'label'
+  ])
+  const accountBySharingDirection = groupBy(sortedAccounts, account => {
+    return account.shared === undefined
+  })
+
+  const myAccounts = accountBySharingDirection[true]
+  const sharedAccounts = accountBySharingDirection[false]
+
+  return (
+    <div>
+      <AddAccountLink>
+        <Button
+          theme="text"
+          icon={<Icon icon={plus} className="u-mr-half" />}
+          label={t('Accounts.add_bank')}
+        />
+      </AddAccountLink>
+      {myAccounts ? (
+        <AccountsTable accounts={myAccounts} t={t} />
+      ) : (
+        <p>{t('Accounts.no-accounts')}</p>
+      )}
+
+      <h4>{t('Accounts.shared-accounts')}</h4>
+
+      {sharedAccounts ? (
+        <AccountsTable accounts={sharedAccounts} t={t} />
+      ) : (
+        <p>{t('Accounts.no-shared-accounts')}</p>
+      )}
+    </div>
+  )
+}
+
+// TODO reactivate when we understand how sharings work
+// const fetchAccountsSharingInfo = props => {
+//   return Promise.resolve([])
+// const { accounts } = props
+// with cozy-client
+// return Promise.all(accounts.data.map(account => {
+//   return props.dispatch(fetchSharingInfo(ACCOUNT_DOCTYPE, account._id))
+// }))
+// }
+
+export default queryConnect({
+  accountsCollection: accountsConn,
+  apps: { query: () => Q(APP_DOCTYPE), as: 'apps' }
+})(OldAccountSettings)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,10 @@ cozy-flags@^2.3.3:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.3.1.tgz#08775ec85b2e9742a741d127e4e2b0223e068e59"
-  integrity sha512-GmPsrk1rnblmqogfyfIB094JXXYYJTjCbUkgERJVie3yoP6gU7FdQMNKH4iHjc8d8NXrq1RlbJbObCBKyb5Yaw==
+cozy-harvest-lib@2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.5.0.tgz#931440b803cc08268a69970fec2caaa0ff5af2f3"
+  integrity sha512-fv0rfTnn20zDEXwzncuoz4rEXDRjQ7EE4XcobWIgK773K4DWHHJ3ji7CRTUvEKZMbdVtLD8NdziFuOI6sqlZhw==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,10 @@ cozy-flags@^2.3.3:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.0.0.tgz#720b9d20407f25c84c98a7ded7822994660932bf"
-  integrity sha512-oGwcHzMMPxG0+2Wn+vYkaCm/IQfqt2rVrSVN/aRcNIsVoQqG556mK4qfL4GWzl1mhQMKekUTRgbN/TULTSv6+w==
+cozy-harvest-lib@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.3.1.tgz#08775ec85b2e9742a741d127e4e2b0223e068e59"
+  integrity sha512-GmPsrk1rnblmqogfyfIB094JXXYYJTjCbUkgERJVie3yoP6gU7FdQMNKH4iHjc8d8NXrq1RlbJbObCBKyb5Yaw==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5346,6 +5346,11 @@ cozy-interapp@0.5.0:
   resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.0.tgz#3df26e5b7a43fa05ad6d73722d186999894dfa16"
   integrity sha512-Srkee6Tf0WYjEQeoj2kYvfZAet0N3T5PEYSgyYzjxHCmkZ+/UJ+iOTf9H9zzovEIsYblRKfS6z1RpXqJ4BGuJQ==
 
+cozy-interapp@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/cozy-interapp/-/cozy-interapp-0.5.4.tgz#2573f1800f073c84c289267d04234954d88eae0c"
+  integrity sha512-f0UaKpBkRUnIKgAWND0e1IwfTTINjizlgDmfQwX3aMyWp8t9wX0xkNFn53TSyKUoBUnfovrclS3hm9fngjEp7A==
+
 cozy-jobs-cli@1.9.13:
   version "1.9.13"
   resolved "https://registry.yarnpkg.com/cozy-jobs-cli/-/cozy-jobs-cli-1.9.13.tgz#4a269ac8138bce6fe85aeaa57be78b4af8b31e9a"
@@ -5635,15 +5640,16 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@35.37.0:
-  version "35.37.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.37.0.tgz#5172d9f863b8e087b666e536c0e48a80cdf20767"
-  integrity sha512-YIJP+z+mOFc0InF8McntRifdYqY6LcarPLqV9aNCBl3ts/sGnneAkRRR/3bEkPaRzEUd/bIpGGEH5MXhV3DoAQ==
+cozy-ui@35.40.2:
+  version "35.40.2"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.40.2.tgz#58866f9a8307e373f74ad09fc2700fbe227860b5"
+  integrity sha512-kNlz1FsgYsp67Kvxo5od62wgE/Wy9MQ5tuiH2e3WSpDa4kHl/+mNXM3/lDys+LQi4hKYZePRfQiZcW/M6Vc/yg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"
     body-scroll-lock "^2.5.8"
     classnames "^2.2.5"
+    cozy-interapp "0.5.4"
     date-fns "^1.28.5"
     hammerjs "^2.0.8"
     intersection-observer "0.11.0"
@@ -12561,13 +12567,6 @@ mini-html-webpack-plugin@^0.2.3:
 minilog@3.1.0, minilog@^3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
-  dependencies:
-    microee "0.0.6"
-
-"minilog@git+https://github.com/cozy/minilog.git#master":
-  version "3.1.0"
-  uid f01f7d9dfe20981177dd34b9662c2f077d818f82
-  resolved "git+https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
   dependencies:
     microee "0.0.6"
 


### PR DESCRIPTION
AccountSettings now use Harvest to edit an account.

- This functionality is behind the flag "banks.harvest-accounts-settings"
- Since banks is on react-router@3, we cannot use directly the routes from
  Harvest and we have to simulate a Switch on our end.