### PR TITLE
fix: Refresh the DisconnectedAccountModal when an account is deleted 

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.2.5",
-    "cozy-harvest-lib": "2.5.0",
+    "cozy-harvest-lib": "2.6.1",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "cozy-realtime": "3.9.0",
     "cozy-scripts": "4.1.0",
     "cozy-stack-client": "13.16.0",
-    "cozy-ui": "35.40.2",
+    "cozy-ui": "35.42.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/settings/AccountsSettings.spec.jsx
+++ b/src/ducks/settings/AccountsSettings.spec.jsx
@@ -1,0 +1,134 @@
+import React from 'react'
+import { createMockClient } from 'cozy-client/dist/mock'
+import { render, fireEvent, act } from '@testing-library/react'
+import AccountsSettings from './AccountsSettings'
+import {
+  accountsConn,
+  schema,
+  ACCOUNT_DOCTYPE as BANK_ACCOUNT_DOCTYPE
+} from 'doctypes'
+import AppLike from 'test/AppLike'
+import { receiveMutationResult } from 'cozy-client/dist/store'
+
+const mockBankAccounts = [
+  {
+    _id: 'my-bank-account1',
+    shortLabel: 'My bank account 1',
+    institutionName: 'My bank',
+    relationships: {
+      connection: {
+        data: { _id: 'connection-1', doctype: 'io.cozy.accounts' }
+      }
+    }
+  },
+  {
+    _id: 'my-bank-account2',
+    shortLabel: 'My bank account 2',
+    institutionLabel: 'My bank',
+    relationships: {
+      connection: {
+        data: { _id: 'connection-1', doctype: 'io.cozy.accounts' }
+      }
+    }
+  },
+  {
+    _id: 'my-bank-account3',
+    shortLabel: 'My bank account 3',
+    institutionLabel: 'My other bank',
+    relationships: {
+      connection: {
+        data: { _id: 'connection-2', doctype: 'io.cozy.accounts' }
+      }
+    }
+  }
+]
+
+describe('AccountsSettings', () => {
+  let originalWarn
+  beforeEach(() => {
+    // eslint-disable-next-line no-console
+    originalWarn = console.warn
+    // eslint-disable-next-line no-console
+    console.warn = function(msg) {
+      if (
+        // Ignore this warning as it is expected, since we have a
+        // io.cozy.bank.accounts that has a relationship to a "deleted"
+        // io.cozy.accounts.
+        msg.includes(
+          'getDocumentFromSlice: io.cozy.accounts:connection-2 is absent'
+        )
+      ) {
+        return
+      } else {
+        originalWarn.apply(this, arguments)
+      }
+    }
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line no-console
+    console.warn = originalWarn
+  })
+
+  const setup = () => {
+    const client = new createMockClient({
+      clientOptions: {
+        schema: schema
+      },
+      queries: {
+        connections: {
+          doctype: 'io.cozy.accounts',
+          data: [
+            {
+              _id: 'connection-1',
+              auth: { identifier: 'mylogin' }
+            }
+          ]
+        },
+        [accountsConn.as]: {
+          doctype: BANK_ACCOUNT_DOCTYPE,
+          ...accountsConn,
+          lastUpdate: new Date(),
+          data: mockBankAccounts
+        }
+      }
+    })
+    client.intents = {
+      getRedirectionURL: () => ''
+    }
+
+    const root = render(
+      <AppLike client={client}>
+        <AccountsSettings />
+      </AppLike>
+    )
+
+    return { client, root }
+  }
+
+  it('should display an edition modal on click', async () => {
+    const { root, client } = setup()
+    const myLoginLine = root.getByText('My other bank')
+    fireEvent.click(myLoginLine)
+    expect(() => root.getByText('My Bank Account 3')).not.toThrow()
+    const bankAccount3 = mockBankAccounts.find(
+      x => x.shortLabel === 'My bank account 3'
+    )
+
+    act(() => {
+      client.store.dispatch(
+        receiveMutationResult(accountsConn.as, {
+          data: [
+            {
+              ...bankAccount3,
+              id: bankAccount3._type,
+              _type: BANK_ACCOUNT_DOCTYPE,
+              _deleted: true
+            }
+          ]
+        })
+      )
+    })
+    expect(() => root.getByText('No contracts anymore')).not.toThrow()
+  })
+})

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -133,6 +133,7 @@ const HarvestBankAccountSettings = ({ connectionId, onDismiss }) => {
                         onDismiss()
                       }}
                       showAccountSelection={false}
+                      showNewAccountButton={false}
                     />
                   )
                 }}

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -112,8 +112,14 @@ const HarvestLoader = ({ connectionId, children }) => {
  * Shows a modal displaying the AccountModal from Harvest
  */
 const HarvestBankAccountSettings = ({ connectionId, onDismiss }) => {
+  const { t } = useI18n()
   return (
-    <Modal mobileFullscreen size="large" dismissAction={onDismiss}>
+    <Modal
+      aria-label={t('Harvest.modal-title')}
+      mobileFullscreen
+      size="large"
+      dismissAction={onDismiss}
+    >
       <HarvestSwitch
         initialFragment={`/accounts/${connectionId}`}
         routes={[

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -885,5 +885,8 @@
         "yearly": "every year"
     },
     "freq-info": "every %{frequency} days"
+  },
+  "Harvest": {
+    "modal-title": "Configure accounts"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -896,5 +896,8 @@
       "yearly": "tous les ans"
     },
     "freq-info": "tous les %{frequency} jours"
+  },
+  "Harvest": {
+    "modal-title": "Configurer les comptes"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5312,10 +5312,10 @@ cozy-flags@^2.3.3:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.5.0.tgz#931440b803cc08268a69970fec2caaa0ff5af2f3"
-  integrity sha512-fv0rfTnn20zDEXwzncuoz4rEXDRjQ7EE4XcobWIgK773K4DWHHJ3ji7CRTUvEKZMbdVtLD8NdziFuOI6sqlZhw==
+cozy-harvest-lib@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.6.1.tgz#36299aab0184099db1be9dc630d8df35d454b041"
+  integrity sha512-2PpeK9nhRYtqZRS1CJnU+uc7nK16i7rRKjs23mV4BR4hPxRK+7aPDsp1KKw5EGuHGpiCQutLk2DKhdkatzg9wQ==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@material-ui/core" "3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5640,10 +5640,10 @@ cozy-ui@35.22.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@35.40.2:
-  version "35.40.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.40.2.tgz#58866f9a8307e373f74ad09fc2700fbe227860b5"
-  integrity sha512-kNlz1FsgYsp67Kvxo5od62wgE/Wy9MQ5tuiH2e3WSpDa4kHl/+mNXM3/lDys+LQi4hKYZePRfQiZcW/M6Vc/yg==
+cozy-ui@35.42.0:
+  version "35.42.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-35.42.0.tgz#753250f9d5b805c8d9e317272303f4c762441e62"
+  integrity sha512-YHV7p+gke0pfPPawwUeJPpf/mZmoXbhslNt6Qn9xZMDpAhVaCVvQ15s9/GHxkFl/32lJYQjTCsDut6c39wrDHQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
Previously, the bank accounts objects, in case they were disconnected
from their io.cozy.accounts (when the io.cozy.accounts has been
deleted by the user), would be stored in the state. Storing them in
the state prevented them to be updated in the DisconnectedAccountModal
when one was deleted.

Here we store only the connectionId in the state, and we get the accounts
by filtering them (on their connectionId) from the accounts coming
from the store. This ensures we do not show a stale UI.

...and other small commits.