### PR TITLE
fix: Show correct icons in Accounts and settings page

### DIFF
--- a/src/components/AccountIcon/index.jsx
+++ b/src/components/AccountIcon/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 import { getAccountInstitutionSlug } from 'ducks/account/helpers'
 import styles from './styles.styl'
@@ -19,7 +19,10 @@ export const AccountIconContainer = ({ size, children }) => {
 
 /** Displays a konnector icon for an io.cozy.bank.accounts */
 const _AccountIcon = ({ account, className, size }) => {
-  const institutionSlug = getAccountInstitutionSlug(account)
+  const institutionSlug = useMemo(() => {
+    return getAccountInstitutionSlug(account)
+  }, [account])
+
   if (!institutionSlug) {
     return null
   }

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -8,6 +8,7 @@ import compose from 'lodash/flowRight'
 import overEvery from 'lodash/overEvery'
 import sumBy from 'lodash/sumBy'
 import get from 'lodash/get'
+import sortBy from 'lodash/sortBy'
 
 import { models } from 'cozy-client'
 import {
@@ -106,8 +107,19 @@ export const getAccountType = account => {
   return type
 }
 
-export const getAccountInstitutionSlug = account =>
-  get(account, 'cozyMetadata.createdByApp')
+export const getAccountInstitutionSlug = account => {
+  const updatedByApps = get(account, 'cozyMetadata.updatedByApps')
+
+  if (Array.isArray(updatedByApps) && updatedByApps.length > 0) {
+    const sortedByDate = sortBy(
+      updatedByApps,
+      app => new Date(app.date)
+    ).reverse()[0]
+
+    return sortedByDate.slug
+  }
+  return get(account, 'cozyMetadata.createdByApp')
+}
 
 export const getAccountBalance = account => {
   if (account.type === 'CreditCard' && account.comingBalance) {

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -1,6 +1,7 @@
 import {
   getAccountUpdatedAt,
   distanceInWords,
+  getAccountInstitutionSlug,
   getAccountType,
   getAccountBalance,
   buildHealthReimbursementsVirtualAccount,
@@ -424,5 +425,41 @@ describe('buildOthersReimbursementsVirtualAccount', () => {
     expect(buildOthersReimbursementsVirtualAccount(transactions)).toMatchObject(
       expected
     )
+  })
+})
+
+describe('getAccountInstitutionSlug', () => {
+  const updatedApps = [
+    {
+      date: '2021-02-18T16:28:46.247Z',
+      slug: 'maif-nestor'
+    },
+    {
+      date: '2021-02-18T16:35:54.125Z',
+      slug: 'boursorama83'
+    },
+    {
+      date: '2021-02-18T16:30:46.247Z',
+      slug: 'ce'
+    }
+  ]
+  const makeAccount = updatedByApps => ({
+    cozyMetadata: {
+      createdByApp: 'maif-nestor',
+      updatedAt: '2021-02-18T16:33:54.125Z',
+      updatedByApps
+    }
+  })
+  it('should return createdByApp slug', () => {
+    const slug1 = getAccountInstitutionSlug(makeAccount(undefined))
+    expect(slug1).toBe('maif-nestor')
+
+    const slug2 = getAccountInstitutionSlug(makeAccount([]))
+    expect(slug2).toBe('maif-nestor')
+  })
+
+  it('should return the last update slug in updatedByApps', () => {
+    const slug = getAccountInstitutionSlug(makeAccount(updatedApps))
+    expect(slug).toBe('boursorama83')
   })
 })

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
@@ -36,19 +36,22 @@ import LegalMention from 'ducks/legal/LegalMention'
 
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
+import { getAccountInstitutionSlug } from '../account/helpers'
 
 const { utils } = models
 
 const AccountListItem = ({ account, onClick, secondary }) => {
+  const konnectorSlug = useMemo(() => {
+    return getAccountInstitutionSlug(account)
+  }, [account])
+
   return (
     <ListItem divider onClick={onClick} className="u-c-pointer">
       <ListItemIcon>
         <AccountIconContainer>
           <KonnectorIcon
             style={{ width: 16, height: 16 }}
-            konnectorSlug={
-              account.cozyMetadata ? account.cozyMetadata.createdByApp : null
-            }
+            konnectorSlug={konnectorSlug}
           />
         </AccountIconContainer>
       </ListItemIcon>


### PR DESCRIPTION
The slug for show the konnector icon was provided by the createdByApp.

In the event that the nestor konnector is used for the first time with
a Boursorama account and after we connect with the Boursorama konnector
with the same account.

So the nestor icon was always displayed instead of icon from the
last connected konnector.

In this example it will be boursorama icon.

Now Accounts and settings/accounts page show correctly icons