### PR TITLE
Remove the fake triggers in the manifest

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -73,8 +73,7 @@
     "categorization": {
       "type": "node",
       "file": "categorization.js",
-      "comment": "This service must be called programmatically from konnectors, this is why the trigger is in the past. See https://github.com/cozy/cozy-banks/blob/master/docs/services.md for more information.",
-      "trigger": "@at 2000-01-01T00:00:00.000Z"
+      "comment": "This service must be called programmatically from konnectors, this is why the trigger is in the past. See https://github.com/cozy/cozy-banks/blob/master/docs/services.md for more information."
     },
     "stats": {
       "type": "node",
@@ -97,8 +96,7 @@
     "budgetAlerts": {
       "type": "node",
       "file": "budgetAlerts.js",
-      "comment": "Service is run inside onOperationOrBillCreate. This is why the trigger is in the past. The service described here is for diagnosis/debug.",
-      "trigger": "@at 2000-01-01T00:00:00.000Z"
+      "comment": "Service is run inside onOperationOrBillCreate. This is why the trigger is in the past. The service described here is for diagnosis/debug."
     },
     "linkMyselfToAccounts": {
       "type": "node",

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -96,7 +96,7 @@
     "budgetAlerts": {
       "type": "node",
       "file": "budgetAlerts.js",
-      "comment": "Service is run inside onOperationOrBillCreate. This is why the trigger is in the past. The service described here is for diagnosis/debug."
+      "comment": "Service is run inside onOperationOrBillCreate. The service described here is for diagnosis/debug."
     },
     "linkMyselfToAccounts": {
       "type": "node",

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -73,7 +73,7 @@
     "categorization": {
       "type": "node",
       "file": "categorization.js",
-      "comment": "This service must be called programmatically from konnectors, this is why the trigger is in the past. See https://github.com/cozy/cozy-banks/blob/master/docs/services.md for more information."
+      "comment": "This service must be called programmatically from konnectors. See https://github.com/cozy/cozy-banks/blob/master/docs/services.md for more information."
     },
     "stats": {
       "type": "node",


### PR DESCRIPTION
With a recent change in the stack^1, it is no longer mandatory to have
a trigger for each service. So, we can remove the triggers for services
that are called from other services in the manifest.

1: https://github.com/cozy/cozy-stack/pull/2672