### PR TITLE
chore: Upgrade cozy-harvest-lib to enable some new banking connectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "1.9.2",
     "cozy-doctypes": "1.69.0",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "2.27.5",
+    "cozy-harvest-lib": "2.28.0",
     "cozy-interapp": "0.5.0",
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4584,10 +4584,10 @@ cozy-bar@8.1.1:
     redux-thunk "2.3.0"
     semver-compare "^1.0.0"
 
-cozy-bi-auth@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.15.tgz#c3d450b1d4c5b053101888f6d139d5a1ef806a27"
-  integrity sha512-qZAYjUoyQFhqKiVph6k/P3d/GQMR+K6pQr4bqhzdGoDhrBjMZYvho6doQpyKYZpWiJCjHXaX4aJDOtfC5Qwinw==
+cozy-bi-auth@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.16.tgz#82ac022b3a7a76aa9cce28cc2827e79a4c35a671"
+  integrity sha512-XC9hkmND7YA/qFLy8KTTqZMhRFNWsuU5ys2st3ZuvB+EXqAferMamWlfgPl6ogIDpt8zr4ldqf9U3dX2S79GKg==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"
@@ -4823,14 +4823,14 @@ cozy-flags@2.4.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@2.27.5:
-  version "2.27.5"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.27.5.tgz#bdd8fd5119d48356e63c575442596fa70d6ee39e"
-  integrity sha512-eR823JpDqXdSMu1bEGKu83jnQMO459dBNcKZIwgKyFX1tkPEVVXEhlhE5ZInj60caHBxe6GTV4WPTGl6uKmqsg==
+cozy-harvest-lib@2.28.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-2.28.0.tgz#aea3df9e8e5b7dc4ae46abebc460b727b26f6085"
+  integrity sha512-lSI9A1E+Ww9CFgdgO6XL4UDRQlSX4Gn8+XemGBovAjfrbNKvUpNgMm0/VGQhyqUrQxgsGtPdewtE15AmvKJ0qw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@material-ui/core" "3"
-    cozy-bi-auth "0.0.15"
+    cozy-bi-auth "0.0.16"
     cozy-doctypes "^1.75.0"
     cozy-keys-lib "^3.1.2"
     cozy-logger "^1.6.0"


### PR DESCRIPTION
As commit described.
Upgrade cozy-harvest-lib.