### PR TITLE
fix: Handle message only if there is an account

### DIFF
--- a/src/components/JobsContext.jsx
+++ b/src/components/JobsContext.jsx
@@ -47,8 +47,9 @@ const JobsProvider = ({ children, client, options }) => {
     const exist = index !== -1
 
     const { onSuccess, onError } = options
+    const hasAccount = msg.account
     let arr = [...currJobsInProgress]
-    if (worker === 'konnector') {
+    if (worker === 'konnector' && hasAccount) {
       if (state === 'running' && !exist) {
         arr.push(msg)
       } else if (state === 'done' && exist) {


### PR DESCRIPTION
There is a toast when we try to connect with bad credentials
on boursorama konnector.