### PR TITLE
fix: Add namespace for tracking event

### DIFF
--- a/src/ducks/settings/BalanceLowerRules.jsx
+++ b/src/ducks/settings/BalanceLowerRules.jsx
@@ -31,5 +31,5 @@ export default makeRuleComponent({
   getNewRule: () => ({ ...newBalanceLowerRule }),
   getRuleDescriptionKey: getBalanceLowerDescriptionKey,
   getRuleDescriptionProps: getBalanceLowerDescriptionProps,
-  trackPageName: 'alerte-solde_bas'
+  trackPageName: 'parametres:configuration:alerte-solde_bas'
 })

--- a/src/ducks/settings/DelayedDebitAlertRules.jsx
+++ b/src/ducks/settings/DelayedDebitAlertRules.jsx
@@ -80,7 +80,7 @@ const DelayedDebitRules = makeRuleComponent({
   getRuleDescriptionKey: () => 'Notifications.delayed_debit.description',
   getRuleDescriptionProps: getDescriptionProps,
   shouldOpenOnToggle: shouldOpenOnToggle,
-  trackPageName: 'alerte-paiement_differe'
+  trackPageName: 'parametres:configuration:alerte-paiement_differe'
 })
 
 const WaitForLoadingDelayedDebitRules = props => {

--- a/src/ducks/settings/TransactionGreaterRules.jsx
+++ b/src/ducks/settings/TransactionGreaterRules.jsx
@@ -33,5 +33,5 @@ export default makeRuleComponent({
   getNewRule: () => ({ ...newTransactionGreaterRule }),
   getRuleDescriptionKey: getTransactionGreaterDescriptionKey,
   getRuleDescriptionProps: getTransactionGreaterDescriptionProps,
-  trackPageName: 'alerte-mouvements'
+  trackPageName: 'parametres:configuration:alerte-mouvements'
 })


### PR DESCRIPTION
We need to add the namespace to tracking event.

```patch
- pfm:alerte-budget
+ pfm:parametres:configuration:alerte-budget
```