### PR TITLE
fix: Empty groups after adding a bank

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -295,17 +295,10 @@ class Balance extends PureComponent {
       return
     }
 
-    const accounts = accountsCollection.data
-
-    if (accounts.length > 0) {
-      this.stopRealtime()
-      this.stopRealtimeFallback()
-      this.stopResumeListeners()
-    } else {
-      this.startRealtime()
-      this.startRealtimeFallback()
-      this.startResumeListeners()
-    }
+    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
+    this.startRealtime()
+    this.startRealtimeFallback()
+    this.startResumeListeners()
   }
 
   /**

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -27,6 +27,7 @@ import {
   cronKonnectorTriggersConn,
   accountsConn,
   ACCOUNT_DOCTYPE,
+  GROUP_DOCTYPE,
   TRIGGER_DOCTYPE,
   TRANSACTION_DOCTYPE,
   transactionsConn
@@ -60,7 +61,8 @@ const syncPouchImmediately = async client => {
 const REALTIME_DOCTYPES = [
   ACCOUNT_DOCTYPE,
   TRIGGER_DOCTYPE,
-  TRANSACTION_DOCTYPE
+  TRANSACTION_DOCTYPE,
+  GROUP_DOCTYPE
 ]
 
 const isLoading = props => {

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -1,7 +1,6 @@
 import { mount, shallow } from 'enzyme'
 import AppLike from 'test/AppLike'
 import getClient from 'test/client'
-import fixtures from 'test/fixtures'
 import Loading from 'components/Loading'
 import NoAccount from './NoAccount'
 import AccountsImporting from './AccountsImporting'
@@ -77,16 +76,18 @@ describe('Balance page', () => {
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
       expect(instance.startRealtimeFallback).toHaveBeenCalled()
     })
-    it('should stop periodic data fetch if there are accounts', () => {
-      const accounts = fixtures['io.cozy.bank.accounts']
-      const { instance } = setup({ accountsData: accounts })
 
-      jest.spyOn(instance, 'startRealtimeFallback')
-      jest.spyOn(instance, 'stopRealtimeFallback')
-      instance.ensureListenersProperlyConfigured()
-      expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
-      expect(instance.stopRealtimeFallback).toHaveBeenCalled()
-    })
+    // See issue #2009 https://github.com/cozy/cozy-banks/issues/2009
+    // it('should stop periodic data fetch if there are accounts', () => {
+    //   const accounts = fixtures['io.cozy.bank.accounts']
+    //   const { instance } = setup({ accountsData: accounts })
+    //
+    //   jest.spyOn(instance, 'startRealtimeFallback')
+    //   jest.spyOn(instance, 'stopRealtimeFallback')
+    //   instance.ensureListenersProperlyConfigured()
+    //   expect(instance.startRealtimeFallback).not.toHaveBeenCalled()
+    //   expect(instance.stopRealtimeFallback).toHaveBeenCalled()
+    // })
 
     it('should correctly start realtime fallback', () => {
       const { instance } = setup()


### PR DESCRIPTION
The first [PR] (https://github.com/cozy/cozy-banks/pull/2010) does not correct the problem of empty groups but keeps the interface up to date.  An [issue](https://github.com/cozy/cozy-banks/issues/2009) is open in order to optimize real time.

Empty groups remained displayed because they were not monitored and therefore not updated when the automatic group creation job was completed.

So I added GROUP_DOCTYPE in the list of doctypes to watch