### PR TITLE
feat: Upgrade cozy-harvest-lib to get Orange Banks with new cozy-bi-auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "2.19.1-beta.2",
+    "cozy-harvest-lib": "2.22.0",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4615,10 +4615,10 @@ cozy-bar@7.16.0:
     redux-thunk "2.3.0"
     semver-compare "^1.0.0"
 
-cozy-bi-auth@0.0.13:
-  version "0.0.13"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.13.tgz#b7b7028dda7508e1ca4e6072614030976ed09a7a"
-  integrity sha512-vz6TcLtT00wzpw53x1NYzCds6hAKBDyTcZZ4Ef+vs10a5MpLIKbLX/iepOaRs39gy+hvcbJNEhXKRifUpt9Tyg==
+cozy-bi-auth@0.0.14:
+  version "0.0.14"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.14.tgz#e38c2bd3f6534dde0f86aa05ceca7f82b0fee74b"
+  integrity sha512-1IcC0Dbn/wtCsS6rKuXZfFFRq+vMw849b5RoKXHinLA5fBsfxPF+xOre0tT3tKY0Uc3QgKKmd4D+za6vg7Vj2A==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"
@@ -4841,16 +4841,16 @@ cozy-flags@2.4.0:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.19.1-beta.2:
-  version "2.19.1-beta.2"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.19.1-beta.2.tgz#3c19a89ab0b4a12d88f017f0fcb0056e737e1f2d"
-  integrity sha512-VLiRw0SnX+/6cpfhFjP9rAAx/97o/LBYsEJmN4EAoEayEM99mNIdJc9xCuwL/wFxzF11hv8h/50fMgwbrh80ig==
+cozy-harvest-lib@2.22.0:
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.22.0.tgz#627e34cc65fdf2eb518c13f6675ef7c7535670bc"
+  integrity sha512-iJyi4xM/mYA7NWQbBeTb7l5bUk++1BXwHP7Zk8voh4PNEpHbAD79dECA1gCPP3utsVje6honPgv7Pm//xYXjNw==
   dependencies:
     "@babel/runtime" "^7.5.2"
     "@cozy/minilog" "^1.0.0"
     "@material-ui/core" "3"
     "@testing-library/react" "^10.4.9"
-    cozy-bi-auth "0.0.13"
+    cozy-bi-auth "0.0.14"
     cozy-doctypes "^1.74.7"
     cozy-keys-lib "3.1.2"
     cozy-logger "1.6.0"


### PR DESCRIPTION
The new version of cozy-bi-auth embedded in this new version of cozy-harvest-libs contains BI information to be able to create Orange Bank connections from user browser.