### PR TITLE
fix: Revert "Merge pull request #2010 from cozy/fix-keep-realtime-on"

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -295,10 +295,17 @@ class Balance extends PureComponent {
       return
     }
 
-    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
-    this.startRealtime()
-    this.startRealtimeFallback()
-    this.startResumeListeners()
+    const accounts = accountsCollection.data
+
+    if (accounts.length > 0) {
+      this.stopRealtime()
+      this.stopRealtimeFallback()
+      this.stopResumeListeners()
+    } else {
+      this.startRealtime()
+      this.startRealtimeFallback()
+      this.startResumeListeners()
+    }
   }
 
   /**

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -1,6 +1,7 @@
 import { mount, shallow } from 'enzyme'
 import AppLike from 'test/AppLike'
 import getClient from 'test/client'
+import fixtures from 'test/fixtures'
 import Loading from 'components/Loading'
 import NoAccount from './NoAccount'
 import AccountsImporting from './AccountsImporting'
@@ -76,18 +77,16 @@ describe('Balance page', () => {
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
     })
+    it('should stop periodic data fetch if there are accounts', () => {
+      const accounts = fixtures['io.cozy.bank.accounts']
+      const { instance } = setup({ accountsData: accounts })
 
-    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
-    // it('should stop periodic data fetch if there are accounts', () => {
-    //   const accounts = fixtures['io.cozy.bank.accounts']
-    //   const { instance } = setup({ accountsData: accounts })
-    //
-    //   jest.spyOn(instance, 'startRealtimeFallback')
-    //   jest.spyOn(instance, 'stopRealtimeFallback')
-    //   instance.ensureListenersProperlyConfigured()
-    //   expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
-    //   expect(instance.stopRealtimeFallback).toHaveBeenCalled()
-    // })
+      jest.spyOn(instance, 'startRealtimeFallback')
+      jest.spyOn(instance, 'stopRealtimeFallback')
+      instance.ensureListenersProperlyConfigured()
+      expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
+      expect(instance.stopRealtimeFallback).toHaveBeenCalled()
+    })
 
     it('should correctly start realtime fallback', () => {
       const { instance } = setup()


### PR DESCRIPTION
Revert fix: 

Didn't fix when all groups (from a bank) are deleted, the "Balance" page is not
refreshed with the new data and sometimes there are empty groups.

See: https://github.com/cozy/cozy-banks/pull/2010