### PR TITLE
fix: Only send the last part of the page name for events inside edition modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "2.19.1-beta.1",
+    "cozy-harvest-lib": "2.19.1-beta.2",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/src/ducks/settings/Rules.jsx
+++ b/src/ducks/settings/Rules.jsx
@@ -4,7 +4,7 @@ import { Stack, useI18n } from 'cozy-ui/transpiled/react'
 import AddRuleButton from 'ducks/settings/AddRuleButton'
 import useList from './useList'
 import { getRuleId, getNextRuleId } from './ruleUtils'
-import { trackEvent } from 'ducks/tracking/browser'
+import { trackEvent, getPageLastPart } from 'ducks/tracking/browser'
 
 export { AddRuleButton }
 
@@ -42,7 +42,7 @@ const Rules = ({
         setSaving(true)
         await createOrUpdate(newItem)
         trackEvent({
-          name: `${trackPageName}-creer_alerte`
+          name: `${getPageLastPart(trackPageName)}-creer_alerte`
         })
       } finally {
         setSaving(false)

--- a/src/ducks/settings/makeRuleComponent.jsx
+++ b/src/ducks/settings/makeRuleComponent.jsx
@@ -5,7 +5,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { makeEditionModalFromSpec } from 'components/EditionModal'
 import Rules from 'ducks/settings/Rules'
-import { trackEvent } from 'ducks/tracking/browser'
+import { trackEvent, getPageLastPart } from 'ducks/tracking/browser'
 import EditableSettingCard from './EditableSettingCard'
 import { ensureNewRuleFormat } from './ruleUtils'
 
@@ -57,7 +57,9 @@ const makeRuleComponent = ({
             onToggle={enabled => {
               createOrUpdateRule({ ...rule, enabled })
               trackEvent({
-                name: `${trackPageName}-${enabled ? 'on' : 'off'}`
+                name: `${getPageLastPart(trackPageName)}-${
+                  enabled ? 'on' : 'off'
+                }`
               })
             }}
             removeModalTitle={t('Settings.rules.remove-modal.title')}

--- a/src/ducks/tracking/browser.jsx
+++ b/src/ducks/tracking/browser.jsx
@@ -38,3 +38,7 @@ export const useTrackPage = pageName => {
     tracker.trackPage(pageName)
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 }
+export const getPageLastPart = pageName => {
+  const lastIndex = pageName.lastIndexOf(':')
+  return pageName.substring(lastIndex + 1)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4841,10 +4841,10 @@ cozy-flags@2.4.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.19.1-beta.1:
-  version "2.19.1-beta.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.19.1-beta.1.tgz#a523a1807dd5fbeddd22e73e91ece99134f2e2e7"
-  integrity sha512-9aM0jx7/HA1bbm88DW8al+rlwOX7FTlGgXVjOX2Cp4IDwHsog9L4ro+tdm4Zhv3f8u9r2llOI/mf2wNNOeOtSg==
+cozy-harvest-lib@2.19.1-beta.2:
+  version "2.19.1-beta.2"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.19.1-beta.2.tgz#3c19a89ab0b4a12d88f017f0fcb0056e737e1f2d"
+  integrity sha512-VLiRw0SnX+/6cpfhFjP9rAAx/97o/LBYsEJmN4EAoEayEM99mNIdJc9xCuwL/wFxzF11hv8h/50fMgwbrh80ig==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@cozy/minilog" "^1.0.0"


### PR DESCRIPTION
I was sending the complete page name (with parametres:configuration) instead
of only sending "alerte-solde_bas-on".