### PR TITLE
fix: Only need to store konnector triggers for konnectorAlerts service

### DIFF
--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -157,7 +157,11 @@ export const buildNotification = (client, options) => {
  * @return {Promise}
  */
 export const sendTriggerNotifications = async client => {
-  const { data: triggers } = await client.query(Q('io.cozy.triggers'))
+  const { data: triggers } = await client.query(
+    Q('io.cozy.triggers').where({
+      worker: 'konnector'
+    })
+  )
   const konnectorTriggers = triggers.filter(trigger =>
     isKonnectorWorker(trigger.attributes)
   )

--- a/src/targets/services/konnectorAlerts.spec.js
+++ b/src/targets/services/konnectorAlerts.spec.js
@@ -142,7 +142,7 @@ const {
 describe('job notifications service', () => {
   const setup = ({ triggersResponse, settingsResponse, jobsResponse } = {}) => {
     const client = new CozyClient({})
-    client.query = async queryDef => {
+    client.query = jest.fn(async queryDef => {
       const { doctype, id } = queryDef
       if (doctype === 'io.cozy.triggers') {
         return triggersResponse || mockTriggersResponse
@@ -153,7 +153,7 @@ describe('job notifications service', () => {
       } else {
         throw new Error(`No mock for queryDef ${queryDef}`)
       }
-    }
+    })
     client.save = jest.fn()
     client.stackClient.fetchJSON = jest
       .fn()
@@ -190,6 +190,14 @@ describe('job notifications service', () => {
       }
     })
     await sendTriggerNotifications(client)
+    expect(client.query).toHaveBeenCalledWith(
+      expect.objectContaining({
+        doctype: 'io.cozy.triggers',
+        selector: {
+          worker: 'konnector'
+        }
+      })
+    )
     expect(sendNotification).not.toHaveBeenCalled()
     expectTriggerStatesToHaveBeenSaved(client)
   })


### PR DESCRIPTION
Triggers are not only for konnectors and can be used for sharing / notes 
etc... If we do not scope the query, we end up with all the trigger states
inside the io.cozy.bank.settings that tracks the konnector trigger states,
where we only need the states for konnector triggers. In a given cozy, we
stored 173 trigger states, and now we only store 23.