### PR TITLE
fix: Show konnector icons

### DIFF
--- a/src/components/AccountIcon/index.jsx
+++ b/src/components/AccountIcon/index.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import KonnectorIcon from 'ducks/balance/KonnectorIcon'
+import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 import { getAccountInstitutionSlug } from 'ducks/account/helpers'
 import styles from './styles.styl'
 import cx from 'classnames'
@@ -25,7 +25,7 @@ const _AccountIcon = ({ account, className, size }) => {
   }
   return (
     <AccountIconContainer size={size}>
-      <KonnectorIcon slug={institutionSlug} className={className} />
+      <KonnectorIcon konnectorSlug={institutionSlug} className={className} />
     </AccountIconContainer>
   )
 }

--- a/src/ducks/balance/AccountRowLoading.jsx
+++ b/src/ducks/balance/AccountRowLoading.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { flowRight as compose } from 'lodash'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import { translate } from 'cozy-ui/transpiled/react'
-import KonnectorIcon from 'ducks/balance/KonnectorIcon'
+import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 import styles from 'ducks/balance/AccountRow.styl'
 import stylesLoading from 'ducks/balance/AccountRowLoading.styl'
 import cx from 'classnames'
@@ -19,7 +19,7 @@ export class AccountRowLoading extends React.PureComponent {
   }
 
   render() {
-    const { t, konnector, status } = this.props
+    const { t, konnectorSlug, status } = this.props
     const isErrored = status === 'errored'
     const liProps = isErrored ? { onClick: () => this.redirect() } : {}
     return (
@@ -31,9 +31,9 @@ export class AccountRowLoading extends React.PureComponent {
       >
         <div className={styles.AccountRow__column}>
           <div className={styles.AccountRow__logo}>
-            {konnector && (
+            {konnectorSlug && (
               <KonnectorIcon
-                slug={konnector}
+                konnectorSlug={konnectorSlug}
                 className={styles.KonnectorIcon}
               />
             )}
@@ -75,7 +75,7 @@ export class AccountRowLoading extends React.PureComponent {
 
 AccountRowLoading.propTypes = {
   t: PropTypes.func.isRequired,
-  konnector: PropTypes.string.isRequired,
+  konnectorSlug: PropTypes.string.isRequired,
   account: PropTypes.string,
   status: PropTypes.string.isRequired
 }

--- a/src/ducks/balance/AccountsList.jsx
+++ b/src/ducks/balance/AccountsList.jsx
@@ -47,7 +47,7 @@ export const DumbAccountsList = props => {
           // When loading, a._id is the slug of the connector and can be non-unique, this is why we concat the index
           <AccountRowLoading
             key={i + '_' + a._id}
-            konnector={a._id}
+            konnectorSlug={a._id}
             account={a.account}
             status={a.status}
           />

--- a/src/ducks/balance/KonnectorIcon.jsx
+++ b/src/ducks/balance/KonnectorIcon.jsx
@@ -1,3 +1,0 @@
-import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
-
-export default KonnectorIcon

--- a/src/ducks/recurrence/search.spec.js
+++ b/src/ducks/recurrence/search.spec.js
@@ -57,7 +57,9 @@ describe('recurrence bundles', () => {
 
     updatedRecurrences.forEach(assertValidRecurrence)
     // eslint-disable
-    expect(sortBy(updatedRecurrences.map(formatRecurrence)).join('\n')).toMatchSnapshot()
+    expect(
+      sortBy(updatedRecurrences.map(formatRecurrence)).join('\n')
+    ).toMatchSnapshot()
   })
 
   it('should update existing bundles', () => {
@@ -69,7 +71,9 @@ describe('recurrence bundles', () => {
     )
     const recurrences = findAndUpdateRecurrences([], transactions)
 
-    expect(sortBy(recurrences.map(formatRecurrence)).join('\n')).toMatchSnapshot()
+    expect(
+      sortBy(recurrences.map(formatRecurrence)).join('\n')
+    ).toMatchSnapshot()
 
     const updatedRecurrences = findAndUpdateRecurrences(
       recurrences,
@@ -78,6 +82,8 @@ describe('recurrence bundles', () => {
 
     updatedRecurrences.forEach(assertValidRecurrence)
 
-    expect(sortBy(updatedRecurrences.map(formatRecurrence)).join('\n')).toMatchSnapshot()
+    expect(
+      sortBy(updatedRecurrences.map(formatRecurrence)).join('\n')
+    ).toMatchSnapshot()
   })
 })

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -28,7 +28,7 @@ import plus from 'assets/icons/16/plus.svg'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
 import HarvestBankAccountSettings from 'ducks/settings/HarvestBankAccountSettings'
 import { getAccountInstitutionLabel } from 'ducks/account/helpers'
-import KonnectorIcon from 'ducks/balance/KonnectorIcon'
+import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 
 import { accountsConn, APP_DOCTYPE } from 'doctypes'
 import { AccountIconContainer } from 'components/AccountIcon'


### PR DESCRIPTION
KonnectorIcon from banks was replaced by KonnectorIcon from Harvest
but the API differed a bit, preventing the icons from being shown.

I am merging as soon as this is green.