### PR TITLE
feat: Upgrade Android SDK

### DIFF
--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -19,7 +19,7 @@
         </host>
         <ios-team-id value="3AKXFMV43J" />
     </universal-links>
-    <preference name="android-targetSdkVersion" value="28" />
+    <preference name="android-targetSdkVersion" value="29" />
     <platform name="android">
         <config-file parent="/manifest/application" target="app/src/main/AndroidManifest.xml">
             <meta-data android:name="google_analytics_adid_collection_enabled" android:value="false" />


### PR DESCRIPTION
We need to target at least Android SDK 29 to publish new version.