### PR TITLE
Deduplicate accounts in autogroups service

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -21,6 +21,8 @@ module.exports = function(api) {
             {
               root: ['./src'],
               alias: {
+                'ducks/client/manifest':
+                  './src/ducks/client/manifest-babel-node',
                 ducks: './src/ducks',
                 'cozy-ui/react': 'cozy-ui/transpiled/react'
               }

--- a/docs/services.md
+++ b/docs/services.md
@@ -27,11 +27,6 @@ $ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.tools:8080 banks
 $ node build/budgetAlerts.js
 ```
 
-Some services like the "budgetAlerts" one expose a CLI that can perform service related tasks.
-
-```
-yarn run services:budgetAlerts --help
-```
 
 ## Services
 
@@ -83,6 +78,8 @@ Whenever an `io.cozy.bank.accounts` is created, we check if it could belong in a
 on its type (checkings, savings, credit cards). These `io.cozy.bank.groups` documents are created with
 the `auto: true` attributes.
 
+ℹ️  This service an be run via CLI via `yarn service:autogroups`
+
 ### Budget alerts
 
 slug: `budgetAlerts`
@@ -108,6 +105,8 @@ to existing recurrence groups.
 
 See Paper "Paiements recurrents" for more information on the service.
 
+ℹ️  This service an be run via CLI via `yarn service recurrence`
+
 ### Konnector alerts
 
 slug: `konnectorAlerts`
@@ -118,6 +117,8 @@ Here are the rules for those notifications:
 - They should only be sent for LOGIN_FAILED and USER_ACTION_NEEDED errors
 - They should only be sent for automatic jobs (not manual)
 - We should not send a notification if the state stays the same
+
+ℹ️  This service an be run via CLI via `yarn service konnectorAlerts`
 
 ## I am writing a banking konnector, what should I do?
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -78,7 +78,7 @@ Whenever an `io.cozy.bank.accounts` is created, we check if it could belong in a
 on its type (checkings, savings, credit cards). These `io.cozy.bank.groups` documents are created with
 the `auto: true` attributes.
 
-ℹ️  This service an be run via CLI via `yarn service:autogroups`
+ℹ️  This service can be run via CLI via `yarn service:autogroups`
 
 ### Budget alerts
 
@@ -105,7 +105,7 @@ to existing recurrence groups.
 
 See Paper "Paiements recurrents" for more information on the service.
 
-ℹ️  This service an be run via CLI via `yarn service recurrence`
+ℹ️  This service can be run via CLI via `yarn service recurrence`
 
 ### Konnector alerts
 
@@ -118,7 +118,7 @@ Here are the rules for those notifications:
 - They should only be sent for automatic jobs (not manual)
 - We should not send a notification if the state stays the same
 
-ℹ️  This service an be run via CLI via `yarn service konnectorAlerts`
+ℹ️  This service can be run via CLI via `yarn service konnectorAlerts`
 
 ## I am writing a banking konnector, what should I do?
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "secrets:decrypt": "openssl aes-256-cbc -K $ENCRYPTED_KEY -iv $ENCRYPTED_IV -in ./scripts/encrypted.tar.gz.enc -d | tar zxv -C scripts",
     "secrets:encrypt": "tar zcvf ./scripts/decrypted.tar.gz ./scripts/decrypted && travis encrypt-file ./scripts/decrypted.tar.gz ./scripts/encrypted.tar.gz.enc -p",
     "release": "./scripts/release.sh",
-    "service": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/services/cli.js"
+    "service": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/services/cli.js",
+    "service:autogroups": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/targets/services/autogroups.js"
   },
   "husky": {
     "hooks": {

--- a/src/ducks/balance/AccountsList.jsx
+++ b/src/ducks/balance/AccountsList.jsx
@@ -24,8 +24,9 @@ const getSortedAccounts = (group, accounts) => {
   }
 }
 
-const mkAccountsSelector = (group, client) => state =>
-  getHydratedAccountsFromGroup(state, group, client)
+const mkAccountsSelector = (group, client) => state => {
+  return getHydratedAccountsFromGroup(state, group, client)
+}
 
 export const AccountsList = props => {
   const client = useClient()

--- a/src/ducks/client/manifest-babel-node.js
+++ b/src/ducks/client/manifest-babel-node.js
@@ -1,0 +1,12 @@
+/**
+ * This files overrides the manifest.js from the same folder when in the
+ * context of the service CLI, see babel.config.js ("cli" env part), otherwise
+ * the manifest.webapp cannot be imported as a JSON.
+ */
+
+const fs = require('fs')
+const path = require('path')
+
+export default JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../../../manifest.webapp')).toString()
+)

--- a/src/ducks/groups/services.spec.js
+++ b/src/ducks/groups/services.spec.js
@@ -1,4 +1,4 @@
-import { createAutoGroups } from './services'
+import { createAutoGroups, removeDuplicateAccountsFromGroups } from './services'
 import { createClientWithData } from 'test/client'
 import { GROUP_DOCTYPE, ACCOUNT_DOCTYPE, schema } from 'doctypes'
 import { fetchSettings } from 'ducks/settings/helpers'
@@ -56,7 +56,7 @@ describe('createAutoGroups', () => {
             {
               _id: 'checkings_auto',
               accountType: 'Checkings',
-              accounts: ['a1']
+              accounts: ['a1', 'a1']
             }
           ],
           [ACCOUNT_DOCTYPE]: [{ _id: 'a2', type: 'Checkings' }]
@@ -76,6 +76,37 @@ describe('createAutoGroups', () => {
       )
 
       expect(settings.autogroups.processedAccounts).toEqual(['a1', 'a2'])
+
+      // Due to account deduplication
+      expect(client.save).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('duplicate accounts removal', () => {
+    it('should remove duplicate accounts from an existing group', async () => {
+      const { client } = setup({
+        data: {
+          [GROUP_DOCTYPE]: [
+            {
+              _id: 'checkings_auto',
+              accountType: 'Checkings',
+              accounts: ['a1', 'a1']
+            }
+          ],
+          [ACCOUNT_DOCTYPE]: [{ _id: 'a2', type: 'Checkings' }]
+        },
+        processedAccounts: ['a1']
+      })
+
+      await removeDuplicateAccountsFromGroups(client)
+
+      expect(client.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          _id: 'checkings_auto',
+          accountType: 'Checkings',
+          accounts: ['a1']
+        })
+      )
     })
   })
 })

--- a/src/utils/getPermissions.js
+++ b/src/utils/getPermissions.js
@@ -1,4 +1,4 @@
-import manifest from '../../manifest.webapp'
+import manifest from 'ducks/client/manifest'
 
 const getPermissions = () =>
   Object.keys(manifest.permissions).map(

--- a/test/client.js
+++ b/test/client.js
@@ -18,6 +18,7 @@ export const getClient = ({ uri, token, fetchJSONReturn } = defaultOptions) => {
     uri,
     token
   })
+  client.ensureStore()
   if (fetchJSONReturn) {
     client.client.fetchJSON = jest.fn().mockReturnValue(fetchJSONReturn)
   }

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -2,7 +2,7 @@ import { configure, mount, shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import logger from 'cozy-logger'
 import { makeDeprecatedLifecycleMatcher, ignoreOnConditions } from './jestUtils'
-import minilog from 'minilog'
+import minilog from '@cozy/minilog'
 
 // To avoid the errors while creating theme (since no CSS stylesheet
 // defining CSS variables is injected during tests)
@@ -62,6 +62,7 @@ console.warn = ignoreOnConditions(
   Object.values(ignoredWarnings).map(x => x.matcher)
 )
 
+minilog.suggest.deny(/.*/, 'warn')
 minilog.pipe({
   emit: () => {},
   write: function(namespace, level, message) {


### PR DESCRIPTION
In production, we have seen cases where there were duplicated accounts
in groups. Here, we add the removal of duplicate accounts in the
autogroups service.