### PR TITLE
fix: Recurrence ActionMenu are rendered correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "cozy-notifications": "0.5.0",
     "cozy-pouch-link": "14.1.3",
     "cozy-realtime": "3.9.0",
-    "cozy-scripts": "5.0.0",
+    "cozy-scripts": "5.0.1",
     "cozy-stack-client": "14.1.2",
     "cozy-ui": "36.3.1",
     "d3": "5.11.0",

--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -18,6 +18,7 @@ import { Media, Img, Bd } from 'cozy-ui/transpiled/react/Media'
 import { SubTitle, Caption } from 'cozy-ui/transpiled/react/Text'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Empty from 'cozy-ui/transpiled/react/Empty'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import Breadcrumbs from 'cozy-ui/transpiled/react/Breadcrumbs'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -67,6 +68,10 @@ const useDocument = (doctype, id) => {
 const identity = x => x
 const portal = children => ReactDOM.createPortal(children, document.body)
 
+// Need to reset line-height to 1 for action menus to be correctly rendered
+// inside Img element
+const imgLineHeightStyle = { lineHeight: 1 }
+
 const RecurrenceActionMenu = ({
   recurrence,
   onClickRename,
@@ -78,20 +83,25 @@ const RecurrenceActionMenu = ({
   const { isMobile } = useBreakpoints()
   const wrapper = isMobile ? portal : identity
   return wrapper(
-    <ActionMenu {...props}>
-      <RenameActionItem onClick={onClickRename} />
-      <DeleteActionItem onClick={onClickDelete} />
-      {isMobile ? (
-        <>
-          <hr />
-          <OngoingActionItem recurrence={recurrence} onClick={onClickOngoing} />
-          <FinishedActionItem
-            recurrence={recurrence}
-            onClick={onClickFinished}
-          />
-        </>
-      ) : null}
-    </ActionMenu>
+    <CozyTheme variant="normal">
+      <ActionMenu {...props}>
+        <RenameActionItem onClick={onClickRename} />
+        <DeleteActionItem onClick={onClickDelete} />
+        {isMobile ? (
+          <>
+            <hr />
+            <OngoingActionItem
+              recurrence={recurrence}
+              onClick={onClickOngoing}
+            />
+            <FinishedActionItem
+              recurrence={recurrence}
+              onClick={onClickFinished}
+            />
+          </>
+        ) : null}
+      </ActionMenu>
+    </CozyTheme>
   )
 }
 
@@ -148,10 +158,12 @@ const RecurrenceStatusMenu = ({
   ...props
 }) => {
   return (
-    <ActionMenu {...props}>
-      <OngoingActionItem recurrence={recurrence} onClick={onClickOngoing} />
-      <FinishedActionItem recurrence={recurrence} onClick={onClickFinished} />
-    </ActionMenu>
+    <CozyTheme variant="normal">
+      <ActionMenu {...props}>
+        <OngoingActionItem recurrence={recurrence} onClick={onClickOngoing} />
+        <FinishedActionItem recurrence={recurrence} onClick={onClickFinished} />
+      </ActionMenu>
+    </CozyTheme>
   )
 }
 
@@ -290,7 +302,7 @@ const BundleInfo = withRouter(({ bundle, router }) => {
                   <BackButton theme="primary" />
                 </SubTitle>
               </Bd>
-              <Img className="u-flex">
+              <Img className="u-flex" style={imgLineHeightStyle}>
                 <ActionMenuHelper
                   opener={
                     <Button extension="narrow" theme="secondary">

--- a/yarn.lock
+++ b/yarn.lock
@@ -3029,10 +3029,10 @@ babel-preset-cozy-app@1.7.0:
     browserslist-config-cozy "^0.3.0"
     lodash "4.17.15"
 
-babel-preset-cozy-app@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/babel-preset-cozy-app/-/babel-preset-cozy-app-1.9.1.tgz#a190df4702feaaea5560eafa2e506d5816024f2a"
-  integrity sha512-zi2NCe1WSWrC0fKU9C9MTiY0XGXQ9EdEZqK3rLTk7mr8M2hRWjWEUwH2HyOMd0ZkL25c29YSUpmYJXk7xBIIWw==
+babel-preset-cozy-app@1.9.2:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/babel-preset-cozy-app/-/babel-preset-cozy-app-1.9.2.tgz#eb072c931828b2cacf84fd8dac57f345b5b608d8"
+  integrity sha512-fNECVqgGUjj/O0jbH25EqoWAeXRN+4voVZecG794BqmXYejvW0dPIIzLtMlsIDXR/YAYVWefF6faJegRI1xSTQ==
   dependencies:
     "@babel/core" "7.2.2"
     "@babel/helper-plugin-utils" "7.0.0"
@@ -5427,10 +5427,10 @@ cozy-realtime@3.9.0:
     cozy-device-helper "^1.9.2"
     minilog "https://github.com/cozy/minilog.git#master"
 
-cozy-scripts@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-5.0.0.tgz#70f8041ea69d774717eb3ee7b33945dd8ce4c14b"
-  integrity sha512-bpmjCE6MrzXOgjUnqOHUfTKk5r/uIh70xxbwZuXdHxmrjbbkWgJ+kZSK9ChAmU+HBpQb5/xFg0UA8TvWSQjLXw==
+cozy-scripts@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-5.0.1.tgz#f0efca8b39618c9b8cb33a19c893b5aa347e04e5"
+  integrity sha512-9bqibwsYPs2DWEc1NwQspcrrMa/NK2zbur2YYDgAiAZ96VrpGaszf8tRMSDWa3+DWtPnWR7OoKR61GueeEA9UA==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"
@@ -5439,7 +5439,7 @@ cozy-scripts@5.0.0:
     babel-eslint "10.1.0"
     babel-jest "24.9.0"
     babel-loader "8.1.0"
-    babel-preset-cozy-app "^1.9.0"
+    babel-preset-cozy-app "1.9.2"
     chalk "3"
     commander "2.19.0"
     copy-webpack-plugin "4.6.0"


### PR DESCRIPTION
Following an update of cozy-ui, ActionMenu were rendered incorrectly

- Need to reset the CozyTheme when rendering an ActionMenu inside
  a CozyTheme otherwise the text is white inside the ActionMenu
- Need to reset the line-height otherwise text is cut inside ActionMenu
  items