### PR TITLE
Fix: Close AccountSwitch after selection

### DIFF
--- a/src/components/Title/Title.jsx
+++ b/src/components/Title/Title.jsx
@@ -1,26 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import { MainTitle } from 'cozy-ui/transpiled/react/Text'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import styles from 'components/Title/Title.styl'
-import { useCozyTheme } from 'cozy-ui/transpiled/react/CozyTheme'
 
 const Title = props => {
-  const theme = useCozyTheme()
   const { children, className } = props
 
   return (
-    <MainTitle
-      tag="h1"
-      ellipsis={true}
-      className={cx(
-        styles.Title,
-        theme && styles[`TitleColor_${theme}`],
-        className
-      )}
-    >
+    <Typography variant="h4" className={cx(styles.Title, className)}>
       {children}
-    </MainTitle>
+    </Typography>
   )
 }
 

--- a/src/components/Title/Title.styl
+++ b/src/components/Title/Title.styl
@@ -3,10 +3,6 @@
 .Title
     line-height 2.5rem
     margin 0
-    color var(--black) !important
-
-.TitleColor_inverted
-    color var(--primaryContrastTextColor) !important
 
 +small-screen()
     .Title

--- a/src/components/Title/__snapshots__/Title.spec.jsx.snap
+++ b/src/components/Title/__snapshots__/Title.spec.jsx.snap
@@ -1,23 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Title should display children 1`] = `
-<ForwardRef
+<WithStyles(Typography)
   className="Title"
-  ellipsis={true}
-  tag="h1"
+  variant="h4"
 >
   content
-</ForwardRef>
+</WithStyles(Typography)>
 `;
 
 exports[`Title should extend className 1`] = `
-<ForwardRef
+<WithStyles(Typography)
   className="Title noPaddingBottom"
-  ellipsis={true}
-  tag="h1"
+  variant="h4"
 >
   content
-</ForwardRef>
+</WithStyles(Typography)>
 `;
 
 exports[`Title should handle theme 1`] = `

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -180,7 +180,7 @@ const AccountSwitchMenu = ({
           disableRipple
           divider
           onClick={handleReset}
-          selected={filteringDoc === undefined}
+          selected={!filteringDoc}
         >
           <AccountListItemText
             primary={t('AccountSwitch.all_accounts')}
@@ -330,7 +330,7 @@ const AccountSwitch = props => {
 
   const handleClose = useCallback(
     ev => {
-      ev.preventDefault()
+      ev && ev.preventDefault()
       setOpen(false)
     },
     [setOpen]


### PR DESCRIPTION
- AccountSwitch did not close after click
- All accounts was not correctly selected

Those regressions were introduced after the AccountSwitchMenu was
converted to a Dialog.

Also, convert the reimbursements page title to a Typography component,
this way it adapts to the theme automatically.