### PR TITLE
Fix search via params

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cozy-realtime": "3.9.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "15.2.0",
-    "cozy-ui": "40.2.0",
+    "cozy-ui": "40.4.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -40,7 +40,7 @@ const isSearchSufficient = searchStr => searchStr.length > 2
 const SearchSuggestions = () => {
   const { t } = useI18n()
   return (
-    <Typography align="center" variant="body">
+    <Typography align="center" variant="body1">
       {t('Search.suggestions')}
     </Typography>
   )

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useEffect } from 'react'
 import { createSelector } from 'reselect'
 import { useSelector } from 'react-redux'
 import minBy from 'lodash/minBy'
@@ -144,6 +144,13 @@ const SearchPage = () => {
     setSearch(ev.target.value)
     performSearch(ev.target.value)
   }
+
+  // at mount time, perform a search if there is the search params
+  useEffect(() => {
+    if (params.search) {
+      performSearch(params.search)
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div>

--- a/src/ducks/search/SearchPage.spec.jsx
+++ b/src/ducks/search/SearchPage.spec.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import SearchPage from './SearchPage'
+import { render } from '@testing-library/react'
+import AppLike from 'test/AppLike'
+import fixtures from 'test/fixtures/demo'
+import { createMockClient } from 'cozy-client/dist/mock'
+import { TRANSACTION_DOCTYPE } from 'doctypes'
+import getClient from 'selectors/getClient'
+
+// Mock debounce since we need to run the search synchronously here
+// jest.useFakeTimers() does not work well with lodash/debounce
+jest.mock('lodash/debounce', () => fn => fn)
+
+jest.mock('components/BackButton', () => () => null)
+jest.mock('components/Bar', () => ({
+  BarLeft: ({ children }) => children,
+  BarCenter: ({ children }) => children,
+  BarRight: ({ children }) => children,
+  BarTheme: ({ children }) => children,
+  BarSearch: ({ children }) => children
+}))
+jest.mock('selectors/getClient', () => jest.fn())
+
+describe('SearchPage', () => {
+  const setup = ({ router: routerOption } = {}) => {
+    const defaultRouter = {
+      params: {}
+    }
+    const router = routerOption || defaultRouter
+    const client = createMockClient({
+      queries: {
+        transactions: {
+          doctype: TRANSACTION_DOCTYPE,
+          data: fixtures[TRANSACTION_DOCTYPE]
+        }
+      }
+    })
+
+    getClient.mockReturnValue(client)
+    const root = render(
+      <AppLike client={client} router={router}>
+        <SearchPage />
+      </AppLike>
+    )
+
+    return {
+      root
+    }
+  }
+
+  it('should show a page with advice on how to search', () => {
+    const { root } = setup()
+    expect(
+      root.getByText('Type something to search a transaction')
+    ).toBeTruthy()
+  })
+
+  it('should perform a search when there is a search param', () => {
+    const { root } = setup({
+      router: {
+        params: {
+          search: 'Martin'
+        }
+      }
+    })
+
+    expect(root.getByText('3 results')).toBeTruthy()
+    expect(root.getByText('Docteur Martoni')).toBeTruthy()
+  })
+})

--- a/src/services/cli.js
+++ b/src/services/cli.js
@@ -43,7 +43,7 @@ const main = async () => {
     uri: args.url,
     scope: getScope(manifest),
     oauth: {
-      softwareID: 'banks.recurrence-cli'
+      softwareID: 'banks.service-cli'
     }
   })
   const serviceEntrypoint = serviceEntrypoints[args.service]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5206,10 +5206,10 @@ cozy-ui@40.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@40.2.0:
-  version "40.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.2.0.tgz#b9192c580566eb6f42bb36788b25f5158567a059"
-  integrity sha512-S9Bvlvqm/YHhVzf/wrnPAOl2uzrL9B3BkRiXGdPORWvUeco5m9twxm4FrS4zD8QoEMdk3mX/h2yR3mRqkT3X9A==
+cozy-ui@40.4.0:
+  version "40.4.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-40.4.0.tgz#1b5f302bab116e6348f07c192deeeb27f2e8ca73"
+  integrity sha512-dinvj4BrPHKc36ade4R+EsOAOV1/FQNFbyWcZG7CYf1BgQSDY4bnKN0ehsMhJmy0JPESZAxqagNcCGdLyc8YVQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
When arriving on the search page via the search icon on the transaction
modal, we have to perform the search immediately at mount.