### PR TITLE
feat: Add devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "react-dom": "16.9.0",
     "react-fastclick": "^3.0.2",
     "react-hint": "3.2.0",
+    "react-inspector": "^5.1.0",
     "react-markdown": "4.2.2",
     "react-redux": "7.2.0",
     "react-router": "3.2.4",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -22,6 +22,9 @@ import RouterContext from 'components/RouterContext'
 import AppSearchBar from 'components/AppSearchBar'
 import useKeyboardState from 'components/useKeyboardState'
 
+import CozyDevTools from 'ducks/devtools'
+import banksPanels from 'ducks/devtools/banksPanels'
+
 import styles from './App.styl'
 
 const KeyboardAwareSidebar = ({ children }) => {
@@ -55,6 +58,7 @@ const App = props => {
         <Warnings />
         <Alerter />
       </Layout>
+      {flag('debug') ? <CozyDevTools panels={banksPanels} /> : null}
     </RouterContext.Provider>
   )
 }

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -10,8 +10,7 @@ import {
   GroupsSettings,
   GroupSettings,
   NewGroupSettings,
-  Configuration,
-  Debug
+  Configuration
 } from 'ducks/settings'
 import { Balance, BalanceDetailsPage } from 'ducks/balance'
 import {
@@ -89,7 +88,6 @@ const AppRoute = () => (
           <Route path="accounts" component={AccountsSettings} />
           <Route path="groups" component={GroupsSettings} />
           <Route path="configuration" component={Configuration} />
-          <Route path="debug" component={Debug} />
         </Route>
       </Route>
       <Route path="transfers" component={scrollToTopOnMount(TransferPage)} />

--- a/src/components/__snapshots__/AppRoute.spec.jsx.snap
+++ b/src/components/__snapshots__/AppRoute.spec.jsx.snap
@@ -110,10 +110,6 @@ exports[`App route should be a function returning a route 1`] = `
           component={[Function]}
           path="configuration"
         />
-        <Route
-          component={[Function]}
-          path="debug"
-        />
       </Route>
     </Route>
     <Route
@@ -249,10 +245,6 @@ exports[`App route should have renderExtraRoutes 1`] = `
         <Route
           component={[Function]}
           path="configuration"
-        />
-        <Route
-          component={[Function]}
-          path="debug"
         />
       </Route>
     </Route>

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useCallback } from 'react'
 import sortBy from 'lodash/sortBy'
 import overEvery from 'lodash/overEvery'
 import get from 'lodash/get'
+
 import Grid from '@material-ui/core/Grid'
 import Box from '@material-ui/core/Box'
 import Table from '@material-ui/core/Table'
@@ -25,7 +26,7 @@ import { NavSecondaryAction, ListGridItem } from './common'
 const styles = {
   panelRight: { height: '100%', overflow: 'scroll', flexGrow: 1 },
   mono: { fontFamily: 'monospace' },
-  input: { width: 400 },
+  input: { width: 400 }
 }
 
 const TableCell = withStyles({
@@ -185,14 +186,13 @@ const QueryListItem = ({ name, selected, onClick }) => {
 }
 const QueryPanels = () => {
   const queries = useSelector(state => state.cozy.queries)
-  const [selectedQuery, setSelectedQuery] = useState(
-    () => Object.keys(queries)[0]
-  )
   const sortedQueries = useMemo(() => {
     return sortBy(Object.values(queries), queryState => queryState.lastUpdate)
       .map(queryState => queryState.id)
       .reverse()
   }, [queries])
+
+  const [selectedQuery, setSelectedQuery] = useState(() => sortedQueries[0])
 
   return (
     <>

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -39,7 +39,7 @@ const FetchStatus = ({ fetchStatus }) => {
   return (
     <span
       className={
-        fetchStatus == 'loaded'
+        fetchStatus === 'loaded'
           ? 'u-valid'
           : fetchStatus === 'pending'
           ? 'u-warn'

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useCallback } from 'react'
 import sortBy from 'lodash/sortBy'
 import Grid from '@material-ui/core/Grid'
 import Box from '@material-ui/core/Box'
@@ -9,7 +9,7 @@ import ListItem from 'cozy-ui/transpiled/react/ListItem'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { useSelector } from 'react-redux'
 import format from 'date-fns/format'
-import Inspector from 'react-inspector'
+import { TableInspector, ObjectInspector } from 'react-inspector'
 
 import { NavSecondaryAction, ListGridItem } from './common'
 
@@ -38,13 +38,28 @@ const FetchStatus = ({ fetchStatus }) => {
 
 const QueryData = ({ data, doctype }) => {
   const client = useClient()
-
+  const [showTable, setShowTable] = useState(false)
   const documents = useSelector(state => state.cozy.documents[doctype])
 
   const storeData = useMemo(() => {
     return data.map(id => client.hydrateDocument(documents[id]))
   }, [client, data, documents])
-  return <Inspector data={storeData} />
+
+  const handleShowTable = useCallback(() => setShowTable(value => !value), [
+    setShowTable
+  ])
+  return (
+    <>
+      Table:{' '}
+      <input type="checkbox" onClick={handleShowTable} checked={showTable} />
+      <br />
+      {showTable ? (
+        <TableInspector data={storeData} />
+      ) : (
+        <ObjectInspector data={storeData} />
+      )}
+    </>
+  )
 }
 
 const QueryState = ({ name }) => {

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -4,6 +4,13 @@ import overEvery from 'lodash/overEvery'
 import get from 'lodash/get'
 import Grid from '@material-ui/core/Grid'
 import Box from '@material-ui/core/Box'
+import Table from '@material-ui/core/Table'
+import TableBody from '@material-ui/core/TableBody'
+import MuiTableCell from '@material-ui/core/TableCell'
+import TableContainer from '@material-ui/core/TableContainer'
+import TableRow from '@material-ui/core/TableRow'
+import Paper from '@material-ui/core/Paper'
+import { withStyles } from '@material-ui/core/styles'
 
 import { useClient } from 'cozy-client'
 import Typography from 'cozy-ui/transpiled/react/Typography'
@@ -20,6 +27,12 @@ const styles = {
   mono: { fontFamily: 'monospace' },
   input: { width: 400 },
 }
+
+const TableCell = withStyles({
+  root: {
+    fontFamily: 'inherit'
+  }
+})(MuiTableCell)
 
 const FetchStatus = ({ fetchStatus }) => {
   return (
@@ -122,32 +135,36 @@ const QueryState = ({ name }) => {
   }, [queryState])
   return (
     <>
-      <table style={styles.mono}>
-        <tr>
-          <td>doctype</td>
-          <td>{queryState.definition.doctype}</td>
-        </tr>
-        <tr>
-          <td>fetchStatus</td>
-          <td>
-            <FetchStatus fetchStatus={queryState.fetchStatus} />
-          </td>
-        </tr>
-        <tr>
-          <td>lastFetch</td>
-          <td>{format(lastFetch, 'HH:mm:ss')}</td>
-        </tr>
-        <tr>
-          <td>lastUpdate</td>
-          <td>{format(lastUpdate, 'HH:mm:ss')}</td>
-        </tr>
-        <tr>
-          <td>documents</td>
-          <td>
-            {data && data.length !== undefined ? data.length : data ? 1 : 0}
-          </td>
-        </tr>
-      </table>
+      <TableContainer component={Paper} elevation={0}>
+        <Table style={styles.mono} size="small" className="u-w-auto">
+          <TableBody>
+            <TableRow>
+              <TableCell>doctype</TableCell>
+              <TableCell>{queryState.definition.doctype}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>fetchStatus</TableCell>
+              <TableCell>
+                <FetchStatus fetchStatus={queryState.fetchStatus} />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>lastFetch</TableCell>
+              <TableCell>{format(lastFetch, 'HH:mm:ss')}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>lastUpdate</TableCell>
+              <TableCell>{format(lastUpdate, 'HH:mm:ss')}</TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>documents</TableCell>
+              <TableCell>
+                {data && data.length !== undefined ? data.length : data ? 1 : 0}
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
       <QueryData data={data} doctype={queryState.definition.doctype} />
     </>
   )

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -17,7 +17,8 @@ import { NavSecondaryAction, ListGridItem } from './common'
 
 const styles = {
   panelRight: { height: '100%', overflow: 'scroll', flexGrow: 1 },
-  mono: { fontFamily: 'monospace' }
+  mono: { fontFamily: 'monospace' },
+  input: { width: 400 },
 }
 
 const FetchStatus = ({ fetchStatus }) => {
@@ -92,7 +93,14 @@ const QueryData = ({ data, doctype }) => {
       Table:{' '}
       <input type="checkbox" onClick={handleShowTable} checked={showTable} />
       <br />
-      Search: <input type="text" onChange={handleSearch} value={search} />
+      Search:{' '}
+      <input
+        type="text"
+        placeholder="field.nested_field:value;other_field:other_value"
+        onChange={handleSearch}
+        value={search}
+        style={styles.input}
+      />
       <br />
       {showTable ? (
         <TableInspector data={viewData} />

--- a/src/ducks/devtools/Queries.jsx
+++ b/src/ducks/devtools/Queries.jsx
@@ -1,0 +1,140 @@
+import React, { useState, useMemo } from 'react'
+import sortBy from 'lodash/sortBy'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box'
+
+import { useClient } from 'cozy-client'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import ListItem from 'cozy-ui/transpiled/react/ListItem'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import { useSelector } from 'react-redux'
+import format from 'date-fns/format'
+import Inspector from 'react-inspector'
+
+import { NavSecondaryAction, ListGridItem } from './common'
+
+const styles = {
+  panelRight: { height: '100%', overflow: 'scroll', flexGrow: 1 },
+  mono: { fontFamily: 'monospace' }
+}
+
+const FetchStatus = ({ fetchStatus }) => {
+  return (
+    <span
+      className={
+        fetchStatus == 'loaded'
+          ? 'u-valid'
+          : fetchStatus === 'pending'
+          ? 'u-warn'
+          : fetchStatus === 'error'
+          ? 'u-error'
+          : ''
+      }
+    >
+      {fetchStatus}
+    </span>
+  )
+}
+
+const QueryData = ({ data, doctype }) => {
+  const client = useClient()
+
+  const documents = useSelector(state => state.cozy.documents[doctype])
+
+  const storeData = useMemo(() => {
+    return data.map(id => client.hydrateDocument(documents[id]))
+  }, [client, data, documents])
+  return <Inspector data={storeData} />
+}
+
+const QueryState = ({ name }) => {
+  const queryState = useSelector(state => state.cozy.queries[name])
+  const { data } = queryState
+  const { lastFetch, lastUpdate } = useMemo(() => {
+    return {
+      lastFetch: new Date(queryState.lastFetch),
+      lastUpdate: new Date(queryState.lastUpdate)
+    }
+  }, [queryState])
+  return (
+    <>
+      <table style={styles.mono}>
+        <tr>
+          <td>doctype</td>
+          <td>{queryState.definition.doctype}</td>
+        </tr>
+        <tr>
+          <td>fetchStatus</td>
+          <td>
+            <FetchStatus fetchStatus={queryState.fetchStatus} />
+          </td>
+        </tr>
+        <tr>
+          <td>lastFetch</td>
+          <td>{format(lastFetch, 'HH:mm:ss')}</td>
+        </tr>
+        <tr>
+          <td>lastUpdate</td>
+          <td>{format(lastUpdate, 'HH:mm:ss')}</td>
+        </tr>
+        <tr>
+          <td>documents</td>
+          <td>
+            {data && data.length !== undefined ? data.length : data ? 1 : 0}
+          </td>
+        </tr>
+      </table>
+      <QueryData data={data} doctype={queryState.definition.doctype} />
+    </>
+  )
+}
+const QueryListItem = ({ name, selected, onClick }) => {
+  const queryState = useSelector(state => state.cozy.queries[name])
+  const lastUpdate = useMemo(
+    () => format(new Date(queryState.lastUpdate), 'HH:mm:ss'),
+    [queryState]
+  )
+
+  return (
+    <ListItem dense button selected={selected} onClick={onClick}>
+      <ListItemText primary={name} secondary={lastUpdate} />
+      <NavSecondaryAction />
+    </ListItem>
+  )
+}
+const QueryPanels = () => {
+  const queries = useSelector(state => state.cozy.queries)
+  const [selectedQuery, setSelectedQuery] = useState(
+    () => Object.keys(queries)[0]
+  )
+  const sortedQueries = useMemo(() => {
+    return sortBy(Object.values(queries), queryState => queryState.lastUpdate)
+      .map(queryState => queryState.id)
+      .reverse()
+  }, [queries])
+
+  return (
+    <>
+      <ListGridItem>
+        {sortedQueries.map(queryName => {
+          return (
+            <QueryListItem
+              name={queryName}
+              key={queryName}
+              onClick={() => setSelectedQuery(queryName)}
+              selected={name === selectedQuery}
+            />
+          )
+        })}
+      </ListGridItem>
+      <Box clone p={1}>
+        <Grid item style={styles.panelRight}>
+          <Typography variant="subtitle1">{selectedQuery}</Typography>
+          {selectedQuery ? <QueryState name={selectedQuery} /> : null}
+        </Grid>
+      </Box>
+    </>
+  )
+}
+
+export default QueryPanels

--- a/src/ducks/devtools/banksPanels.js
+++ b/src/ducks/devtools/banksPanels.js
@@ -1,0 +1,44 @@
+import LibraryVersionsDevtools from 'ducks/devtools/LibraryVersions'
+import ServiceDevtools from 'ducks/devtools/Services'
+import NotificationDevtools from 'ducks/devtools/Notifications'
+import PinDevtools from 'ducks/devtools/Pin'
+import ClientInfoDevtools from 'ducks/devtools/ClientInfo'
+import MiscDevtools from 'ducks/devtools/Misc'
+import HiddenPagesDevtools from 'ducks/devtools/HiddenPages'
+import FlagsDevtools from 'ducks/devtools/Flags'
+
+export default [
+  {
+    id: 'libraries',
+    Component: LibraryVersionsDevtools
+  },
+
+  {
+    id: 'services',
+    Component: ServiceDevtools
+  },
+  {
+    id: 'notifications',
+    Component: NotificationDevtools
+  },
+  {
+    id: 'pin',
+    Component: PinDevtools
+  },
+  {
+    id: 'client',
+    Component: ClientInfoDevtools
+  },
+  {
+    id: 'misc',
+    Component: MiscDevtools
+  },
+  {
+    id: 'hidden pages',
+    Component: HiddenPagesDevtools
+  },
+  {
+    id: 'flags',
+    Component: FlagsDevtools
+  }
+]

--- a/src/ducks/devtools/common.jsx
+++ b/src/ducks/devtools/common.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
+import Grid from '@material-ui/core/Grid'
+
+const styles = {
+  listGridItem: {
+    height: '100%',
+    overflow: 'scroll',
+    flexBasis: 240,
+    flexShrink: 0,
+    flexGrow: 0,
+    boxShadow: '4px 0 8px rgba(0, 0, 0, 0.10)'
+  }
+}
+
+const NavSecondaryAction = () => {
+  return (
+    <ListItemSecondaryAction>
+      <Icon icon={RightIcon} className="u-mr-half" />
+    </ListItemSecondaryAction>
+  )
+}
+
+const ListGridItem = ({ children }) => {
+  return (
+    <Grid item height="100%" style={styles.listGridItem}>
+      {children}
+    </Grid>
+  )
+}
+
+export { NavSecondaryAction, ListGridItem }

--- a/src/ducks/devtools/common.jsx
+++ b/src/ducks/devtools/common.jsx
@@ -18,7 +18,11 @@ const styles = {
 const NavSecondaryAction = () => {
   return (
     <ListItemSecondaryAction>
-      <Icon icon={RightIcon} className="u-mr-half" />
+      <Icon
+        icon={RightIcon}
+        className="u-mr-half"
+        color="var(--secondaryTextColor)"
+      />
     </ListItemSecondaryAction>
   )
 }

--- a/src/ducks/devtools/index.jsx
+++ b/src/ducks/devtools/index.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useCallback, useMemo } from 'react'
+import Fab from '@material-ui/core/Fab'
+import Paper from '@material-ui/core/Paper'
+import IconButton from '@material-ui/core/IconButton'
+import Grid from '@material-ui/core/Grid'
+import Box from '@material-ui/core/Box'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import ListItem from 'cozy-ui/transpiled/react/ListItem'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import GearIcon from 'cozy-ui/transpiled/react/Icons/Gear'
+import CrossIcon from 'cozy-ui/transpiled/react/Icons/Cross'
+
+import Queries from 'ducks/devtools/Queries'
+import { NavSecondaryAction, ListGridItem } from 'ducks/devtools/common'
+import useLocalState from 'ducks/devtools/useLocalState'
+
+const styles = {
+  fab: { position: 'fixed', left: '1rem', bottom: '1rem' },
+  panel: { position: 'fixed', bottom: 0, height: 300, left: 0, right: 0 },
+  closeIcon: { position: 'absolute', top: '0.5rem', right: '0.5rem' },
+  panelContainer: { height: '100%', flexWrap: 'nowrap' },
+  panelRight: { height: '100%', overflow: 'scroll', flexGrow: 1 },
+  mono: { fontFamily: 'monospace' }
+}
+
+const defaultPanels = [
+  {
+    id: 'queries',
+    Component: Queries
+  }
+]
+
+const DevToolsNavList = ({ selected, panels, onNav }) => {
+  return (
+    <List>
+      {panels.map(panel => {
+        return (
+          <ListItem
+            key={panel.name}
+            selected={selected === panel.id}
+            dense
+            button
+            onClick={() => onNav(panel.id)}
+          >
+            <ListItemText>{panel.id}</ListItemText>
+            <NavSecondaryAction />
+          </ListItem>
+        )
+      })}
+    </List>
+  )
+}
+
+const DevToolsPanel = props => {
+  const panels = useMemo(() => {
+    if (props.panels) {
+      return [...defaultPanels, ...props.panels]
+    }
+    return defaultPanels
+  }, [props.panels])
+  const [currentPanel, setCurrentPanel] = useState('queries')
+  return (
+    <Paper elevation={12} {...props}>
+      <IconButton style={styles.closeIcon} onClick={props.onClose}>
+        <Icon icon={CrossIcon} size={12} />
+      </IconButton>
+      <Grid container height="100%" style={styles.panelContainer}>
+        <ListGridItem>
+          <Box p={1}>
+            <Typography variant="subtitle1">Cozy Devtools</Typography>
+          </Box>
+          <DevToolsNavList
+            panels={panels}
+            selected={currentPanel}
+            onNav={setCurrentPanel}
+          />
+        </ListGridItem>
+        {panels.map(panelOptions =>
+          currentPanel === panelOptions.id ? <panelOptions.Component /> : null
+        )}
+      </Grid>
+    </Paper>
+  )
+}
+
+const DevTools = ({ panels }) => {
+  const [open, setOpen] = useLocalState('cozydevtools__open', false)
+  const handleToggle = useCallback(() => setOpen(state => !state), [setOpen])
+  return (
+    <>
+      <Fab color="primary" onClick={handleToggle} style={styles.fab}>
+        <Icon icon={GearIcon} />
+      </Fab>
+      {open ? (
+        <CozyTheme variant="normal">
+          <DevToolsPanel
+            style={styles.panel}
+            onClose={handleToggle}
+            panels={panels}
+          />
+        </CozyTheme>
+      ) : null}
+    </>
+  )
+}
+
+export default DevTools

--- a/src/ducks/devtools/useLocalState.js
+++ b/src/ducks/devtools/useLocalState.js
@@ -1,0 +1,24 @@
+import { useState, useCallback } from 'react'
+
+const useLocalState = (key, initialState) => {
+  const [state, setState] = useState(() => {
+    const item = localStorage.getItem(key)
+    try {
+      return item !== null ? JSON.parse(item) : initialState
+    } catch (e) {
+      return initialState
+    }
+  })
+
+  const setLocalState = useCallback(
+    newState => {
+      setState(newState)
+      localStorage.setItem(key, JSON.stringify(newState))
+    },
+    [setState, key]
+  )
+
+  return [state, setLocalState]
+}
+
+export default useLocalState

--- a/src/ducks/devtools/useLocalState.js
+++ b/src/ducks/devtools/useLocalState.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 
 const useLocalState = (key, initialState) => {
   const [state, setState] = useState(() => {
@@ -13,10 +13,13 @@ const useLocalState = (key, initialState) => {
   const setLocalState = useCallback(
     newState => {
       setState(newState)
-      localStorage.setItem(key, JSON.stringify(newState))
     },
-    [setState, key]
+    [setState]
   )
+
+  useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(state))
+  }, [key, state])
 
   return [state, setLocalState]
 }

--- a/src/ducks/settings/Settings.jsx
+++ b/src/ducks/settings/Settings.jsx
@@ -1,7 +1,6 @@
 /* global __TARGET__, __APP_VERSION__ */
 import React from 'react'
 
-import flag from 'cozy-flags'
 import { useI18n } from 'cozy-ui/transpiled/react'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { Tabs, Tab } from 'cozy-ui/transpiled/react/MuiTabs'
@@ -26,9 +25,7 @@ const Settings = ({ children }) => {
   const tabNames = ['configuration', 'accounts', 'groups']
 
   let defaultTab = location.pathname.replace('/settings/', '')
-  if (flag('debug')) {
-    tabNames.push('debug')
-  }
+
   if (tabNames.indexOf(defaultTab) === -1) defaultTab = 'configuration'
 
   const goTo = url => () => {
@@ -36,7 +33,7 @@ const Settings = ({ children }) => {
   }
 
   return (
-    <React.Fragment>
+    <>
       <BarTheme theme="primary" />
       <Padded className={isMobile ? 'u-p-0' : 'u-pb-half'}>
         <PageTitle>{t('Settings.title')}</PageTitle>
@@ -66,8 +63,8 @@ const Settings = ({ children }) => {
           <AppVersion version={__APP_VERSION__} />
         </Padded>
       )}
-    </React.Fragment>
+    </>
   )
 }
 
-export default flag.connect(Settings)
+export default Settings

--- a/yarn.lock
+++ b/yarn.lock
@@ -9602,6 +9602,14 @@ is-docker@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.0.0.tgz#2cb0df0e75e2d064fe1864c37cdeacb7b2dcf25b"
   integrity sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ==
 
+is-dom@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-dom/-/is-dom-1.1.0.tgz#af1fced292742443bb59ca3f76ab5e80907b4e8a"
+  integrity sha512-u82f6mvhYxRPKpw8V1N0W8ce1xXwOrQtgGcxl6UCL5zBmZu3is/18K0rR7uFCnMDuAsS/3W54mGL4vsaFUQlEQ==
+  dependencies:
+    is-object "^1.0.1"
+    is-window "^1.0.2"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -9817,6 +9825,11 @@ is-object-like-x@^1.5.1:
     is-function-x "^3.3.0"
     is-primitive "^3.0.0"
 
+is-object@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
+  integrity sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==
+
 is-observable@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
@@ -9975,6 +9988,11 @@ is-whitespace@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/is-whitespace/-/is-whitespace-0.3.0.tgz#1639ecb1be036aec69a54cbb401cfbed7114ab7f"
   integrity sha1-Fjnssb4DauxppUy7QBz77XEUq38=
+
+is-window@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-window/-/is-window-1.0.2.tgz#2c896ca53db97de45d3c33133a65d8c9f563480d"
+  integrity sha1-LIlspT25feRdPDMTOmXYyfVjSA0=
 
 is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
@@ -15082,7 +15100,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@15.7.2, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@15.7.2, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -15557,6 +15575,15 @@ react-input-autosize@^3.0.0:
   integrity sha512-nL9uS7jEs/zu8sqwFE5MAPx6pPkNAriACQ2rGLlqmKr2sPGtN7TXTyDdQt4lbNXVx7Uzadb40x8qotIuru6Rhg==
   dependencies:
     prop-types "^15.5.8"
+
+react-inspector@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.0.tgz#45a325e15f33e595be5356ca2d3ceffb7d6b8c3a"
+  integrity sha512-JAwswiengIcxi4X/Ssb8nf6suOuQsyit8Fxo04+iPKTnPNY3XIOuagjMZSzpJDDKkYcc/ARlySOYZZv626WUvA==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    is-dom "^1.0.0"
+    prop-types "^15.0.0"
 
 react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6, react-is@^16.9.0:
   version "16.13.1"


### PR DESCRIPTION
Add start of a devtool panel that could be reused across apps. It is displayed via a floating-action-button only shown if the flag('debug') is set.

- Add queries viewer that list all queries from cozy-client with their fetch status and data
- Ability to receive devtools panels from the app, this way we can move the debug page from settings to this panel
![image](https://user-images.githubusercontent.com/465582/112479974-d6d67100-8d75-11eb-861b-a026fd2ba8ee.png)
