### PR TITLE
fix: Keep real time active when focus on balance page

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -295,17 +295,10 @@ class Balance extends PureComponent {
       return
     }
 
-    const accounts = accountsCollection.data
-
-    if (accounts.length > 0) {
-      this.stopRealtime()
-      this.stopRealtimeFallback()
-      this.stopResumeListeners()
-    } else {
-      this.startRealtime()
-      this.startRealtimeFallback()
-      this.startResumeListeners()
-    }
+    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
+    this.startRealtime()
+    this.startRealtimeFallback()
+    this.startResumeListeners()
   }
 
   /**

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -1,7 +1,6 @@
 import { mount, shallow } from 'enzyme'
 import AppLike from 'test/AppLike'
 import getClient from 'test/client'
-import fixtures from 'test/fixtures'
 import Loading from 'components/Loading'
 import NoAccount from './NoAccount'
 import AccountsImporting from './AccountsImporting'
@@ -77,16 +76,18 @@ describe('Balance page', () => {
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
     })
-    it('should stop periodic data fetch if there are accounts', () => {
-      const accounts = fixtures['io.cozy.bank.accounts']
-      const { instance } = setup({ accountsData: accounts })
 
-      jest.spyOn(instance, 'startRealtimeFallback')
-      jest.spyOn(instance, 'stopRealtimeFallback')
-      instance.ensureListenersProperlyConfigured()
-      expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
-      expect(instance.stopRealtimeFallback).toHaveBeenCalled()
-    })
+    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
+    // it('should stop periodic data fetch if there are accounts', () => {
+    //   const accounts = fixtures['io.cozy.bank.accounts']
+    //   const { instance } = setup({ accountsData: accounts })
+    //
+    //   jest.spyOn(instance, 'startRealtimeFallback')
+    //   jest.spyOn(instance, 'stopRealtimeFallback')
+    //   instance.ensureListenersProperlyConfigured()
+    //   expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
+    //   expect(instance.stopRealtimeFallback).toHaveBeenCalled()
+    // })
 
     it('should correctly start realtime fallback', () => {
       const { instance } = setup()


### PR DESCRIPTION
Issue:
  When all groups (from a bank) are deleted, the "Balance" page is not
refreshed with the new data and sometimes there are empty groups.
We must have fills groups with the accounts values.

Fix:
  Keep realtime on allows to have an always up-to-date UI. 
  Not the best for the app (see [2009](https://github.com/cozy/cozy-banks/issues/2009) issue)