### PR TITLE
fix: Show PinCode when app is restart and change timeout

### DIFF
--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -154,7 +154,7 @@ class PinGuard extends React.Component {
   }
 
   static defaultProps = {
-    timeout: 60 * 1000
+    timeout: 30 * 1000
   }
 }
 

--- a/src/ducks/pin/PinGuard.jsx
+++ b/src/ducks/pin/PinGuard.jsx
@@ -26,12 +26,11 @@ class PinGuard extends React.Component {
     const last = savedLast || Date.now()
     const cachedPinSetting = pinSettingStorage.load()
 
-    const willShowPin = this.isTooLate(last)
     return {
       last, // timestamp of last interaction
-      showPin: willShowPin,
+      showPin: true,
       cachedPinSetting,
-      hasBeenShownOnce: !willShowPin
+      hasBeenShownOnce: false
     }
   }
 

--- a/src/ducks/pin/PinGuard.spec.jsx
+++ b/src/ducks/pin/PinGuard.spec.jsx
@@ -54,7 +54,14 @@ describe('PinGuard', () => {
     const { root } = setup({
       pinSetting: PIN_DOC
     })
-    expect(pinAuthIsShown(root)).toBe(false)
+
+    const state = root.find(PinGuard).state()
+    expect(state.showPin).toBe(true)
+    expect(state.hasBeenShownOnce).toBe(false)
+
+    expect(root.children).toHaveLength(1)
+    expect(pinAuthIsShown(root)).toBe(true)
+
     jest.runAllTimers()
     root.update()
     expect(pinAuthIsShown(root)).toBe(true)
@@ -102,6 +109,14 @@ describe('PinGuard', () => {
     jest.spyOn(Date, 'now').mockReturnValue(1337)
     const instance = root.find(PinGuard).instance()
     jest.spyOn(instance, 'setState')
+    expect(pinAuthIsShown(root)).toBe(true)
+
+    root
+      .find(PinAuth)
+      .props()
+      .onSuccess()
+    root.update()
+
     expect(pinAuthIsShown(root)).toBe(false)
     instance.handleInteraction()
     expect(instance.setState).toHaveBeenCalledWith({

--- a/src/ducks/pin/PinGuard.spec.jsx
+++ b/src/ducks/pin/PinGuard.spec.jsx
@@ -55,13 +55,9 @@ describe('PinGuard', () => {
       pinSetting: PIN_DOC
     })
 
-    const state = root.find(PinGuard).state()
-    expect(state.showPin).toBe(true)
-    expect(state.hasBeenShownOnce).toBe(false)
-
     expect(root.children).toHaveLength(1)
+    expect(root.find(App)).toHaveLength(0)
     expect(pinAuthIsShown(root)).toBe(true)
-
     jest.runAllTimers()
     root.update()
     expect(pinAuthIsShown(root)).toBe(true)

--- a/src/ducks/settings/PinSettings.jsx
+++ b/src/ducks/settings/PinSettings.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { queryConnect } from 'cozy-client'
+import { queryConnect, withClient } from 'cozy-client'
 import compose from 'lodash/flowRight'
 
 import { translate } from 'cozy-ui/transpiled/react'
@@ -89,6 +89,7 @@ class PinSettings extends React.Component {
 }
 
 export default compose(
+  withClient,
   translate(),
   queryConnect({
     pinSetting

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -674,7 +674,7 @@
     "attempt-count": "%{current}/%{max} essais",
     "settings": {
       "toggle-title": "Verrouillage de l'application",
-      "toggle-description": "Verrouiller mon app par code pin ou empreinte digitale. Le déverrouillage sera demandé après 1 minute d'inactivité dans l'application."
+      "toggle-description": "Verrouiller mon app par code pin ou empreinte digitale. Le déverrouillage sera demandé après 30 secondes d'inactivité dans l'application."
     },
     "fingerprint-text": "Ou votre empreinte digitale",
     "use-fingerprint": {


### PR DESCRIPTION
- Change timeout to 30sec (prev: 1min)
- Show PinCode when app is restart 
- Add withClient to avoid props.client is undefined when the pin is disabled in Settings
