### PR TITLE
fix: Add missing groups.fetch

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -241,6 +241,7 @@ class Balance extends PureComponent {
     this.props.accounts.fetch()
     this.props.transactions.fetch()
     this.props.triggers.fetch()
+    this.props.groups.fetch()
   }
 
   handleResume() {


### PR DESCRIPTION
Fetching groups when realtime is active

Related to PR [#2012](https://github.com/cozy/cozy-banks/pull/2012)