### PR TITLE
Revert "Merge pull request #2018 from cozy/fix-konnector-icons"

### DIFF
--- a/src/components/AccountIcon/index.jsx
+++ b/src/components/AccountIcon/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React from 'react'
 import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 import { getAccountInstitutionSlug } from 'ducks/account/helpers'
 import styles from './styles.styl'
@@ -19,10 +19,7 @@ export const AccountIconContainer = ({ size, children }) => {
 
 /** Displays a konnector icon for an io.cozy.bank.accounts */
 const _AccountIcon = ({ account, className, size }) => {
-  const institutionSlug = useMemo(() => {
-    return getAccountInstitutionSlug(account)
-  }, [account])
-
+  const institutionSlug = getAccountInstitutionSlug(account)
   if (!institutionSlug) {
     return null
   }

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -8,7 +8,6 @@ import compose from 'lodash/flowRight'
 import overEvery from 'lodash/overEvery'
 import sumBy from 'lodash/sumBy'
 import get from 'lodash/get'
-import sortBy from 'lodash/sortBy'
 
 import { models } from 'cozy-client'
 import {
@@ -107,19 +106,8 @@ export const getAccountType = account => {
   return type
 }
 
-export const getAccountInstitutionSlug = account => {
-  const updatedByApps = get(account, 'cozyMetadata.updatedByApps')
-
-  if (Array.isArray(updatedByApps) && updatedByApps.length > 0) {
-    const sortedByDate = sortBy(
-      updatedByApps,
-      app => new Date(app.date)
-    ).reverse()[0]
-
-    return sortedByDate.slug
-  }
-  return get(account, 'cozyMetadata.createdByApp')
-}
+export const getAccountInstitutionSlug = account =>
+  get(account, 'cozyMetadata.createdByApp')
 
 export const getAccountBalance = account => {
   if (account.type === 'CreditCard' && account.comingBalance) {

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -1,7 +1,6 @@
 import {
   getAccountUpdatedAt,
   distanceInWords,
-  getAccountInstitutionSlug,
   getAccountType,
   getAccountBalance,
   buildHealthReimbursementsVirtualAccount,
@@ -425,41 +424,5 @@ describe('buildOthersReimbursementsVirtualAccount', () => {
     expect(buildOthersReimbursementsVirtualAccount(transactions)).toMatchObject(
       expected
     )
-  })
-})
-
-describe('getAccountInstitutionSlug', () => {
-  const updatedApps = [
-    {
-      date: '2021-02-18T16:28:46.247Z',
-      slug: 'maif-nestor'
-    },
-    {
-      date: '2021-02-18T16:35:54.125Z',
-      slug: 'boursorama83'
-    },
-    {
-      date: '2021-02-18T16:30:46.247Z',
-      slug: 'ce'
-    }
-  ]
-  const makeAccount = updatedByApps => ({
-    cozyMetadata: {
-      createdByApp: 'maif-nestor',
-      updatedAt: '2021-02-18T16:33:54.125Z',
-      updatedByApps
-    }
-  })
-  it('should return createdByApp slug', () => {
-    const slug1 = getAccountInstitutionSlug(makeAccount(undefined))
-    expect(slug1).toBe('maif-nestor')
-
-    const slug2 = getAccountInstitutionSlug(makeAccount([]))
-    expect(slug2).toBe('maif-nestor')
-  })
-
-  it('should return the last update slug in updatedByApps', () => {
-    const slug = getAccountInstitutionSlug(makeAccount(updatedApps))
-    expect(slug).toBe('boursorama83')
   })
 })

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react'
+import React, { useState } from 'react'
 
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
@@ -36,22 +36,19 @@ import LegalMention from 'ducks/legal/LegalMention'
 
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
-import { getAccountInstitutionSlug } from '../account/helpers'
 
 const { utils } = models
 
 const AccountListItem = ({ account, onClick, secondary }) => {
-  const konnectorSlug = useMemo(() => {
-    return getAccountInstitutionSlug(account)
-  }, [account])
-
   return (
     <ListItem divider onClick={onClick} className="u-c-pointer">
       <ListItemIcon>
         <AccountIconContainer>
           <KonnectorIcon
             style={{ width: 16, height: 16 }}
-            konnectorSlug={konnectorSlug}
+            konnectorSlug={
+              account.cozyMetadata ? account.cozyMetadata.createdByApp : null
+            }
           />
         </AccountIconContainer>
       </ListItemIcon>


### PR DESCRIPTION
We revert because the bank accounts can be edited by apps/konnectors other than a bank connector.

We cannot trust updatedByApps.

We keep the fact of displaying an icon from the createdByApp, it is the banking konnector that
takes care of updating the createdByApp field.
