### PR TITLE
fix: Specify index fields otherwise wrong index is chosen

### DIFF
--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -306,7 +306,9 @@ const BundleInfo = ({ bundle }) => {
         <>
           <Padded>
             <Media>
-              <Bd>
+              {/* Bd has overflow:hidden and it crops the hover circle from the Breadcrumbs
+	          IconButton, this is why we have to add u-ov-visible. */}
+              <Bd className="u-ov-visible">
                 <Typography variant="h5">
                   <Breadcrumbs
                     items={[

--- a/src/ducks/recurrence/queries.js
+++ b/src/ducks/recurrence/queries.js
@@ -20,6 +20,7 @@ export const bundleTransactionsQueryConn = ({ bundle }) => {
     query: () => {
       const initialQDef = queryRecurrenceTransactions(bundle)
       const qDef = initialQDef
+        .indexFields(['relationships.recurrence.data._id', 'date'])
         .sortBy([
           { 'relationships.recurrence.data._id': 'desc' },
           { date: 'desc' }


### PR DESCRIPTION
Due to https://github.com/cozy/cozy-client/issues/903, we have
to manually specify the index fields.