### PR TITLE
fix: Change header for transfer page when there is no bank

### DIFF
--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -427,7 +427,7 @@ class TransferPage extends React.Component {
     }
 
     if (accounts.data.length === 0) {
-      return <NoBank />
+      return <NoBank isMobile={isMobile} />
     }
 
     if (recipients.data.length === 0) {

--- a/src/ducks/transfers/TransferPage.jsx
+++ b/src/ducks/transfers/TransferPage.jsx
@@ -119,20 +119,30 @@ const NoRecipient = () => {
   )
 }
 
-const NoBank = () => {
+const NoBank = ({ isMobile }) => {
   const { t } = useI18n()
 
   return (
-    <Padded>
-      <PageTitle>{t('Transfer.no-bank.title')}</PageTitle>
-      <AddAccountButton
-        absolute
-        extension="full"
-        label={t('Transfer.no-bank.add-bank')}
-        theme="primary"
-        className="u-mt-0"
-      />
-    </Padded>
+    <>
+      <Header theme={isMobile ? 'inverted' : 'normal'}>
+        <Padded className="u-pv-half">
+          <LegalMention />
+        </Padded>
+      </Header>
+      <Padded>
+        <PageTitle>{t('Transfer.page-title')}</PageTitle>
+        <Typography variant="body1" align="center" className="u-mt-3">
+          {t('Transfer.no-bank.title')}
+        </Typography>
+        <AddAccountButton
+          absolute
+          extension="full"
+          label={t('Transfer.no-bank.add-bank')}
+          theme="primary"
+          className="u-mt-3"
+        />
+      </Padded>
+    </>
   )
 }
 


### PR DESCRIPTION
In NoBank component (Transfer page}:
- addition of the nominal header and changing of text by "Transfer"
- The label (with : "Ajoutez une banque pour pouvoir effectuer
 un virement") is added above "Add a bank" button
- Add of spacing between label and button