### PR TITLE
fix: Blank page when coming from notif to /balance/<account>/details

### DIFF
--- a/src/ducks/balance/SetFilterAndRedirect.jsx
+++ b/src/ducks/balance/SetFilterAndRedirect.jsx
@@ -16,56 +16,43 @@ import { filterByDoc } from 'ducks/filters'
  * - Sets filter doc accordingly
  * - Redirects to the right page
  */
-const mkSetFilterAndRedirect = () =>
-  function SetFilterAndRedirect() {
-    const router = useRouter()
-    const params = useParams()
-    const dispatch = useDispatch()
-    const accounts = useQuery(accountsConn.query, accountsConn)
-    const groups = useQuery(groupsConn.query, groupsConn)
-    useEffect(() => {
-      if (
-        accounts.fetchStatus === 'loading' ||
-        groups.fetchStatus === 'loading'
-      ) {
-        return
-      } else {
-        const docId = params.accountOrGroupId
-        const account =
-          accounts.data && accounts.data.find(x => x._id === docId)
-        if (account) {
-          dispatch(filterByDoc({ _type: ACCOUNT_DOCTYPE, _id: account._id }))
-          router.push(`/balances/${params.page}`)
-          return
-        }
+const SetFilterAndRedirect = () => {
+  const router = useRouter()
+  const params = useParams()
+  const dispatch = useDispatch()
+  const accounts = useQuery(accountsConn.query, accountsConn)
+  const groups = useQuery(groupsConn.query, groupsConn)
 
-        const group = groups.data && groups.data.find(x => x._id === docId)
-        if (group) {
-          dispatch(filterByDoc({ _type: GROUP_DOCTYPE, _id: account._id }))
-          router.push(`/balances/${params.page}`)
-          return
-        }
-
-        // eslint-disable-next-line no-console
-        console.warn(`Unknown account or group with id ${docId}`)
-        router.push(params.page)
-      }
-    }, [
-      accounts,
-      dispatch,
-      groups,
-      params.accountOrGroupId,
-      params.page,
-      router
-    ])
-
+  useEffect(() => {
     if (
       accounts.fetchStatus === 'loading' ||
       groups.fetchStatus === 'loading'
     ) {
-      return <Loading />
-    }
-    return null
-  }
+      return
+    } else {
+      const docId = params.accountOrGroupId
+      const account = accounts.data && accounts.data.find(x => x._id === docId)
+      if (account) {
+        dispatch(filterByDoc({ _type: ACCOUNT_DOCTYPE, _id: account._id }))
+        router.push(`/balances/${params.page}`)
+        return
+      }
 
-export default mkSetFilterAndRedirect
+      const group = groups.data && groups.data.find(x => x._id === docId)
+      if (group) {
+        dispatch(filterByDoc({ _type: GROUP_DOCTYPE, _id: group._id }))
+        router.push(`/balances/${params.page}`)
+        return
+      }
+
+      router.push(`/balances`)
+    }
+  }, [accounts, groups]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (accounts.fetchStatus === 'loading' || groups.fetchStatus === 'loading') {
+    return <Loading />
+  }
+  return null
+}
+
+export default SetFilterAndRedirect

--- a/src/ducks/balance/SetFilterAndRedirect.spec.jsx
+++ b/src/ducks/balance/SetFilterAndRedirect.spec.jsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { Provider as ReduxProvider, useDispatch } from 'react-redux'
+import { CozyProvider } from 'cozy-client'
+import { createMockClient } from 'cozy-client/dist/mock'
+import { render } from '@testing-library/react'
+
+import { useParams, useRouter } from 'components/RouterContext'
+import SetFilterAndRedirect from './SetFilterAndRedirect'
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn()
+}))
+
+jest.mock('components/RouterContext', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn()
+}))
+
+beforeEach(() => {
+  useDispatch.mockReset()
+  useParams.mockReset()
+  useRouter.mockReset()
+})
+
+describe('SetFilterAndRedirect', () => {
+  const setup = ({ params }) => {
+    const router = { push: jest.fn() }
+    const dispatch = jest.fn()
+    useDispatch.mockReturnValue(dispatch)
+    useRouter.mockReturnValue(router)
+    useParams.mockReturnValue(params)
+    const client = createMockClient({
+      queries: {
+        accounts: {
+          doctype: 'io.cozy.bank.accounts',
+          data: [{ _id: 'account-1' }]
+        },
+        groups: {
+          doctype: 'io.cozy.bank.groups',
+          data: [{ _id: 'group-1' }]
+        }
+      }
+    })
+    const root = render(
+      <CozyProvider client={client}>
+        <ReduxProvider store={client.store}>
+          <SetFilterAndRedirect />
+        </ReduxProvider>
+      </CozyProvider>
+    )
+    return { root, router, dispatch }
+  }
+
+  it('should redirect to an existing account and set the filter', () => {
+    const { router, dispatch } = setup({
+      params: {
+        accountOrGroupId: 'account-1',
+        page: 'details'
+      }
+    })
+    expect(router.push).toHaveBeenCalledWith(`/balances/details`)
+    expect(dispatch).toHaveBeenCalledWith({
+      doc: {
+        _id: 'account-1',
+        _type: 'io.cozy.bank.accounts'
+      },
+      type: 'FILTER_BY_DOC'
+    })
+  })
+
+  it('should redirect to an existing group and set the filter', () => {
+    const { router, dispatch } = setup({
+      params: {
+        accountOrGroupId: 'group-1',
+        page: 'details'
+      }
+    })
+    expect(router.push).toHaveBeenCalledWith(`/balances/details`)
+    expect(dispatch).toHaveBeenCalledWith({
+      doc: {
+        _id: 'group-1',
+        _type: 'io.cozy.bank.groups'
+      },
+      type: 'FILTER_BY_DOC'
+    })
+  })
+
+  it('should redirect to balances if account/group does not exist', () => {
+    const { router, dispatch } = setup({
+      params: {
+        accountOrGroupId: 'unexisting-group-id',
+        page: 'details'
+      }
+    })
+    expect(router.push).toHaveBeenCalledWith(`/balances`)
+    expect(dispatch).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The SetFilterAndRedirect is used when a user comes from a notification
with a `/balances/<accountId>/details` route. Its role is to set the
`filter` inside redux and then to redirect to the "normal" `/balances/details`
route.

It seems there was a typo or a bad refactor at some point since the routes
file was using a component constructor function instead of the component:
when this route was matched, a blank page was shown to the user.

- Export a component, not a component constructor
- Added tests