### PR TITLE
Fix recurrence bundle page loading

### DIFF
--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -390,7 +390,7 @@ const BundleTransactions = ({ bundle }) => {
     return <Loading />
   }
 
-  const transactions = transactionCol.data
+  const { data: transactions, fetchStatus, lastError } = transactionCol
 
   const TransactionRow = isMobile
     ? BundleTransactionMobile
@@ -402,11 +402,18 @@ const BundleTransactions = ({ bundle }) => {
       <Wrapper>
         {transactions.length === 0 ? (
           <Padded>
-            <Empty
-              icon={{}}
-              title={t('Recurrence.no-transactions.title')}
-              text={t('Recurrence.no-transactions.text')}
-            />
+            {fetchStatus === 'failed' ? (
+              <>
+                <p>{t('Loading.error')}</p>
+                <p>{lastError && lastError.message}</p>
+              </>
+            ) : (
+              <Empty
+                icon={{}}
+                title={t('Recurrence.no-transactions.title')}
+                text={t('Recurrence.no-transactions.text')}
+              />
+            )}
           </Padded>
         ) : null}
         {transactions.map(tr => (
@@ -421,7 +428,7 @@ const BundleTransactions = ({ bundle }) => {
   )
 }
 
-const RecurrenceBundlePage = ({ params }) => {
+const RecurrencePage = ({ params }) => {
   const recurrenceCol = useQuery(recurrenceConn.query, recurrenceConn)
 
   const bundleId = params.bundleId
@@ -440,4 +447,4 @@ const RecurrenceBundlePage = ({ params }) => {
   )
 }
 
-export default withRouter(RecurrenceBundlePage)
+export default withRouter(RecurrencePage)

--- a/src/ducks/recurrence/queries.js
+++ b/src/ducks/recurrence/queries.js
@@ -17,11 +17,15 @@ export const queryRecurrencesTransactions = recurrences =>
 
 export const bundleTransactionsQueryConn = ({ bundle }) => {
   return {
-    query: () =>
-      queryRecurrenceTransactions(bundle)
+    query: () => {
+      const initialQDef = queryRecurrenceTransactions(bundle)
+      const qDef = initialQDef
         .sortBy([{ date: 'desc' }])
+        .where({ ...initialQDef.selector, date: { $gt: null } })
         .UNSAFE_noLimit()
-        .include(['bills', 'account', 'reimbursements', 'recurrence']),
+        .include(['bills', 'account', 'reimbursements', 'recurrence'])
+      return qDef
+    },
     as: `bundle-transactions-${bundle._id}`,
     fetchPolicy: older30s
   }

--- a/src/ducks/recurrence/queries.js
+++ b/src/ducks/recurrence/queries.js
@@ -20,7 +20,11 @@ export const bundleTransactionsQueryConn = ({ bundle }) => {
     query: () => {
       const initialQDef = queryRecurrenceTransactions(bundle)
       const qDef = initialQDef
-        .sortBy([{ date: 'desc' }])
+        .sort([
+          { 'relationships.recurrence.data._id': 'desc' },
+          { date: 'desc' }
+        ])
+        .indexFields(['relationships.recurrence.data._id', 'date'])
         .where({ ...initialQDef.selector, date: { $gt: null } })
         .UNSAFE_noLimit()
         .include(['bills', 'account', 'reimbursements', 'recurrence'])


### PR DESCRIPTION
Without a "fake" selector, the index could not be inferred by PouchDB,
breaking the loading of the recurrence bundle data.

Since there was no check to see if the query loading was in "failed"
status, the "no data found" message was shown to the user.