### PR TITLE
feat: Rely on the bar from the stack

### DIFF
--- a/src/utils/cozyBar.js
+++ b/src/utils/cozyBar.js
@@ -1,3 +1,5 @@
-import cozyBar from 'cozy-bar/dist/cozy-bar'
+/* global cozy */
+
+const cozyBar = cozy.bar
 
 export default cozyBar

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -68,3 +68,11 @@ if (process.env.TRAVIS_CI) {
     'console.error should not be called during tests'
   )
 }
+
+window.cozy = {
+  bar: {
+    BarLeft: () => null,
+    BarCenter: () => null,
+    BarRight: () => null
+  }
+}


### PR DESCRIPTION
For a time, banks needed a new version of the bar and we had relied
on the bar from the node_modules. This is different from the other
apps and we need now to revert this. Having the bar served from
the stack has several advantages:

- It diminishes the build size of the app
- It allows apps to cache the bar
- Every app uses the same bar