### PR TITLE
feat: Look inside the trigger for bank account update date

### DIFF
--- a/src/components/Section/index.js
+++ b/src/components/Section/index.js
@@ -1,5 +1,1 @@
-export {
-  default as Section,
-  SectionTitle,
-  SectionSeparator
-} from 'components/Section/Section'
+export { default as Section, SectionTitle } from 'components/Section/Section'

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -1,3 +1,5 @@
+import flag from 'cozy-flags'
+import { BankAccount } from 'cozy-doctypes'
 import overSome from 'lodash/overSome'
 import flatten from 'lodash/flatten'
 import uniqBy from 'lodash/uniqBy'
@@ -6,6 +8,8 @@ import compose from 'lodash/flowRight'
 import overEvery from 'lodash/overEvery'
 import sumBy from 'lodash/sumBy'
 import get from 'lodash/get'
+
+import { models } from 'cozy-client'
 import {
   getDate,
   getReimbursedAmount as getTransactionReimbursedAmount,
@@ -18,9 +22,11 @@ import {
   getCategoryIdFromName
 } from 'ducks/categories/helpers'
 import { differenceInCalendarDays, isAfter, subMonths } from 'date-fns'
-import flag from 'cozy-flags'
-import { BankAccount } from 'cozy-doctypes'
 import { ACCOUNT_DOCTYPE, CONTACT_DOCTYPE } from 'doctypes'
+
+const {
+  triggers: { triggerStates }
+} = models
 
 const PARTS_TO_DELETE = ['(sans Secure Key)']
 
@@ -38,16 +44,6 @@ export const getAccountInstitutionLabel = account => {
 
 export const getAccountLabel = account =>
   account ? account.shortLabel || account.label : ''
-
-export const getAccountUpdateDateDistance = (account, from) => {
-  const updateDate = BankAccount.getUpdatedAt(account)
-
-  if (!updateDate || !from) {
-    return null
-  }
-
-  return differenceInCalendarDays(from, updateDate)
-}
 
 export const distanceInWords = distance => {
   if (!Number.isFinite(distance)) {
@@ -121,7 +117,7 @@ export const getAccountBalance = account => {
   return account.balance
 }
 
-export const getAccountUpdatedAt = account => {
+export const getAccountUpdatedAt = (account, jobTrigger) => {
   if (flag('demo')) {
     return {
       translateKey: distanceInWords(0),
@@ -129,9 +125,17 @@ export const getAccountUpdatedAt = account => {
     }
   }
   const today = new Date()
-  const updateDistance = getAccountUpdateDateDistance(account, today)
-  const updateDistanceInWords = distanceInWords(updateDistance)
+  const updatedAtAccount = BankAccount.getUpdatedAt(account)
 
+  // TODO replace by getLastSuccess when https://github.com/cozy/cozy-client/pull/854
+  // is merged
+  const updatedAtTrigger = triggerStates.getLastsuccess(jobTrigger)
+  const updateDate = updatedAtTrigger || updatedAtAccount
+  const updateDistance = updateDate
+    ? differenceInCalendarDays(today, updateDate)
+    : null
+
+  const updateDistanceInWords = distanceInWords(updateDistance)
   return {
     translateKey: updateDistanceInWords,
     params: { nbDays: updateDistance }

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -1,5 +1,5 @@
 import {
-  getAccountUpdateDateDistance,
+  getAccountUpdatedAt,
   distanceInWords,
   getAccountType,
   getAccountBalance,
@@ -13,25 +13,42 @@ import { getCategoryIdFromName } from 'ducks/categories/helpers'
 import { CONTACT_DOCTYPE } from 'doctypes'
 import MockDate from 'mockdate'
 import fixtures from 'test/fixtures/unit-tests'
+import triggersFixtures from 'test/fixtures/triggers.json'
 import flag from 'cozy-flags'
 
 jest.mock('cozy-flags')
 
-describe('getAccountUpdateDateDistance', () => {
-  it('should return null if an argument is missing', () => {
-    const account = { cozyMetadata: { updatedAt: new Date(2019, 0, 10) } }
-    const from = new Date(2019, 0, 10)
-
-    expect(getAccountUpdateDateDistance()).toBeNull()
-    expect(getAccountUpdateDateDistance(account)).toBeNull()
-    expect(getAccountUpdateDateDistance(undefined, from)).toBeNull()
+describe('getAccountUpdatedAt', () => {
+  beforeEach(() => {
+    MockDate.set(new Date(2019, 0, 12))
   })
 
-  it('should return the right distance in days', () => {
-    const account = { cozyMetadata: { updatedAt: new Date(2019, 0, 1) } }
+  afterEach(() => {
+    MockDate.reset()
+  })
 
-    expect(getAccountUpdateDateDistance(account, new Date(2019, 0, 10))).toBe(9)
-    expect(getAccountUpdateDateDistance(account, new Date(2019, 0, 2))).toBe(1)
+  const jobTrigger = triggersFixtures[1].attributes
+  const account = { cozyMetadata: { updatedAt: new Date(2019, 0, 10) } }
+  it('should work when jobTrigger does not exist', () => {
+    expect(getAccountUpdatedAt(account, null)).toEqual({
+      params: { nbDays: 2 },
+      translateKey: 'Balance.updated-at.n-days-ago'
+    })
+  })
+
+  it('should work when jobTrigger exists', () => {
+    expect(getAccountUpdatedAt(account, jobTrigger)).toEqual({
+      params: { nbDays: 3 },
+      translateKey: 'Balance.updated-at.n-days-ago'
+    })
+  })
+
+  it('should return a particular key when update date is today', () => {
+    MockDate.set(new Date(2019, 0, 9))
+    expect(getAccountUpdatedAt(account, jobTrigger)).toEqual({
+      params: { nbDays: 0 },
+      translateKey: 'Balance.updated-at.today'
+    })
   })
 })
 

--- a/test/fixtures/triggers.json
+++ b/test/fixtures/triggers.json
@@ -15,7 +15,12 @@
     },
     "attributes": {
       "current_state": {
-        "status": "done"
+        "status": "done",
+        "trigger_id": "4407c92da13df4a255cc40da8a0c02e6",
+        "status": "done",
+        "last_success": "2019-01-09T09:00:00+01:00",
+        "last_execution": "2019-01-09T09:00:00+01:00",
+        "last_manual_execution": "2019-01-09T09:00:00+01:00"
       }
     }
   },


### PR DESCRIPTION
This fixes the fonctional bug where the account is shown not to have been
updated when its data has not changed. This is due to the fact that the
banking konnectors only update bank accounts when they have changed. Thus
the cozyMetadata.updatedAt attribute can be unchanged for a long time for
account without a lot of changes (savings account for example).

It could confuse users that expect to see the last synchronisation date, 
not the date where the object has been changed, in the AccountRow.

Here, the trigger last success date is used to determine the last sync date
shown in the account row. We keep the logic to take the bank account last
update date, in case the user has uninstalled the konnector. If the trigger
exists, its last success date is prioritized over the account update.