### PR TITLE
refactor: Extract getTracker to be able to override it

### DIFF
--- a/src/ducks/tracking/browser.jsx
+++ b/src/ducks/tracking/browser.jsx
@@ -1,62 +1,7 @@
-/* global __PIWIK_TRACKER_URL__, __PIWIK_SITEID__ */
-
 import React, { useContext, createContext, useEffect } from 'react'
-import memoize from 'lodash/memoize'
+import { getTracker } from 'ducks/tracking/tracker'
 
-import flag from 'cozy-flags'
-import { getTracker as uiGetTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
-import Alerter from 'cozy-ui/transpiled/react/Alerter'
-
-const trackerShim = {
-  trackPage: () => {},
-  trackEvent: () => {},
-  push: () => {}
-}
-
-export const getMatomoTracker = memoize(() => {
-  const trackerInstance = uiGetTracker(
-    __PIWIK_TRACKER_URL__,
-    __PIWIK_SITEID__,
-    true, //
-    false
-  )
-
-  if (!trackerInstance) {
-    return trackerShim
-  }
-
-  trackerInstance.push([
-    'setTrackerUrl',
-    'https://matomo.cozycloud.cc/matomo.php'
-  ])
-  trackerInstance.push(['setSiteId', 8])
-
-  return {
-    trackEvent: event => {
-      const { name, action, category } = event
-      if (!name) {
-        throw new Error('An event must have at least a name')
-      }
-      if (flag('banks.show-tracking-alerts')) {
-        Alerter.info(`Tracking event: ${JSON.stringify(event)}`)
-      }
-      trackerInstance.push(['trackEvent', category, name, action])
-    },
-    trackPage: pagePath => {
-      const message = `Tracking page ${pagePath}`
-      if (flag('banks.show-tracking-alerts')) {
-        Alerter.info(message)
-      }
-      trackerInstance.push([
-        'setCustomUrl',
-        'https://cozy-banks/' + pagePath.replace(/:/g, '/')
-      ])
-      trackerInstance.push(['trackPageView'])
-    }
-  }
-})
-
-export const getTracker = getMatomoTracker
+export { getTracker }
 
 export const trackEvent = options => {
   const tracker = getTracker()

--- a/src/ducks/tracking/tracker.js
+++ b/src/ducks/tracking/tracker.js
@@ -1,0 +1,59 @@
+/* global __PIWIK_TRACKER_URL__, __PIWIK_SITEID__ */
+
+import memoize from 'lodash/memoize'
+
+import flag from 'cozy-flags'
+import { getTracker as uiGetTracker } from 'cozy-ui/transpiled/react/helpers/tracker'
+/* global __PIWIK_TRACKER_URL__, __PIWIK_SITEID__ */
+
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
+
+export const trackerShim = {
+  trackPage: () => {},
+  trackEvent: () => {}
+}
+
+export const getMatomoTracker = memoize(() => {
+  const trackerInstance = uiGetTracker(
+    __PIWIK_TRACKER_URL__,
+    __PIWIK_SITEID__,
+    true, //
+    false
+  )
+
+  if (!trackerInstance) {
+    return trackerShim
+  }
+
+  trackerInstance.push([
+    'setTrackerUrl',
+    'https://matomo.cozycloud.cc/matomo.php'
+  ])
+  trackerInstance.push(['setSiteId', 8])
+
+  return {
+    trackEvent: event => {
+      const { name, action, category } = event
+      if (!name) {
+        throw new Error('An event must have at least a name')
+      }
+      if (flag('banks.show-tracking-alerts')) {
+        Alerter.info(`Tracking event: ${JSON.stringify(event)}`)
+      }
+      trackerInstance.push(['trackEvent', category, name, action])
+    },
+    trackPage: pagePath => {
+      const message = `Tracking page ${pagePath}`
+      if (flag('banks.show-tracking-alerts')) {
+        Alerter.info(message)
+      }
+      trackerInstance.push([
+        'setCustomUrl',
+        'https://cozy-banks/' + pagePath.replace(/:/g, '/')
+      ])
+      trackerInstance.push(['trackPageView'])
+    }
+  }
+})
+
+export const getTracker = getMatomoTracker


### PR DESCRIPTION
To be able to override the getTracker, we need to extract this function from the browser.jsx otherwise functions inside browser.jsx that use getTracker would retain a reference to the original getTracker function.