### PR TITLE
fix: Allows not to have an intermediate state

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -238,10 +238,13 @@ class Balance extends PureComponent {
   }
 
   updateQueries() {
-    this.props.accounts.fetch()
+    this.props.accounts.fetch().then(resp => {
+      if (resp.meta.count > 0) {
+        this.props.groups.fetch()
+      }
+    })
     this.props.transactions.fetch()
     this.props.triggers.fetch()
-    this.props.groups.fetch()
   }
 
   handleResume() {


### PR DESCRIPTION
Issue:
  When adding a bank after deleting all accounts
for several seconds (1 to 5 sec) the groups are empty.

With "realtime" there are multiple fetching like "accounts" and "groups"
which are called in parallel.
When we fetch groups when there are no accounts, the groups are empty.

No need to search for groups as long as there are no accounts, otherwise there are empty groups.

Fix:
  When the realtime is active, we call fetch Accounts
so when there are data we can fetching the groups.