### PR TITLE
Improve tracking in modals

### DIFF
--- a/src/components/EditionModal/EditionModal.jsx
+++ b/src/components/EditionModal/EditionModal.jsx
@@ -22,7 +22,11 @@ import resultWithArgs from 'utils/resultWithArgs'
 import Confirmation from 'components/Confirmation'
 
 import { BackIcon } from 'components/BackButton'
-import { useTrackPage, useTracker } from 'ducks/tracking/browser'
+import {
+  useTrackPage,
+  useTracker,
+  trackParentPage
+} from 'ducks/tracking/browser'
 
 export const CHOOSING_TYPES = {
   category: 'category',
@@ -212,6 +216,18 @@ const EditionModal = props => {
 
   useTrackPage(trackPageName)
 
+  const handleDismiss = () => {
+    onDismiss()
+
+    // :/ We need to set a timeout otherwise we fire the track page too soon
+    // and one of the event (for example clicking on "Annuler") might be wrongly
+    // included in the parent page, this is why we delay a bit the hit to the
+    // parent page.
+    setTimeout(() => {
+      trackParentPage()
+    }, 100)
+  }
+
   const handleChoosingCancel = () => {
     setChoosing(null)
   }
@@ -245,7 +261,7 @@ const EditionModal = props => {
         </>
       }
       mobileFullscreen={true}
-      dismissAction={onDismiss}
+      dismissAction={handleDismiss}
       closable={!choosing}
       overflowHidden={true}
     >
@@ -269,7 +285,7 @@ const EditionModal = props => {
           canBeRemoved={canBeRemoved}
           doc={doc}
           onEdit={onEdit}
-          onDismiss={onDismiss}
+          onDismiss={handleDismiss}
           onRemove={onRemove}
           removeModalTitle={removeModalTitle}
           removeModalDescription={removeModalDescription}

--- a/src/components/ModalStack.jsx
+++ b/src/components/ModalStack.jsx
@@ -4,7 +4,7 @@
  * It is here temporarily, waiting for the PR to be merged
  */
 
-import React, { useState } from 'react'
+import React, { useState, useCallback } from 'react'
 import Modal from 'cozy-ui/transpiled/react/Modal'
 import { ViewStackContext } from 'cozy-ui/transpiled/react'
 import sleep from 'utils/sleep'
@@ -39,10 +39,15 @@ const useStack = (initialState, options = {}) => {
  * Wraps children on the stack with a modal. When pushing on the stack,
  * children can take options.
  */
-const ModalStack = ({ children }) => {
+const ModalStack = ({ children, onPop }) => {
   const [stChildren, , stackPush, stackPop] = useStack(
     React.Children.toArray(children)
   )
+
+  const handlePop = useCallback(() => {
+    onPop && onPop()
+    stackPop()
+  }, [onPop, stackPop])
 
   const contextValue = { stackPush, stackPop }
 
@@ -54,7 +59,7 @@ const ModalStack = ({ children }) => {
         const props = hasProps ? child[1] : null
         child = hasProps ? child[0] : child
         return (
-          <Modal mobileFullscreen key={i} dismissAction={stackPop} {...props}>
+          <Modal mobileFullscreen key={i} dismissAction={handlePop} {...props}>
             {child}
           </Modal>
         )

--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -57,6 +57,7 @@ import useToggle from 'components/useToggle'
 import ActionMenuHelper from 'components/ActionMenuHelper'
 
 import { useHistory, useParams } from 'components/RouterContext'
+import { useTrackPage } from 'ducks/tracking/browser'
 
 const useDocument = (doctype, id) => {
   const client = useClient()
@@ -436,6 +437,8 @@ const RecurrencePage = () => {
 
   const bundleId = params.bundleId
   const bundle = useDocument(RECURRENCE_DOCTYPE, bundleId)
+
+  useTrackPage('recurrences:details')
 
   if (isQueryLoading(recurrenceCol) && !hasQueryBeenLoaded(recurrenceCol)) {
     return <Loading />

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -26,6 +26,8 @@ import BackButton from 'components/BackButton'
 import PageTitle from 'components/Title/PageTitle'
 import Figure from 'cozy-ui/transpiled/react/Figure'
 
+import { useTrackPage } from 'ducks/tracking/browser'
+
 import frLocale from 'date-fns/locale/fr'
 import enLocale from 'date-fns/locale/en'
 import esLocale from 'date-fns/locale/es'
@@ -185,6 +187,8 @@ const RecurrencesPage = () => {
 
   const { t } = useI18n()
   const BundlesWrapper = isMobile ? BundleMobileWrapper : BundlesTable
+
+  useTrackPage('recurrences')
 
   return (
     <>

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -63,7 +63,7 @@ import TransactionModalRow, {
 } from 'ducks/transactions/TransactionModalRow'
 
 import withDocs from 'components/withDocs'
-import { useParams, useLocation } from 'components/RouterContext'
+import { useLocation } from 'components/RouterContext'
 
 const SearchForTransactionIcon = ({ transaction }) => {
   const label = getLabel(transaction)
@@ -113,7 +113,6 @@ const TransactionCategoryEditorSlide = ({ transaction }) => {
   const { t } = useI18n()
   const { stackPop } = useViewStack()
   const { isMobile } = useBreakpoints()
-  const { categoryName, subcategoryName } = useParams()
 
   const onAfterUpdate = transaction => {
     trackEvent({
@@ -121,11 +120,7 @@ const TransactionCategoryEditorSlide = ({ transaction }) => {
     })
   }
 
-  useTrackPage(
-    categoryName && subcategoryName
-      ? `analyse:${categoryName}:depense-categorie`
-      : `mon_compte:depense:categorie`
-  )
+  useTrackPage(lastTracked => `${lastTracked}:depense-categorie`)
 
   return (
     <>
@@ -152,13 +147,7 @@ const TransactionApplicationDateEditorSlide = ({
 }) => {
   const { t } = useI18n()
   const { stackPop } = useViewStack()
-  const { categoryName, subcategoryName } = useParams()
 
-  useTrackPage(
-    categoryName && subcategoryName
-      ? `analyse:${categoryName}:depense-affectation_mois`
-      : `mon_compte:depense:affectation_mois`
-  )
 
   const handleBeforeUpdate = () => {
     beforeUpdate()
@@ -241,6 +230,8 @@ const TransactionRecurrenceEditorSlide = ({ transaction }) => {
   const { t } = useI18n()
 
   const { stackPop } = useViewStack()
+  useTrackPage(lastTracked => `${lastTracked}:affectation_recurrence`)
+
 
   return (
     <div>
@@ -434,13 +425,8 @@ const TransactionModalInfo = props => {
 
 const TransactionModal = ({ requestClose, ...props }) => {
   const { t } = useI18n()
-  const { categoryName, subcategoryName } = useParams()
 
-  useTrackPage(
-    categoryName && subcategoryName
-      ? `analyse:${categoryName}:depense`
-      : `mon_compte:depense`
-  )
+  useTrackPage(lastTracked => `${lastTracked}:depense`)
 
   return (
     <PageModal


### PR DESCRIPTION
- For events to correctly be attributed to each page, when closing the modal, we need to send a hit to the parent page.
- The transaction modal cannot know from where it is opened so it needs to send a page name that depends on the previous page. To achieve this, a functional variant of trackPage is added.
- Also fixed a bug where the events in the alert edition modal were sent with the complete page name, when we want only the events to have the last part.