### PR TITLE
fix: Send notification if there has been a success after the last error

### DIFF
--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -86,8 +86,12 @@ const shouldNotify = async (client, trigger, previousStatesByTriggerId) => {
     return { ok: false, reason: 'no-previous-state' }
   }
 
+  // When the previous error is actionable, it's important to check if there
+  // was a succesful execution since the last failure, otherwise we must not
+  // send a notification.
   if (
     isErrorActionable(previousState.last_error) &&
+    trigger.current_state.last_failure > trigger.current_state.last_execution &&
     !flag('banks.konnector-alerts.ignore-previous-status')
   ) {
     return { ok: false, reason: 'previous-error-is-actionable' }


### PR DESCRIPTION
If there was a success after the last error, we must not take into account
the last error, and send a notification even if the last error was
actionnable.