### PR TITLE
feat: Add flag to hide close button

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "cozy-realtime": "3.11.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "19.1.0",
-    "cozy-ui": "45.5.0",
+    "cozy-ui": "46.0.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/transactions/FileOpener.jsx
+++ b/src/ducks/transactions/FileOpener.jsx
@@ -2,8 +2,8 @@
 
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-
 import { withClient } from 'cozy-client'
+import flag from 'cozy-flags'
 import IntentDialogOpener from 'cozy-ui/transpiled/react/IntentDialogOpener'
 
 import { checkApp, DRIVE_INFO } from 'ducks/mobile/appAvailability'
@@ -58,7 +58,9 @@ class FileOpener extends Component {
     return (
       <IntentDialogOpener
         fullScreen
-        showCloseButton={false}
+        showCloseButton={
+          flag('banks.file-opener.hide-close-button') ? false : true
+        }
         action="OPEN"
         create={createIntent}
         doctype="io.cozy.files"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5288,10 +5288,10 @@ cozy-ui@40.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@45.5.0:
-  version "45.5.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-45.5.0.tgz#1c8ead05e514ab996c80921df1c7b53cfda0fb91"
-  integrity sha512-m/BYLrwQB6I11drZ3nAic+8ZRldca8EoWwA/EK+AdP3OHF+anSgDfI3UDujC2HUdHq45ja7PX38C2puHxW+Ofw==
+cozy-ui@46.0.0:
+  version "46.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-46.0.0.tgz#2655c5c53f913857139a18add2f6c68fac8b5814"
+  integrity sha512-YEzfR6+QB4kyV2qPpkVf+zD1I3PL3qbsashwdE+CPoFs295T1O/8HbWKcCoBiHPMgTRC+99DZ/6P9ZlYReWNcg==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
This is necessary due to a circular dep between drive and banks. With
previous drive, back arrow at the top left of the viewer does not work. So
we will use the cross button of the dialog to close it. When drive has been
published, we will set the flag to true in production so that the cross is
hidden

I am merging as soon as this is green since it is very small.