### PR TITLE
Better import in progress

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -1,6 +1,6 @@
 /* global __TARGET__ */
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import { Provider } from 'react-redux'
 
 import I18n from 'cozy-ui/transpiled/react/I18n'
@@ -12,6 +12,20 @@ import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoin
 import flag from 'cozy-flags'
 
 import { TrackerProvider } from 'ducks/tracking/browser'
+import JobsProvider from 'components/JobsContext'
+import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import { initTranslation } from 'cozy-ui/react/I18n'
+
+const jobsProviderOptions = t => ({
+  onSuccess: () => Alerter.success(t('JobsContext.alerter-success')),
+  onError: () => Alerter.error(t('JobsContext.alerter-errored'))
+})
+
+const initT = (lang, dictRequire) => {
+  const polyglot = initTranslation(lang, dictRequire)
+  const t = polyglot.t.bind(polyglot)
+  return { t }
+}
 
 const AppContainer = ({ store, lang, history, client }) => {
   const AppRoute = require('components/AppRoute').default
@@ -19,16 +33,24 @@ const AppContainer = ({ store, lang, history, client }) => {
     __TARGET__ === 'mobile' || flag('authentication')
       ? require('ducks/mobile/MobileRouter').default
       : require('react-router').Router
+
+  const dictRequire = lang => require(`locales/${lang}`)
+  const { t } = useMemo(() => {
+    return initT(lang, dictRequire)
+  }, [lang])
+
   return (
     <BreakpointsProvider>
       <IconSprite />
       <TrackerProvider>
         <Provider store={store}>
           <CozyProvider client={client}>
-            <I18n lang={lang} dictRequire={lang => require(`locales/${lang}`)}>
-              <MuiCozyTheme>
-                <Router history={history} routes={AppRoute()} />
-              </MuiCozyTheme>
+            <I18n lang={lang} dictRequire={dictRequire}>
+              <JobsProvider client={client} options={jobsProviderOptions(t)}>
+                <MuiCozyTheme>
+                  <Router history={history} routes={AppRoute()} />
+                </MuiCozyTheme>
+              </JobsProvider>
             </I18n>
           </CozyProvider>
         </Provider>

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -6,7 +6,7 @@ import { withRouter } from 'react-router'
 import compose from 'lodash/flowRight'
 
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
-import { Layout, Main, Content } from 'cozy-ui/transpiled/react/Layout'
+import { Content, Layout, Main } from 'cozy-ui/transpiled/react/Layout'
 import UISidebar from 'cozy-ui/transpiled/react/Sidebar'
 
 import { settingsConn } from 'doctypes'

--- a/src/components/JobsContext.jsx
+++ b/src/components/JobsContext.jsx
@@ -1,0 +1,127 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react'
+import { JOBS_DOCTYPE } from '../doctypes'
+import CozyRealtime from 'cozy-realtime'
+import logger from 'cozy-logger'
+import isFunction from 'lodash/isFunction'
+
+const log = logger.namespace('import.context')
+
+export const JobsContext = createContext({})
+
+export const useJobsContext = () => {
+  return useContext(JobsContext)
+}
+
+// @TODO add tests for JobsContext
+/** Allows to subscribe to jobs and thus to know jobs in progress
+ *
+ * @param client
+ * @param options
+ * @returns jobsInProgress
+ */
+const JobsProvider = ({ children, client, options }) => {
+  const [jobsInProgress, setJobsInProgress] = useState([])
+  const realtimeStartedRef = useRef(false)
+  const jobsInProgressRef = useRef([])
+
+  const realtime = useMemo(() => {
+    return new CozyRealtime({ client })
+  }, [client])
+
+  const handleRealtime = data => {
+    const { worker, state, message: msg } = data
+
+    // hack: Using jobsInProgressRef because jobsInProgress (from state)
+    // keep its default value
+    // The ideal would be to use only jobsInProgress and do not use the ref
+    const { current: currJobsInProgress } = jobsInProgressRef
+    const index = currJobsInProgress.findIndex(a => a.account === msg.account)
+    const exist = index !== -1
+
+    const { onSuccess, onError } = options
+    let arr = [...currJobsInProgress]
+    if (worker === 'konnector') {
+      if (state === 'running' && !exist) {
+        arr.push(msg)
+      } else if (state === 'done' && exist) {
+        arr.splice(index, 1)
+
+        if (isFunction(onSuccess)) {
+          onSuccess()
+        }
+      } else if (state === 'errored' && exist) {
+        arr.splice(index, 1)
+        if (isFunction(onError)) {
+          onError()
+        }
+      }
+      jobsInProgressRef.current = arr
+      setJobsInProgress(jobsInProgressRef.current)
+    }
+  }
+
+  const startJobsRealtime = () => {
+    if (!realtimeStartedRef.current) {
+      log('info', 'Start Jobs Realtime')
+      realtimeStartedRef.current = true
+
+      realtime.subscribe('created', JOBS_DOCTYPE, handleRealtime)
+      realtime.subscribe('updated', JOBS_DOCTYPE, handleRealtime)
+      realtime.subscribe('deleted', JOBS_DOCTYPE, handleRealtime)
+    }
+  }
+
+  const stopJobsRealtime = () => {
+    if (realtimeStartedRef.current) {
+      log('info', 'Stop Jobs Realtime')
+      realtimeStartedRef.current = false
+
+      realtime.unsubscribe('created', JOBS_DOCTYPE, handleRealtime)
+      realtime.unsubscribe('updated', JOBS_DOCTYPE, handleRealtime)
+      realtime.unsubscribe('deleted', JOBS_DOCTYPE, handleRealtime)
+    }
+  }
+
+  // @TODO useRealtime hook
+  useEffect(() => {
+    startJobsRealtime()
+    return () => stopJobsRealtime()
+  }, [])
+
+  return (
+    <JobsContext.Provider
+      value={{
+        jobsInProgress
+      }}
+    >
+      {children}
+    </JobsContext.Provider>
+  )
+}
+
+export default JobsProvider
+
+/**
+ * @function
+ * @description HOC to provide import context as prop
+ *
+ * @param  {Component} Component - wrapped component
+ * @returns {Function} - Component that will receive import context as prop
+ */
+export const withJobsInProgress = Component => {
+  const Wrapped = props => {
+    const { jobsInProgress = [] } = useJobsContext()
+    return <Component {...props} jobsInProgress={jobsInProgress} />
+  }
+  Wrapped.displayName = `withJobsInProgress(${Component.displayName ||
+    Component.name})`
+  return Wrapped
+}

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -8,6 +8,7 @@ export const TRANSACTION_DOCTYPE = 'io.cozy.bank.operations'
 export const SETTINGS_DOCTYPE = 'io.cozy.bank.settings'
 export const BILLS_DOCTYPE = 'io.cozy.bills'
 export const TRIGGER_DOCTYPE = 'io.cozy.triggers'
+export const JOBS_DOCTYPE = 'io.cozy.jobs'
 export const APP_DOCTYPE = 'io.cozy.apps'
 export const KONNECTOR_DOCTYPE = 'io.cozy.konnectors'
 export const COZY_ACCOUNT_DOCTYPE = 'io.cozy.accounts'
@@ -248,4 +249,9 @@ export const myselfConn = {
   query: () => Q('io.cozy.contacts').where({ me: true }),
   as: 'myself',
   fetchPolicy: older30s
+}
+
+export const konnectorConn = {
+  query: slug => Q(KONNECTOR_DOCTYPE).getById(`${KONNECTOR_DOCTYPE}/${slug}`),
+  as: 'konnector'
 }

--- a/src/ducks/balance/AccountRowLoading.jsx
+++ b/src/ducks/balance/AccountRowLoading.jsx
@@ -53,7 +53,7 @@ export class AccountRowLoading extends React.PureComponent {
           <Typography variant="body1">
             {isErrored
               ? t('Balance.importing-accounts-error')
-              : t('Balance.importing-accounts')}
+              : t('Balance.import-accounts')}
           </Typography>
           <Typography variant="caption">
             {isErrored ? (

--- a/src/ducks/balance/AccountRowLoading.spec.jsx
+++ b/src/ducks/balance/AccountRowLoading.spec.jsx
@@ -36,7 +36,7 @@ describe('Account Row Loading', () => {
 
   it('should progress with any status', () => {
     const { root } = setup(konnectorInfos[0])
-    expect(root.getByText('Importing accounts')).toBeTruthy()
+    expect(root.getByText('Import accounts')).toBeTruthy()
     expect(root.getByText('In progress')).toBeTruthy()
     expect(root.getByRole('progressbar')).toBeTruthy()
   })

--- a/src/ducks/balance/AccountsImporting.jsx
+++ b/src/ducks/balance/AccountsImporting.jsx
@@ -14,6 +14,8 @@ import BarTheme from 'ducks/bar/BarTheme'
 
 import headerTitleStyles from 'ducks/balance/HeaderTitle.styl'
 import styles from 'ducks/balance/AccountsImporting.styl'
+import flag from 'cozy-flags'
+import Delayed from 'components/Delayed'
 
 const muiStyles = () => ({
   linearColorPrimary: {
@@ -95,10 +97,12 @@ const AccountsImporting = ({ classes, konnectorInfos }) => {
   )
 }
 
+const groupPanelDelay = flag('balance.no-delay-groups') ? 0 : 150
+
 const ImportInProgress = ({ classes }) => {
   const { t } = useI18n()
   return (
-    <>
+    <Delayed delay={groupPanelDelay}>
       <LinearProgress
         className={styles.progress}
         classes={{
@@ -106,9 +110,9 @@ const ImportInProgress = ({ classes }) => {
           barColorPrimary: classes.linearBarColorPrimary
         }}
       />
-      <div className={styles.text}>{t('Balance.importing-accounts')}</div>
+      <div className={styles.text}>{t('Balance.import-accounts')}</div>
       <div className={styles.text}>{t('Balance.delay')}</div>
-    </>
+    </Delayed>
   )
 }
 

--- a/src/ducks/balance/AccountsImporting.spec.jsx
+++ b/src/ducks/balance/AccountsImporting.spec.jsx
@@ -45,7 +45,7 @@ describe('Importing Accounts', () => {
       konnectorInfos
     })
     expect(root.getAllByRole('progressbar').length).toEqual(3)
-    expect(root.getAllByText('Importing accounts').length).toEqual(3)
+    expect(root.getAllByText('Import accounts').length).toEqual(3)
     expect(root.getByText('This may take a few minutes…')).toBeTruthy()
   })
 
@@ -60,7 +60,7 @@ describe('Importing Accounts', () => {
     })
 
     expect(root.queryAllByRole('progressbar').length).toEqual(0)
-    expect(root.queryByText('Importing accounts')).toBeFalsy()
+    expect(root.queryByText('Import accounts')).toBeFalsy()
     expect(root.queryByText('This may take a few minutes…')).toBeFalsy()
   })
 })

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -51,6 +51,8 @@ import BarTheme from 'ducks/bar/BarTheme'
 import { filterByAccounts } from 'ducks/filters'
 import { trackPage } from 'ducks/tracking/browser'
 import { isVirtualAccount } from 'ducks/balance/helpers'
+import ImportGroupPanel from 'ducks/balance/ImportGroupPanel'
+import { withJobsInProgress } from 'components/JobsContext'
 
 const syncPouchImmediately = async client => {
   const pouchLink = client.links.find(link => link.pouches)
@@ -415,6 +417,7 @@ class Balance extends PureComponent {
             [styles.Balance__panelsContainer]: true
           })}
         >
+          <ImportGroupPanel />
           <BalancePanels
             groups={groups}
             panelsState={this.state.panels}
@@ -451,5 +454,6 @@ export default compose(
       virtualGroups: getVirtualGroups
     })
   ),
-  withClient
+  withClient,
+  withJobsInProgress
 )(Balance)

--- a/src/ducks/balance/Balance.spec.jsx
+++ b/src/ducks/balance/Balance.spec.jsx
@@ -319,7 +319,7 @@ describe('Balance page', () => {
       expect(wrapper.find(NoAccount)).toHaveLength(1)
     })
 
-    it('should show importing accounts', () => {
+    it('should show import accounts', () => {
       const triggers = [
         {
           attributes: {

--- a/src/ducks/balance/GroupPanel.jsx
+++ b/src/ducks/balance/GroupPanel.jsx
@@ -32,7 +32,7 @@ import BottomIcon from 'cozy-ui/transpiled/react/Icons/Bottom'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-const GroupPanelSummary = withStyles({
+export const GroupPanelSummary = withStyles({
   root: {
     maxHeight: '3.5rem',
     height: '3.5rem'
@@ -53,7 +53,7 @@ const GroupPanelSummary = withStyles({
   }
 })(ExpansionPanelSummary)
 
-const GroupPanelExpandIcon = React.memo(function GroupPanelExpandIcon() {
+export const GroupPanelExpandIcon = React.memo(function GroupPanelExpandIcon() {
   return (
     <Icon
       icon={BottomIcon}

--- a/src/ducks/balance/ImportGroupPanel.jsx
+++ b/src/ducks/balance/ImportGroupPanel.jsx
@@ -1,0 +1,152 @@
+import cx from 'classnames'
+import React, { useEffect, useState } from 'react'
+
+import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
+import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
+import { withStyles } from '@material-ui/core/styles'
+import ExpansionPanel from 'cozy-ui/transpiled/react/MuiCozyTheme/ExpansionPanel'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import styles from 'ducks/balance/GroupPanel.styl'
+
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { GroupPanelExpandIcon } from 'ducks/balance/GroupPanel'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import AccountIcon from 'components/AccountIcon'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { useJobsContext } from 'components/JobsContext'
+import { Q, useClient } from 'cozy-client'
+import { KONNECTOR_DOCTYPE } from 'doctypes'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+export const GroupPanelSummary = withStyles({
+  root: {
+    maxHeight: '3.5rem',
+    height: '3.5rem'
+  },
+  content: {
+    paddingLeft: '3rem',
+    paddingRight: '0',
+    height: '100%'
+  },
+  expanded: {},
+  expandIcon: {
+    left: '0.375rem',
+    right: 'auto',
+    transform: 'translateY(-50%) rotate(-90deg)',
+    '&$expanded': {
+      transform: 'translateY(-50%) rotate(0)'
+    }
+  }
+})(ExpansionPanelSummary)
+
+const EllipseTypography = withStyles({
+  root: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
+  }
+})(Typography)
+
+const ListItemTextColumn = withStyles({
+  root: {
+    flexBasis: '100%',
+    paddingRight: '1rem'
+  }
+})(ListItemText)
+
+const PrimaryColumn = withStyles({
+  root: {
+    flexBasis: '200%' // Primary column is twice as large as other columns
+  }
+})(ListItemTextColumn)
+
+const ImportGroupPanel = () => {
+  const { t } = useI18n()
+  const { jobsInProgress = [] } = useJobsContext()
+  const [expanded, setExpanded] = useState(true)
+
+  if (jobsInProgress.length === 0) {
+    return null
+  }
+
+  return (
+    <ExpansionPanel expanded={expanded} onClick={() => setExpanded(!expanded)}>
+      <GroupPanelSummary
+        expandIcon={<GroupPanelExpandIcon />}
+        IconButtonProps={{
+          disableRipple: true
+        }}
+        className={cx({
+          [styles['GroupPanelSummary--unchecked']]: false
+        })}
+      >
+        <div className={styles.GroupPanelSummary__content}>
+          <div className={styles.GroupPanelSummary__labelBalanceWrapper}>
+            <div className={styles.GroupPanelSummary__label}>
+              {t('Balance.import-accounts')}
+            </div>
+          </div>
+        </div>
+        <div className="u-flex u-flex-items-center u-mr-1">
+          <Spinner size="large" />
+        </div>
+      </GroupPanelSummary>
+      <ExpansionPanelDetails>
+        <div className="u-flex-grow-1 u-maw-100">
+          <List>
+            {jobsInProgress.map((a, i) => (
+              <Row key={i} account={a} t={t} />
+            ))}
+          </List>
+        </div>
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
+  )
+}
+
+const Row = ({ account, t }) => {
+  const slug = account.konnector
+
+  const client = useClient()
+  const [name, setName] = useState('')
+
+  useEffect(() => {
+    const slug = account.konnector
+    client
+      .query(Q(KONNECTOR_DOCTYPE).getById(`${KONNECTOR_DOCTYPE}/${slug}`))
+      .then(resp => {
+        const name = resp.data.attributes.name
+        setName(name)
+      })
+  }, [account.konnector, client])
+
+  // @TODO use 'useQuery' instead of 'client'
+  // const resp = useQuery(konnectorConn.query(slug), konnectorConn)
+  // const name = get(resp, 'data[0].attributes.name', '')
+
+  return (
+    <ListItem button disableRipple>
+      <ListItemIcon>
+        <AccountIcon
+          account={{
+            cozyMetadata: {
+              createdByApp: slug
+            }
+          }}
+        />
+      </ListItemIcon>
+      <PrimaryColumn disableTypography>
+        <EllipseTypography variant="body1" color="textPrimary">
+          {name}
+        </EllipseTypography>
+        <Typography variant="caption" color="textSecondary">
+          {t('Balance.import-in-progress')}
+        </Typography>
+      </PrimaryColumn>
+    </ListItem>
+  )
+}
+
+export default ImportGroupPanel

--- a/src/ducks/balance/ImportGroupPanel.spec.jsx
+++ b/src/ducks/balance/ImportGroupPanel.spec.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+import AppLike from 'test/AppLike'
+import ImportGroupPanel from 'ducks/balance/ImportGroupPanel'
+
+import { render } from '@testing-library/react'
+
+import { createMockClient } from 'cozy-client'
+
+describe('ImportGroupPanel', () => {
+  const setup = ({ jobsInProgress }) => {
+    const client = createMockClient({})
+
+    const root = render(
+      <AppLike client={client} jobsInProgress={jobsInProgress}>
+        <ImportGroupPanel />
+      </AppLike>
+    )
+
+    return { root }
+  }
+
+  it('should not be shown', () => {
+    const { root } = setup({})
+    expect(root.queryByText('Import in progress')).toBeNull()
+  })
+
+  // TODO
+  // it('should displays multiple konnector in progress', () => {
+  //   const jobsInProgress = [
+  //     { konnector: 'caissedepargne1', account: '1111' },
+  //     { konnector: 'caissedepargne1', account: '2222' }
+  //   ]
+  //   const { root } = setup({ jobsInProgress })
+  //
+  //   expect(root.getByText('Importing accounts')).toBeTruthy()
+  //   expect(root.getAllByText('Import in progress').length).toEqual(3)
+  // })
+})

--- a/src/ducks/balance/ImportGroupPanel.spec.jsx
+++ b/src/ducks/balance/ImportGroupPanel.spec.jsx
@@ -5,11 +5,26 @@ import ImportGroupPanel from 'ducks/balance/ImportGroupPanel'
 
 import { render } from '@testing-library/react'
 
-import { createMockClient } from 'cozy-client'
+import CozyClient from 'cozy-client'
+import CozyRealtime from 'cozy-realtime'
+
+jest.mock('cozy-realtime')
 
 describe('ImportGroupPanel', () => {
   const setup = ({ jobsInProgress }) => {
-    const client = createMockClient({})
+    const client = new CozyClient({})
+    client.query = jest.fn().mockResolvedValue({
+      data: {
+        attributes: {
+          name: ''
+        }
+      }
+    })
+
+    CozyRealtime.mockReturnValue({
+      subscribe: () => {},
+      unsubscribe: () => {}
+    })
 
     const root = render(
       <AppLike client={client} jobsInProgress={jobsInProgress}>
@@ -25,15 +40,14 @@ describe('ImportGroupPanel', () => {
     expect(root.queryByText('Import in progress')).toBeNull()
   })
 
-  // TODO
-  // it('should displays multiple konnector in progress', () => {
-  //   const jobsInProgress = [
-  //     { konnector: 'caissedepargne1', account: '1111' },
-  //     { konnector: 'caissedepargne1', account: '2222' }
-  //   ]
-  //   const { root } = setup({ jobsInProgress })
-  //
-  //   expect(root.getByText('Importing accounts')).toBeTruthy()
-  //   expect(root.getAllByText('Import in progress').length).toEqual(3)
-  // })
+  it('should displays multiple konnector in progress', () => {
+    const jobsInProgress = [
+      { konnector: 'caissedepargne1', account: '1111' },
+      { konnector: 'boursorama83', account: '2222' }
+    ]
+    const { root } = setup({ jobsInProgress })
+
+    expect(root.getByText('Import accounts')).toBeTruthy()
+    expect(root.getAllByText('Import in progress').length).toEqual(2)
+  })
 })

--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -1,0 +1,180 @@
+import React, { useCallback, useState } from 'react'
+
+import groupBy from 'lodash/groupBy'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { models } from 'cozy-client'
+import DisconnectedAccountModal from 'cozy-harvest-lib/dist/components/DisconnectedAccountModal'
+import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
+import HarvestBankAccountSettings from 'ducks/settings/HarvestBankAccountSettings'
+import { getAccountInstitutionLabel } from 'ducks/account/helpers'
+import { AccountIconContainer } from 'components/AccountIcon'
+import { Unpadded } from 'components/Padded'
+import LegalMention from 'ducks/legal/LegalMention'
+
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+const { utils } = models
+
+const AccountListItem = ({ account, onClick, secondary, isLoading }) => {
+  // Disable onClick if item is in loading
+  const onClickItem = isLoading ? null : onClick
+  return (
+    <ListItem divider onClick={onClickItem} className="u-c-pointer">
+      <ListItemIcon>
+        <AccountIconContainer>
+          <KonnectorIcon
+            style={{ width: 16, height: 16 }}
+            konnectorSlug={
+              account.cozyMetadata ? account.cozyMetadata.createdByApp : null
+            }
+          />
+        </AccountIconContainer>
+      </ListItemIcon>
+      <ListItemText
+        primary={getAccountInstitutionLabel(account)}
+        secondary={secondary}
+      />
+      <ListItemSecondaryAction>
+        {isLoading ? (
+          <Spinner size="large" className="u-mr-1" />
+        ) : (
+          <Icon icon={RightIcon} className="u-coolGrey u-mr-1" />
+        )}
+      </ListItemSecondaryAction>
+    </ListItem>
+  )
+}
+
+/**
+ * Returns the connection id of an account
+ *
+ * To achieve backward compatibility of the UI when accounts
+ * are not connected to any io.cozy.accounts (since banking
+ * connectors historically did not store the io.cozy.accounts
+ * in the io.cozy.bank.accounts), the connectionId
+ * that is assumed for bank accounts that have not been connected
+ * is the konnector slug. This means that every account for
+ * a given konnector will be regrouped (instead of being grouped
+ * by io.cozy.accounts).
+ */
+const getConnectionIdFromAccount = account => {
+  return account.connection && account.connection.raw
+    ? account.connection.raw._id
+    : utils.getCreatedByApp(account)
+}
+
+const transformJobsToFakeAccounts = jobsInProgress => {
+  const jobsInAccounts = jobsInProgress.map(j => ({
+    inProgress: true,
+    connection: {
+      raw: {
+        _id: j.account
+      },
+      data: j.account
+    },
+    connectionId: j.account,
+    cozyMetadata: {
+      createdByApp: j.konnector
+    }
+  }))
+  return jobsInAccounts
+}
+
+const AccountsListSettings = ({
+  accounts: myAccounts = [],
+  jobsInProgress
+}) => {
+  const { t } = useI18n()
+
+  const accounts = [...myAccounts].concat(
+    transformJobsToFakeAccounts(jobsInProgress)
+  )
+
+  const connectionGroups = Object.values(
+    groupBy(accounts, acc => getConnectionIdFromAccount(acc))
+  ).map(accounts => ({
+    accounts,
+    connection: accounts[0].connection.data,
+    connectionId: getConnectionIdFromAccount(accounts[0])
+  }))
+
+  // Depending on whether the bank account is still connected to an
+  // io.cozy.accounts, we will either show the AccountModal or the
+  // DisconnectedAccountModal
+  const [editionModalOptions, setEditionModalOptions] = useState(null)
+
+  const secondary = useCallback(
+    (connection, isLoading) => {
+      if (connection) {
+        if (isLoading) {
+          return t('Settings.accounts-tab.import-in-progress')
+        }
+        return connection.auth.identifier
+      } else {
+        return (
+          <>
+            <Icon icon={UnlinkIcon} size="8" className="u-mr-half" />
+            {t('Harvest.disconnected-account')}
+          </>
+        )
+      }
+    },
+    [t]
+  )
+
+  return (
+    <Unpadded horizontal className={LegalMention.active ? 'u-mv-1' : 'u-mb-1'}>
+      {/* Bank accounts still connected to io.cozy.accounts */}
+      <List>
+        {connectionGroups.map(({ accounts, connection, connectionId }) => {
+          const isLoading =
+            jobsInProgress.some(j => j.account === connectionId) ||
+            accounts[0].inProgress
+
+          return (
+            <AccountListItem
+              key={accounts[0]._id}
+              account={accounts[0]}
+              secondary={secondary(connection, isLoading)}
+              onClick={() => {
+                return setEditionModalOptions({
+                  connection: connection,
+                  connectionId: connectionId
+                })
+              }}
+              isLoading={isLoading}
+            />
+          )
+        })}
+      </List>
+      {editionModalOptions ? (
+        editionModalOptions.connection ? (
+          <HarvestBankAccountSettings
+            connectionId={editionModalOptions.connection._id}
+            onDismiss={() => setEditionModalOptions(null)}
+          />
+        ) : (
+          <DisconnectedAccountModal
+            onClose={() => setEditionModalOptions(null)}
+            accounts={accounts.filter(
+              acc =>
+                getConnectionIdFromAccount(acc) ===
+                editionModalOptions.connectionId
+            )}
+          />
+        )
+      ) : null}
+    </Unpadded>
+  )
+}
+
+export default AccountsListSettings

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
@@ -6,150 +6,29 @@ import sortBy from 'lodash/sortBy'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
-import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
-import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
-import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
-import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
-import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
 import {
-  queryConnect,
-  Q,
-  isQueryLoading,
   hasQueryBeenLoaded,
-  models
+  isQueryLoading,
+  Q,
+  queryConnect
 } from 'cozy-client'
-import DisconnectedAccountModal from 'cozy-harvest-lib/dist/components/DisconnectedAccountModal'
-import KonnectorIcon from 'cozy-harvest-lib/dist/components/KonnectorIcon'
 
 import Loading from 'components/Loading'
 
 import AddAccountLink from 'ducks/settings/AddAccountLink'
-import HarvestBankAccountSettings from 'ducks/settings/HarvestBankAccountSettings'
-import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { useTrackPage } from 'ducks/tracking/browser'
 
 import { accountsConn, APP_DOCTYPE } from 'doctypes'
-import { AccountIconContainer } from 'components/AccountIcon'
-import { Unpadded } from 'components/Padded'
-import LegalMention from 'ducks/legal/LegalMention'
-
-import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
-import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
-
-const { utils } = models
-
-const AccountListItem = ({ account, onClick, secondary }) => {
-  return (
-    <ListItem divider onClick={onClick} className="u-c-pointer">
-      <ListItemIcon>
-        <AccountIconContainer>
-          <KonnectorIcon
-            style={{ width: 16, height: 16 }}
-            konnectorSlug={
-              account.cozyMetadata ? account.cozyMetadata.createdByApp : null
-            }
-          />
-        </AccountIconContainer>
-      </ListItemIcon>
-      <ListItemText
-        primary={getAccountInstitutionLabel(account)}
-        secondary={secondary}
-      />
-      <ListItemSecondaryAction>
-        <Icon icon={RightIcon} className="u-coolGrey u-mr-1" />
-      </ListItemSecondaryAction>
-    </ListItem>
-  )
-}
-
-/**
- * Returns the connection id of an account
- *
- * To achieve backward compatibility of the UI when accounts
- * are not connected to any io.cozy.accounts (since banking
- * connectors historically did not store the io.cozy.accounts
- * in the io.cozy.bank.accounts), the connectionId
- * that is assumed for bank accounts that have not been connected
- * is the konnector slug. This means that every account for
- * a given konnector will be regrouped (instead of being grouped
- * by io.cozy.accounts).
- */
-const getConnectionIdFromAccount = account => {
-  return account.connection && account.connection.raw
-    ? account.connection.raw._id
-    : utils.getCreatedByApp(account)
-}
-
-export const AccountsList = ({ accounts }) => {
-  const { t } = useI18n()
-
-  const connectionGroups = Object.values(
-    groupBy(accounts, acc => getConnectionIdFromAccount(acc))
-  ).map(accounts => ({
-    accounts,
-    connection: accounts[0].connection.data,
-    connectionId: getConnectionIdFromAccount(accounts[0])
-  }))
-
-  // Depending on whether the bank account is still connected to an
-  // io.cozy.accounts, we will either show the AccountModal or the
-  // DisconnectedAccountModal
-  const [editionModalOptions, setEditionModalOptions] = useState(null)
-
-  return (
-    <Unpadded horizontal className={LegalMention.active ? 'u-mv-1' : 'u-mb-1'}>
-      {/* Bank accounts still connected to io.cozy.accounts */}
-      <List>
-        {connectionGroups.map(({ accounts, connection, connectionId }) => (
-          <AccountListItem
-            key={accounts[0]._id}
-            account={accounts[0]}
-            secondary={
-              connection ? (
-                connection.auth.identifier
-              ) : (
-                <>
-                  <Icon icon={UnlinkIcon} size="8" className="u-mr-half" />
-                  {t('Harvest.disconnected-account')}
-                </>
-              )
-            }
-            onClick={() => {
-              return setEditionModalOptions({
-                connection: connection,
-                connectionId: connectionId
-              })
-            }}
-          />
-        ))}
-      </List>
-      {editionModalOptions ? (
-        editionModalOptions.connection ? (
-          <HarvestBankAccountSettings
-            connectionId={editionModalOptions.connection._id}
-            onDismiss={() => setEditionModalOptions(null)}
-          />
-        ) : (
-          <DisconnectedAccountModal
-            onClose={() => setEditionModalOptions(null)}
-            accounts={accounts.filter(
-              acc =>
-                getConnectionIdFromAccount(acc) ===
-                editionModalOptions.connectionId
-            )}
-          />
-        )
-      ) : null}
-    </Unpadded>
-  )
-}
+import { useJobsContext } from 'components/JobsContext'
+import AccountsListSettings from 'ducks/settings/AccountsListSettings'
 
 const AccountsSettings = props => {
   const { t } = useI18n()
   useTrackPage('parametres:comptes')
 
   const { accountsCollection } = props
+  const { jobsInProgress = [] } = useJobsContext()
 
   if (
     isQueryLoading(accountsCollection) &&
@@ -170,8 +49,12 @@ const AccountsSettings = props => {
 
   return (
     <>
-      {myAccounts ? (
-        <AccountsList accounts={myAccounts} t={t} />
+      {myAccounts || jobsInProgress.length > 0 ? (
+        <AccountsListSettings
+          accounts={myAccounts}
+          jobsInProgress={jobsInProgress}
+          t={t}
+        />
       ) : (
         <p>{t('Accounts.no-accounts')}</p>
       )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,7 +71,7 @@
       "unknown": "NC"
     },
     "delay": "This may take a few minutes…",
-    "importing-accounts": "Importing accounts",
+    "import-accounts": "Import accounts",
     "importing-accounts-error": "Failed to import",
     "in-progress": "In progress",
     "error": "Click to restart",
@@ -80,7 +80,8 @@
       "description": "You don't have any accounts associated to this group.",
       "button": "Edit the group"
     },
-    "reimbursements-caption": "Last 6 months"
+    "reimbursements-caption": "Last 6 months",
+    "import-in-progress": "Import in progress"
   },
 
   "SelectDates": {
@@ -560,6 +561,9 @@
         "all-category": "All « %{categoryName} »",
         "cancel": "Cancel"
       }
+    },
+    "accounts-tab": {
+      "import-in-progress": "Import in progress"
     }
   },
 
@@ -877,5 +881,10 @@
     "30-day-balance": "30-day balance",
     "page-title": "Planned transactions",
     "numberEstimatedTransactions": "%{smart_count} planned transaction |||| %{smart_count} planned transactions"
+  },
+
+  "JobsContext": {
+    "alerter-success": "Connector import successful",
+    "alerter-errored": "An error occurred during the import"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -88,7 +88,7 @@
       "unknown": "NC"
     },
     "delay": "Cela peut prendre quelques minutes…",
-    "importing-accounts": "Importation des comptes",
+    "import-accounts": "Import des comptes",
     "importing-accounts-error": "Échec de l'import",
     "in-progress": "En cours",
     "error": "Cliquez pour relancer",
@@ -97,7 +97,8 @@
       "description": "Vous n'avez pas de compte associé à ce groupe.",
       "button": "Éditer le groupe"
     },
-    "reimbursements-caption": "6 derniers mois"
+    "reimbursements-caption": "6 derniers mois",
+    "import-in-progress": "Import en cours"
   },
 
   "Transactions": {
@@ -561,6 +562,9 @@
         "all-category": "Tout « %{categoryName} »",
         "cancel": "Annuler"
       }
+    },
+    "accounts-tab": {
+      "import-in-progress": "Import en cours"
     }
   },
 
@@ -878,5 +882,10 @@
     "30-day-balance": "Solde à 30 jours",
     "page-title": "Dépenses prévues",
     "numberEstimatedTransactions": "%{smart_count} opération prévue |||| %{smart_count} opérations prévues"
+  },
+
+  "JobsContext": {
+    "alerter-success": "Import du connecteur réussi",
+    "alerter-errored": "Une erreur s'est produite lors de l'import"
   }
 }

--- a/test/AppLike.jsx
+++ b/test/AppLike.jsx
@@ -8,6 +8,7 @@ import getClient from 'test/client'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import RouterContext from 'components/RouterContext'
 import { TrackerProvider } from 'ducks/tracking/browser'
+import { JobsContext } from '../src/components/JobsContext'
 
 export const TestI18n = ({ children }) => {
   return (
@@ -17,19 +18,23 @@ export const TestI18n = ({ children }) => {
   )
 }
 
-const AppLike = ({ children, store, client, router }) => (
-  <TrackerProvider>
-    <RouterContext.Provider value={router}>
-      <BreakpointsProvider>
-        <Provider store={(client && client.store) || store}>
-          <CozyProvider client={client || getClient()}>
-            <TestI18n>{children}</TestI18n>
-          </CozyProvider>
-        </Provider>
-      </BreakpointsProvider>
-    </RouterContext.Provider>
-  </TrackerProvider>
-)
+const AppLike = ({ children, store, client, router, jobsInProgress }) => {
+  return (
+    <TrackerProvider>
+      <RouterContext.Provider value={router}>
+        <BreakpointsProvider>
+          <Provider store={(client && client.store) || store}>
+            <CozyProvider client={client || getClient()}>
+              <JobsContext.Provider value={{ jobsInProgress }}>
+                <TestI18n>{children}</TestI18n>
+              </JobsContext.Provider>
+            </CozyProvider>
+          </Provider>
+        </BreakpointsProvider>
+      </RouterContext.Provider>
+    </TrackerProvider>
+  )
+}
 
 AppLike.defaultProps = {
   store


### PR DESCRIPTION
We want to view when an account import is in
progress on the balance page and in the settings
page. For that we activate the realtime on the jobs
when we are on one of these 2 pages otherwise we
stop it. We also want to display a notification to
the user whether it went correctly or not.