### PR TITLE
fix: Wait for flag initialization in onOperationOrBillCreate

### DIFF
--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -193,6 +193,8 @@ const main = async () => {
   attachProcessEventHandlers()
   const client = CozyClient.fromEnv(process.env)
   Document.registerClient(client)
+  client.registerPlugin(flag.plugin)
+  await client.plugins.flags.initializing
   const options = await getOptions(client)
   log('info', 'Options:')
   log('info', JSON.stringify(options))


### PR DESCRIPTION
To properly use flags coming from the server, we need to register the flag plugin and wait for its complete initialization. Here, flags were only coming from the settings document in ad-hoc way (predating the existence of flags stored on the server / context / instance).