### PR TITLE
Fix clicks

### DIFF
--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -376,21 +376,23 @@ const AccountSwitch = props => {
         select
       )}
       {open && (
-        <RawContentDialog
-          open={true}
-          onClose={handleClose}
-          title={t('AccountSwitch.title')}
-          content={
-            <AccountSwitchMenu
-              filteringDoc={filteringDoc}
-              filterByDoc={closeAfterSelect(filterByDoc)}
-              resetFilterByDoc={closeAfterSelect(resetFilterByDoc)}
-              close={handleClose}
-              groups={orderedGroups}
-              accounts={accounts}
-            />
-          }
-        />
+        <CozyTheme variant="normal">
+          <RawContentDialog
+            open={true}
+            onClose={handleClose}
+            title={t('AccountSwitch.title')}
+            content={
+              <AccountSwitchMenu
+                filteringDoc={filteringDoc}
+                filterByDoc={closeAfterSelect(filterByDoc)}
+                resetFilterByDoc={closeAfterSelect(resetFilterByDoc)}
+                close={handleClose}
+                groups={orderedGroups}
+                accounts={accounts}
+              />
+            }
+          />
+        </CozyTheme>
       )}
     </AccountSwitchWrapper>
   )

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -320,8 +320,21 @@ const AccountSwitch = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
 
-  const handleToggle = useCallback(() => setOpen(open => !open), [setOpen])
-  const handleClose = useCallback(() => setOpen(false), [setOpen])
+  const handleToggle = useCallback(
+    ev => {
+      ev.preventDefault()
+      setOpen(open => !open)
+    },
+    [setOpen]
+  )
+
+  const handleClose = useCallback(
+    ev => {
+      ev.preventDefault()
+      setOpen(false)
+    },
+    [setOpen]
+  )
 
   const accounts = accountsCollection.data
   const groups = [...groupsCollection.data, ...virtualGroups].map(group => ({

--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -466,16 +466,20 @@ const TransactionModal = ({ requestClose, transactionId, ...props }) => {
     }
   })
 
-  const handleClose = useCallback(() => {
-    if (location.pathname.startsWith('/balances/details')) {
-      trackPage('mon_compte:compte')
-    } else if (location.pathname.startsWith('/analysis/categories')) {
-      trackPage(lastTracked => replaceLastPart(lastTracked, 'details'))
-    } else {
-      trackParentPage()
-    }
-    requestClose()
-  }, [location, requestClose])
+  const handleClose = useCallback(
+    ev => {
+      if (location.pathname.startsWith('/balances/details')) {
+        trackPage('mon_compte:compte')
+      } else if (location.pathname.startsWith('/analysis/categories')) {
+        trackPage(lastTracked => replaceLastPart(lastTracked, 'details'))
+      } else {
+        trackParentPage()
+      }
+      ev.preventDefault()
+      requestClose()
+    },
+    [location, requestClose]
+  )
 
   return (
     <RawContentDialog

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 import { Media, Bd, Img, Icon, useI18n } from 'cozy-ui/transpiled/react'
@@ -204,8 +204,16 @@ export const RowMobile = React.memo(function RowMobile(props) {
   const { transaction, filteringOnAccount, onRef, showRecurrence } = props
   const account = transaction.account.data
   const rowRest = {}
-  const [showTransactionModal, , transactionModal] = useTransactionModal(
+  const [rawShowTransactionModal, , transactionModal] = useTransactionModal(
     transaction
+  )
+
+  const showTransactionModal = useCallback(
+    ev => {
+      ev.preventDefault()
+      rawShowTransactionModal()
+    },
+    [rawShowTransactionModal]
   )
 
   if (flag('show-transactions-ids')) {

--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -218,57 +218,61 @@ export const RowMobile = React.memo(function RowMobile(props) {
   const recurrence = transaction.recurrence ? transaction.recurrence.data : null
 
   return (
-    <List.Row onRef={onRef} {...rowRest}>
-      <Media className="u-w-100">
-        <Img
-          className="u-clickable u-mr-half"
-          title={t(
-            `Data.subcategories.${getCategoryName(getCategoryId(transaction))}`
-          )}
-          onClick={showTransactionModal}
-        >
-          <CategoryIcon categoryId={getCategoryId(transaction)} />
-        </Img>
-        <Bd className="u-clickable u-mr-half">
-          <List.Content onClick={showTransactionModal}>
-            <Typography className="u-ellipsis" variant="body1">
-              {getLabel(transaction)}
-            </Typography>
-            {!filteringOnAccount && <AccountCaption account={account} />}
-            {applicationDate ? (
-              <ApplicationDateCaption transaction={transaction} />
+    <>
+      <List.Row onRef={onRef} {...rowRest}>
+        <Media className="u-w-100">
+          <Img
+            className="u-clickable u-mr-half"
+            title={t(
+              `Data.subcategories.${getCategoryName(
+                getCategoryId(transaction)
+              )}`
+            )}
+            onClick={showTransactionModal}
+          >
+            <CategoryIcon categoryId={getCategoryId(transaction)} />
+          </Img>
+          <Bd className="u-clickable u-mr-half">
+            <List.Content onClick={showTransactionModal}>
+              <Typography className="u-ellipsis" variant="body1">
+                {getLabel(transaction)}
+              </Typography>
+              {!filteringOnAccount && <AccountCaption account={account} />}
+              {applicationDate ? (
+                <ApplicationDateCaption transaction={transaction} />
+              ) : null}
+            </List.Content>
+          </Bd>
+          <Img
+            onClick={showTransactionModal}
+            className={styles.TransactionRowMobileImg}
+          >
+            <Figure
+              total={transaction.amount}
+              symbol={getCurrencySymbol(transaction.currency)}
+              coloredPositive
+              signed
+            />
+            {recurrence && showRecurrence ? (
+              <RecurrenceCaption recurrence={recurrence} />
             ) : null}
-          </List.Content>
-        </Bd>
-        <Img
-          onClick={showTransactionModal}
-          className={styles.TransactionRowMobileImg}
-        >
-          <Figure
-            total={transaction.amount}
-            symbol={getCurrencySymbol(transaction.currency)}
-            coloredPositive
-            signed
-          />
-          {recurrence && showRecurrence ? (
-            <RecurrenceCaption recurrence={recurrence} />
-          ) : null}
-        </Img>
-        {false}
-      </Media>
-      <TransactionActions
-        transaction={transaction}
-        onlyDefault
-        compact
-        menuPosition="right"
-        className={cx(
-          'u-mt-half',
-          'u-ml-2-half',
-          styles.TransactionRowMobile__actions
-        )}
-      />
+          </Img>
+          {false}
+        </Media>
+        <TransactionActions
+          transaction={transaction}
+          onlyDefault
+          compact
+          menuPosition="right"
+          className={cx(
+            'u-mt-half',
+            'u-ml-2-half',
+            styles.TransactionRowMobile__actions
+          )}
+        />
+      </List.Row>
       {transactionModal}
-    </List.Row>
+    </>
   )
 })
 

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -90,7 +90,6 @@ const TransactionContainerMobile = props => {
  */
 const TransactionSections = props => {
   const {
-    selectTransaction,
     limitMin,
     limitMax,
     filteringOnAccount,
@@ -124,7 +123,6 @@ const TransactionSections = props => {
                   transaction={transaction}
                   isExtraLarge={isExtraLarge}
                   filteringOnAccount={filteringOnAccount}
-                  selectTransaction={selectTransaction}
                 />
               )
             })}
@@ -212,7 +210,6 @@ export class TransactionsDumb extends React.Component {
       limitMax,
       manualLoadMore,
       showTriggerErrors,
-      selectTransaction,
       filteringOnAccount,
       className,
       transactions,
@@ -249,7 +246,6 @@ export class TransactionsDumb extends React.Component {
           )}
 
           <TransactionSections
-            selectTransaction={selectTransaction}
             limitMin={limitMin}
             limitMax={limitMax}
             filteringOnAccount={filteringOnAccount}


### PR DESCRIPTION
Two bugs with clicks in Chrome responsive are solved here.
It seems that Chrome responsive triggers click events a bit after the normal
click, leading to bugs like that. ev.preventDefault() fixes those bugs. I
would have preferred not to have this (I thought the change of structure
to remove the transaction modal from the transaction row would have sufficed)
but I do not see another solution.