### PR TITLE
feat: Disable notifications when corresponding account/group is deleted

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -38,7 +38,7 @@ export const deleteOrphanOperations = async (client, account) => {
 
 const removeAccountFromGroups = async account => {
   const groupCollection = getStackCollection(GROUP_DOCTYPE)
-  const groups = (await groupCollection.all(GROUP_DOCTYPE)).data
+  const groups = (await groupCollection.all()).data
   const ugroups = groups.map(group => removeAccountFromGroup(group, account))
   for (let ugroup of ugroups) {
     await groupCollection.update(ugroup)

--- a/src/ducks/settings/__snapshots__/helpers.spec.jsx.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.jsx.snap
@@ -43,19 +43,10 @@ Object {
     "healthBillLinked": Object {
       "enabled": true,
     },
-    "hebdo": Object {
-      "enabled": false,
-    },
     "lastSeq": 0,
     "lateHealthReimbursement": Object {
       "enabled": false,
       "value": 30,
-    },
-    "mensuel": Object {
-      "enabled": false,
-    },
-    "salaire": Object {
-      "enabled": false,
     },
     "transactionGreater": Array [
       Object {

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -38,16 +38,7 @@ export const DEFAULTS_SETTINGS = {
         enabled: false,
         value: 2
       }
-    ],
-    salaire: {
-      enabled: false
-    },
-    hebdo: {
-      enabled: false
-    },
-    mensuel: {
-      enabled: false
-    }
+    ]
   },
   categoryBudgetAlerts: [],
   billsMatching: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -378,18 +378,6 @@
     "editModal": {
       "title": "Configure notification"
     },
-    "weekly-summary": {
-      "description": "You will receive a summary of your expenses and revenues every Monday of every week.",
-      "title": "Weekly Synthesis"
-    },
-    "when-month-revenue": {
-      "description": "You will receive an email at the reception of your salary each month.",
-      "title": "Payment of salary"
-    },
-    "monthly-summary": {
-      "description": "You will receive a summary of your expenses and income each month.",
-      "title": "Monthly summary"
-    },
     "if-balance-lower": {
       "description": "You will receive a notification if your balance goes under *%{value}€* on any account",
       "descriptionWithAccountGroup": "You will receive a notification if your balance goes under *%{value}€* on *%{accountOrGroupLabel}*",
@@ -440,10 +428,6 @@
           "title": "%{transactionsLength} transactions greater than %{matchingRulesLength} thresholds"
         }
       }
-    },
-    "no-revenue": {
-      "description": "You will be notified if you have not received your salary at the %{input} of each month.",
-      "title": "Salary Delay"
     },
     "when-health-bill-linked": {
       "settingTitle": "Detected",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -441,22 +441,6 @@
         }
       }
     },
-    "no-revenue": {
-      "title": "Retard de salaire",
-      "description": "Vous serez prévenu si vous n’avez pas reçu votre salaire au %{input} de chaque mois."
-    },
-    "when-month-revenue": {
-      "title": "Versement de salaire",
-      "description": "Vous recevrez un email à la réception de votre salaire chaque mois."
-    },
-    "weekly-summary": {
-      "title": "Synthèse hebdomadaire",
-      "description": "Vous recevrez un récapitulatif de vos dépenses et de vos revenus tous les lundis de chaque semaine."
-    },
-    "monthly-summary": {
-      "title": "Synthèse mensuelle",
-      "description": "Vous recevrez un récapitulatif de vos dépenses et de vos revenus tous les premiers de chaque mois."
-    },
     "when-health-bill-linked": {
       "settingTitle": "Detecté",
       "description": "Vous recevrez une notification lorsqu'un remboursement a été trouvé pour une de vos dépenses de santé",

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1681,5 +1681,68 @@
         }
       }
     }
+  ],
+  "io.cozy.bank.settings": [
+    {
+      "_id": "settings-1",
+      "autogroups": {
+        "processedAccounts": []
+      },
+      "linkMyselfToAccounts": {
+        "processedAccounts": []
+      },
+      "notifications": {
+        "lastSeq": 0,
+        "balanceLower": [
+          {
+            "id": 0,
+            "value": 100,
+            "enabled": true,
+            "accountOrGroup": {
+              "_type": "io.cozy.bank.accounts",
+              "_id": "compteisa1"
+            }
+          }
+        ],
+        "transactionGreater": [
+          {
+            "id": 0,
+            "value": 600,
+            "enabled": true
+          }
+        ],
+        "healthBillLinked": {
+          "enabled": true
+        },
+        "lateHealthReimbursement": {
+          "value": 30,
+          "enabled": false
+        },
+        "delayedDebit": [
+          {
+            "id": 0,
+            "enabled": false,
+            "value": 2
+          }
+        ]
+      },
+      "categoryBudgetAlerts": [],
+      "billsMatching": {
+        "billsLastSeq": "0",
+        "transactionsLastSeq": "0"
+      },
+      "appSuggestions": {
+        "lastSeq": 0
+      },
+      "community": {
+        "localModelOverride": {
+          "enabled": true
+        }
+      },
+      "categorization": {
+        "lastSeq": 0
+      },
+      "showIncomeCategory": true
+    }
   ]
 }


### PR DESCRIPTION
Disable notifications if they are focused on an account or group
that gets deleted.