### PR TITLE
fix: Display neatly some empty pages

### DIFF
--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -4,7 +4,7 @@ import cx from 'classnames'
 import { translate, withBreakpoints } from 'cozy-ui/transpiled/react'
 import Text, { Caption } from 'cozy-ui/transpiled/react/Text'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
-import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
+import { Bd, Img, Media } from 'cozy-ui/transpiled/react/Media'
 import CategoryIcon from 'ducks/categories/CategoryIcon'
 import { Table, TdSecondary } from 'components/Table'
 import Figure from 'cozy-ui/transpiled/react/Figure'
@@ -12,7 +12,6 @@ import styles from 'ducks/categories/styles.styl'
 import compose from 'lodash/flowRight'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import PercentageLine from 'components/PercentageLine'
-import Padded from 'components/Padded'
 
 const stAmount = styles['bnk-table-amount']
 const stCategory = styles['bnk-table-category-category']
@@ -30,7 +29,7 @@ class Categories extends Component {
   }
 
   render() {
-    const { t, categories: categoriesProps, selectedCategory } = this.props
+    const { categories: categoriesProps, selectedCategory } = this.props
     let categories = categoriesProps || []
     if (selectedCategory) {
       categories = [selectedCategory]
@@ -40,11 +39,6 @@ class Categories extends Component {
 
     return (
       <>
-        {!hasData && (
-          <Padded>
-            <p>{t('Categories.title.empty_text')}</p>
-          </Padded>
-        )}
         {hasData && (
           <Table className={stTableCategory}>
             <tbody>

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -29,6 +29,7 @@ import { themed } from 'components/useTheme'
 import Table from 'components/Table'
 import { useParams } from 'components/RouterContext'
 import LegalMention from 'ducks/legal/LegalMention'
+import Empty from 'cozy-ui/transpiled/react/Empty'
 
 const Breadcrumb = themed(RawBreadcrumb)
 
@@ -176,6 +177,16 @@ const CategoriesHeader = props => {
             theme={isMobile ? 'normal' : 'inverted'}
           >
             <LegalMention className="u-mt-2 u-pt-1 u-mr-1" />
+
+            {!hasData && (
+              <div className={styles.NoAccount_empty}>
+                <Empty
+                  icon="cozy"
+                  title=""
+                  text={t('Categories.title.empty_text')}
+                />
+              </div>
+            )}
             {incomeToggle || chart ? (
               <Padded className="u-pt-0">
                 {incomeToggle}

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -45,6 +45,12 @@
     bottom 3.5rem
     left calc(50% - 93px)
 
+.NoAccount_empty
+    position: relative
+    transform: translateZ(0)
+    height: 140px
+    display: flex
+
 .CategoriesHeader__Toggle
     > span
         margin-right 1em

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -45,6 +45,7 @@
     bottom 3.5rem
     left calc(50% - 93px)
 
+// Styling can be removed when PR #1642 has been merged
 .NoAccount_empty
     position: relative
     transform: translateZ(0)

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -184,7 +184,7 @@ class CategoriesPage extends Component {
           categories={sortedCategories}
           isFetching={isFetching}
           hasAccount={hasAccount}
-          chart={isSubcategory ? false : true}
+          chart={!isSubcategory}
         />
         {hasAccount &&
           (isFetching ? (

--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -7,6 +7,7 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
 import Figure from 'cozy-ui/transpiled/react/Figure'
 import Card from 'cozy-ui/transpiled/react/Card'
+import Empty from 'cozy-ui/transpiled/react/Empty'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
 import BarTheme from 'ducks/bar/BarTheme'
@@ -131,7 +132,11 @@ const PlannedTransactionsPage = () => {
               />
             ) : null}
             {budget.transactions && budget.transactions.length === 0 ? (
-              <Padded>{t('EstimatedBudget.no-planned-transactions')}</Padded>
+              <Empty
+                icon="cozy"
+                title=""
+                text={t('EstimatedBudget.no-planned-transactions')}
+              />
             ) : null}
           </>
         )}

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -236,7 +236,7 @@ const RecurrencesPage = () => {
         <Padded>
           <LegalMention className="u-mt-3" style={{ marginBottom: '-3rem' }} />
           <Empty
-            icon={{}}
+            icon="cozy"
             title={t('Recurrence.no-recurrences.title')}
             text={t('Recurrence.no-recurrences.text')}
           />


### PR DESCRIPTION
- Display neatly the follow pages: Reccurences, Categorization and PlannedTransaction
- Simplify simple condition