### PR TITLE
Add legal mentions

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "^2.24.0",
+    "cozy-harvest-lib": "2.27.4",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -180,7 +180,7 @@ export const schema = {
   }
 }
 
-const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
+export const older30s = CozyClient.fetchPolicies.olderThan(30 * 1000)
 
 export const accountsConn = {
   query: () => Q(ACCOUNT_DOCTYPE).include(['owners', 'connection']),

--- a/src/ducks/balance/BalanceDetailsHeader.jsx
+++ b/src/ducks/balance/BalanceDetailsHeader.jsx
@@ -10,10 +10,17 @@ import BarBalance from 'components/BarBalance'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { BarRight } from 'components/Bar'
 import SearchIconLink from 'ducks/search/SearchIconLink'
+import LegalMention from 'ducks/legal/LegalMention'
 
 export const DumbBalanceDetailsHeader = props => {
   const { isMobile } = useBreakpoints()
-  const { accountSwitchSize, showBalance, filteredAccounts, children } = props
+  const {
+    accountSwitchSize,
+    showBalance,
+    filteredAccounts,
+    children,
+    legalMention
+  } = props
 
   return (
     <Header theme="inverted" fixed>
@@ -27,6 +34,9 @@ export const DumbBalanceDetailsHeader = props => {
           <BackButton theme="primary" arrow />
           <AccountSwitch size={accountSwitchSize} theme="inverted" />
         </div>
+        {legalMention !== false ? (
+          <LegalMention className={isMobile ? 'u-mr-1 u-mb-half' : ''} />
+        ) : null}
       </Padded>
       {isMobile && (
         <BarRight>

--- a/src/ducks/balance/BalanceDetailsHeader.jsx
+++ b/src/ducks/balance/BalanceDetailsHeader.jsx
@@ -19,7 +19,7 @@ export const DumbBalanceDetailsHeader = props => {
     showBalance,
     filteredAccounts,
     children,
-    legalMention
+    showLegalMention
   } = props
 
   return (
@@ -34,7 +34,7 @@ export const DumbBalanceDetailsHeader = props => {
           <BackButton theme="primary" arrow />
           <AccountSwitch size={accountSwitchSize} theme="inverted" />
         </div>
-        {legalMention !== false ? (
+        {showLegalMention !== false ? (
           <LegalMention className={isMobile ? 'u-mr-1 u-mb-half' : ''} />
         ) : null}
       </Padded>

--- a/src/ducks/balance/BalanceHeader.jsx
+++ b/src/ducks/balance/BalanceHeader.jsx
@@ -16,6 +16,7 @@ import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import { MobileBarSearchIconLink } from 'ducks/search/SearchIconLink'
 import styles from 'ducks/balance/BalanceHeader.styl'
+import LegalMention from 'ducks/legal/LegalMention'
 
 const BalanceHeader = ({
   accountsBalance,
@@ -57,6 +58,11 @@ const BalanceHeader = ({
         </Delayed>
       )}
       <KonnectorUpdateInfo />
+      {LegalMention.active ? (
+        <Padded>
+          <LegalMention />
+        </Padded>
+      ) : null}
     </Header>
   )
 }

--- a/src/ducks/legal/LegalMention.jsx
+++ b/src/ducks/legal/LegalMention.jsx
@@ -1,0 +1,16 @@
+import PropTypes from 'prop-types'
+
+/**
+ * This is a placeholder element that can be overrided.
+ * It is displayed in page headers to show which enterprise is
+ * responsible for retrieving the financial data of the user
+ */
+const LegalMention = () => {
+  return null
+}
+
+LegalMention.propTypes = {
+  className: PropTypes.string
+}
+
+export default LegalMention

--- a/src/ducks/legal/LegalMention.jsx
+++ b/src/ducks/legal/LegalMention.jsx
@@ -13,4 +13,11 @@ LegalMention.propTypes = {
   className: PropTypes.string
 }
 
+/**
+ * This static property is useful since we must be able to know for example
+ * if we need to render a wrapper around the LegalMention. When using LegalMention
+ * it has to be put to true
+ */
+LegalMention.active = false
+
 export default LegalMention

--- a/src/ducks/transactions/TransactionHeader.jsx
+++ b/src/ducks/transactions/TransactionHeader.jsx
@@ -7,8 +7,9 @@ import cx from 'classnames'
 import { BalanceDetailsHeader } from 'ducks/balance'
 import TransactionSelectDates from 'ducks/transactions/TransactionSelectDates'
 import { ConnectedHistoryChart as HistoryChart } from 'ducks/balance/HistoryChart'
-import Padded from 'components/Padded'
+import LegalMention from 'ducks/legal/LegalMention'
 
+import Padded from 'components/Padded'
 import withSize from 'components/withSize'
 import TableHead from './header/TableHead'
 import styles from './TransactionsHeader.styl'
@@ -64,7 +65,7 @@ const TransactionHeader = ({
 }) => {
   const { isMobile } = useBreakpoints()
   return (
-    <BalanceDetailsHeader showBalance={showBalance}>
+    <BalanceDetailsHeader showBalance={showBalance} legalMention={false}>
       <TransactionHeaderBalanceHistory
         currentMonth={currentMonth}
         size={size}
@@ -84,6 +85,7 @@ const TransactionHeader = ({
           handleChangeMonth={handleChangeMonth}
           currentMonth={currentMonth}
         />
+        <LegalMention className="u-mt-1" />
       </Padded>
       <CozyTheme variant="inverted">
         {transactions.length > 0 && <TableHead />}

--- a/src/ducks/transactions/TransactionsPage.styl
+++ b/src/ducks/transactions/TransactionsPage.styl
@@ -3,12 +3,3 @@
 
 .TransactionPage__transactions
     overflow scroll // Allows the container to shrink
-
-// HistoryChart has a different height if it's on small size or medium size
-// See TransactionHeader.jsx
-+medium-screen()
-    .TransactionPage__transactions
-       belowHeader(15rem)
-+small-screen()
-    .TransactionPage__transactions
-        belowHeader(7rem)

--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -41,6 +41,8 @@ import { isLoginFailed } from 'ducks/transfers/utils'
 import BarTheme from 'ducks/bar/BarTheme'
 import { PersonalInfoGate } from 'ducks/personal-info'
 import { trackPage } from 'ducks/tracking/browser'
+import LegalMention from 'ducks/legal/LegalMention'
+import Header from 'components/Header'
 
 const THIRTY_SECONDS = 30 * 1000
 
@@ -371,7 +373,12 @@ class TransferPage extends React.Component {
   }
 
   render() {
-    const { recipients, accounts, myself } = this.props
+    const {
+      recipients,
+      accounts,
+      myself,
+      breakpoints: { isMobile }
+    } = this.props
 
     const {
       category,
@@ -434,7 +441,11 @@ class TransferPage extends React.Component {
             )}
           </>
         ) : null}
-
+        <Header theme={isMobile ? 'inverted' : 'normal'}>
+          <Padded className="u-pv-half">
+            <LegalMention />
+          </Padded>
+        </Header>
         <Stepper currentIndex={this.state.slide} onBack={this.handleGoBack}>
           <ChooseRecipientCategory
             category={category}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -58,7 +58,7 @@ export const querySelector = (queryName, options = {}) => {
 }
 
 export const queryDataSelector = (queryName, options) =>
-  createSelector(
+  queryCreateSelector(
     [querySelector(queryName, options)],
     query => (query && query.data) || []
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,14 +894,6 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime-corejs3@^7.10.2":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
-  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
-  dependencies:
-    core-js-pure "^3.0.0"
-    regenerator-runtime "^0.13.4"
-
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz#26fe4aa77e9f1ecef9b776559bbb8e84d34284b7"
@@ -945,14 +937,14 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+"@babel/runtime@^7.10.0", "@babel/runtime@^7.5.4":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0", "@babel/runtime@^7.5.2":
+"@babel/runtime@^7.3.1", "@babel/runtime@^7.4.0":
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.3.tgz#935122c74c73d2240cafd32ddb5fc2a6cd35cf1f"
   integrity sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==
@@ -963,13 +955,6 @@
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
   integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.5.4":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
-  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1430,17 +1415,6 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@jest/types@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
-  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
 "@marionebl/sander@^0.6.0":
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/@marionebl/sander/-/sander-0.6.1.tgz#1958965874f24bc51be48875feb50d642fc41f7b"
@@ -1608,17 +1582,6 @@
     pretty-format "^24.9.0"
     wait-for-expect "^3.0.0"
 
-"@testing-library/dom@^7.22.3":
-  version "7.22.5"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.22.5.tgz#178fb0bfb52540538667f2f72d4b7fb406a49499"
-  integrity sha512-qALmosaNSny/JqQ+mDhdT0N5u1a76pEcOvfWFDpBQOchtkxDm/w/bCfe0J/K7nHrwJPHelFiAZksaBs//P9fsw==
-  dependencies:
-    "@babel/runtime" "^7.10.3"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    dom-accessibility-api "^0.5.1"
-    pretty-format "^26.4.2"
-
 "@testing-library/react-hooks@^3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.2.tgz#8deb94f7684e0d896edd84a4c90e5b79a0810bc2"
@@ -1626,14 +1589,6 @@
   dependencies:
     "@babel/runtime" "^7.5.4"
     "@types/testing-library__react-hooks" "^3.4.0"
-
-"@testing-library/react@^10.4.9":
-  version "10.4.9"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.4.9.tgz#9faa29c6a1a217bf8bbb96a28bd29d7a847ca150"
-  integrity sha512-pHZKkqUy0tmiD81afs8xfiuseXfU/N7rAX3iKjeZYje86t9VaB0LrxYVa+OOsvkrveX5jCK3IjajVn2MbePvqA==
-  dependencies:
-    "@babel/runtime" "^7.10.3"
-    "@testing-library/dom" "^7.22.3"
 
 "@testing-library/react@^9.4.0":
   version "9.4.0"
@@ -1643,11 +1598,6 @@
     "@babel/runtime" "^7.7.6"
     "@testing-library/dom" "^6.11.0"
     "@types/testing-library__react" "^9.1.2"
-
-"@types/aria-query@^4.2.0":
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
-  integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
 "@types/babel__core@^7.1.0":
   version "7.1.2"
@@ -1726,13 +1676,6 @@
   integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
-    "@types/istanbul-lib-report" "*"
-
-"@types/istanbul-reports@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-3.0.0.tgz#508b13aa344fa4976234e75dddcc34925737d821"
-  integrity sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
-  dependencies:
     "@types/istanbul-lib-report" "*"
 
 "@types/jss@^9.5.6":
@@ -1838,13 +1781,6 @@
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.2.tgz#a64674fc0149574ecd90ba746e932b5a5f7b3653"
   integrity sha512-lwwgizwk/bIIU+3ELORkyuOgDjCh7zuWDFqRtPPhhVgq9N1F7CvLNKg1TX4f2duwtKQ0p044Au9r1PLIXHrIzQ==
-  dependencies:
-    "@types/yargs-parser" "*"
-
-"@types/yargs@^15.0.0":
-  version "15.0.5"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
-  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -2239,11 +2175,6 @@ ansi-regex@^4.0.0, ansi-regex@^4.1.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-4.1.0.tgz#8b9f8f08cf1acb843756a839ca8c7e3168c51997"
   integrity sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
 
-ansi-regex@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
-  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
@@ -2256,7 +2187,7 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   dependencies:
     color-convert "^1.9.0"
 
-ansi-styles@^4.0.0, ansi-styles@^4.1.0:
+ansi-styles@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
   integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
@@ -2360,14 +2291,6 @@ aria-query@3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
-
-aria-query@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
-  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
-  dependencies:
-    "@babel/runtime" "^7.10.2"
-    "@babel/runtime-corejs3" "^7.10.2"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -3629,14 +3552,6 @@ chalk@3:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
-  integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
-
 change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
@@ -4669,10 +4584,10 @@ cozy-bar@^8.1.1-beta.1:
     redux-thunk "2.3.0"
     semver-compare "^1.0.0"
 
-cozy-bi-auth@0.0.14:
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.14.tgz#e38c2bd3f6534dde0f86aa05ceca7f82b0fee74b"
-  integrity sha512-1IcC0Dbn/wtCsS6rKuXZfFFRq+vMw849b5RoKXHinLA5fBsfxPF+xOre0tT3tKY0Uc3QgKKmd4D+za6vg7Vj2A==
+cozy-bi-auth@0.0.15:
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.15.tgz#c3d450b1d4c5b053101888f6d139d5a1ef806a27"
+  integrity sha512-qZAYjUoyQFhqKiVph6k/P3d/GQMR+K6pQr4bqhzdGoDhrBjMZYvho6doQpyKYZpWiJCjHXaX4aJDOtfC5Qwinw==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"
@@ -4883,12 +4798,11 @@ cozy-doctypes@^1.63.2:
     lodash "4.17.15"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.74.8:
-  version "1.74.8"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.74.8.tgz#82a7bc40771ff1181f0b772e509e88b65cda04dd"
-  integrity sha512-3BNy+ivSWOu4TQz9EHYF+DQhlZLAE/HNJekg6cUCflD5lAQUrRqT2IfYydlebgVswrSlDodbI8f+KC5eXBfSOw==
+cozy-doctypes@^1.75.0:
+  version "1.75.0"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.75.0.tgz#04aa524293e5877caa73c2ce44aa687c5561cda9"
+  integrity sha512-Liw6ztj64eRsDeIKnOLi4CARgplwjqL/RNaL4XSBEYd6KE5cewxwO3eTxFEatbxVY7ljwr8hFB4ljBinrJGw1g==
   dependencies:
-    "@babel/runtime" "7.5.5"
     cozy-logger "^1.6.0"
     date-fns "1.30.1"
     es6-promise-pool "2.5.0"
@@ -4909,26 +4823,24 @@ cozy-flags@2.4.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.24.0.tgz#4b5d0836ca482434a0f8f536b6d192dab9ad6686"
-  integrity sha512-y8PkMBr+tf8MWcd7ib2aSxwjVLd/ubBkTEoGXDf4+WWM2hfgBfGdtqF8pH1aGbuFZq18rlLaqFQxoDVH+c+w+Q==
+cozy-harvest-lib@2.27.4:
+  version "2.27.4"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.27.4.tgz#d02bd25949a88b0e098dfe59f10d121e69839c9a"
+  integrity sha512-1NbUj2ecruYG0SPQ4aOBYKCUTu2UZ8mWBTYZphYyybePCVYb+Wy7UNzJnX8zROsvSawT+17VlVGyfzR3DFHS3g==
   dependencies:
-    "@babel/runtime" "^7.5.2"
     "@cozy/minilog" "^1.0.0"
     "@material-ui/core" "3"
-    "@testing-library/react" "^10.4.9"
-    cozy-bi-auth "0.0.14"
-    cozy-doctypes "^1.74.8"
-    cozy-keys-lib "3.1.2"
-    cozy-logger "1.6.0"
+    cozy-bi-auth "0.0.15"
+    cozy-doctypes "^1.75.0"
+    cozy-keys-lib "^3.1.2"
+    cozy-logger "^1.6.0"
     date-fns "^1.30.1"
-    final-form "4.18.5"
-    lodash "4.17.19"
+    final-form "^4.18.5"
+    lodash "^4.17.19"
     microee "^0.0.6"
     node-polyglot "^2.4.0"
-    react-final-form "3.7.0"
-    react-markdown "4.2.2"
+    react-final-form "^3.7.0"
+    react-markdown "^4.2.2"
     react-router-dom "^5.0.1"
     uuid "^3.3.2"
 
@@ -4966,7 +4878,7 @@ cozy-jobs-cli@1.9.13:
     replay "2.4.0"
     strip-json-comments "3.0.1"
 
-cozy-keys-lib@3.1.2:
+cozy-keys-lib@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/cozy-keys-lib/-/cozy-keys-lib-3.1.2.tgz#524b4360d8e6008c3f234aeb9bd9730f1d2276fc"
   integrity sha512-AgCO7otBoUvNs5lYWZquXm/YItM3Go+WseeFx99e6KuYs4219cSlEjzNyHgIGythfXRiBlQjWVuZaK4t/yvaPQ==
@@ -6305,11 +6217,6 @@ doctrine@^3.0.0:
   dependencies:
     esutils "^2.0.2"
 
-dom-accessibility-api@^0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.1.tgz#152f5e88583d900977119223e3e76c2d93d23830"
-  integrity sha512-8DhtmKTYWXNpPiL/QOszbnkAbCGuPz9ieVwDrmWM1rNx4KRI3zqmvKANAD1PJdvvov3+eq1BPLXQkYTpqTrWng==
-
 dom-converter@^0.2:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -7533,12 +7440,12 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-final-form@4.18.5:
-  version "4.18.5"
-  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.18.5.tgz#e359cfaf2892ef135d92fcf22e06b475dda3a885"
-  integrity sha512-DH/I2W7fWxU8J8ZsbYJ5jLvUbhbatCvLhIKlsU17MvY6W3QnetPEyuX5mcxXgIGFNFKxfvqsG3pDy/1/VwOiTw==
+final-form@^4.18.5:
+  version "4.20.1"
+  resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.20.1.tgz#525a7f7f27f55c28d8994b157b24d6104fc560e9"
+  integrity sha512-IIsOK3JRxJrN72OBj7vFWZxtGt3xc1bYwJVPchjVWmDol9DlzMSAOPB+vwe75TUYsw1JaH0fTQnIgwSQZQ9Acg==
   dependencies:
-    "@babel/runtime" "^7.3.1"
+    "@babel/runtime" "^7.10.0"
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -11252,7 +11159,7 @@ lodash@^3.3.1, lodash@^3.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
-lodash@^4.17.20:
+lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
@@ -11817,6 +11724,12 @@ mini-html-webpack-plugin@^0.2.3:
 minilog@3.1.0, minilog@^3.1.0, "minilog@https://github.com/cozy/minilog.git#master":
   version "3.1.0"
   resolved "https://github.com/cozy/minilog.git#f01f7d9dfe20981177dd34b9662c2f077d818f82"
+  dependencies:
+    microee "0.0.6"
+
+"minilog@git+https://github.com/cozy/minilog.git#master":
+  version "3.1.0"
+  resolved "git+https://github.com/cozy/minilog.git#6da0aa58759c4f1a1a7e0fd093dbe2a67c035c55"
   dependencies:
     microee "0.0.6"
 
@@ -14686,16 +14599,6 @@ pretty-format@^24.8.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
-pretty-format@^26.4.2:
-  version "26.4.2"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.4.2.tgz#d081d032b398e801e2012af2df1214ef75a81237"
-  integrity sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==
-  dependencies:
-    "@jest/types" "^26.3.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
 pretty-ms@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-4.0.0.tgz#31baf41b94fd02227098aaa03bd62608eb0d6e92"
@@ -15220,7 +15123,7 @@ react-fast-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
   integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
 
-react-final-form@3.7.0:
+react-final-form@^3.7.0:
   version "3.7.0"
   resolved "https://registry.yarnpkg.com/react-final-form/-/react-final-form-3.7.0.tgz#89196cc18340d0bcdb308941ea3e5dafe0f26684"
   integrity sha512-/FAn1z7i2RFCMC1Bxg9CLA4rKelom6NF8at7PZgOp23T1e45giJQs9hTvuHx5LlX0u6948k0XbYw3y3zBmPOgw==
@@ -15314,6 +15217,20 @@ react-markdown@^4.0.8:
     html-to-react "^1.3.4"
     mdast-add-list-metadata "1.0.1"
     prop-types "^15.7.2"
+    remark-parse "^5.0.0"
+    unified "^6.1.5"
+    unist-util-visit "^1.3.0"
+    xtend "^4.0.1"
+
+react-markdown@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-4.3.1.tgz#39f0633b94a027445b86c9811142d05381300f2f"
+  integrity sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==
+  dependencies:
+    html-to-react "^1.3.4"
+    mdast-add-list-metadata "1.0.1"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
     remark-parse "^5.0.0"
     unified "^6.1.5"
     unist-util-visit "^1.3.0"


### PR DESCRIPTION
Add a placeholder component that can be overrided to show a legal mention.

- Balance page
- Transactions Page
- Transfer page

I had a problem with the transactions header since adding the legal mention
would modify the header height. Since the header is fixed, the list beneath
it has a padding-top for its content to end up lower than the header. Thus,
the padding-top and the header height should be the same. It was previously
done manually in CSS. Unfortunately, I could not override the stylus file:
there were build errors due to MiniCSSExtractPlugin. An alternative solution
was to compute dynamically the height in JS and set the padding-top accordingly.