### PR TITLE
Fix banks context

### DIFF
--- a/src/ducks/context/BanksContext.jsx
+++ b/src/ducks/context/BanksContext.jsx
@@ -19,6 +19,8 @@ export const useBanksContext = () => {
  * @returns {JSX.Element}
  * @constructor
  */
+
+const EMPTY_ARRAY = []
 const BanksProvider = ({ children, client }) => {
   const { jobsInProgress = [] } = useJobsContext()
   const [banksJobsInProgress, setBanksJobsInProgress] = useState([])
@@ -46,6 +48,8 @@ const BanksProvider = ({ children, client }) => {
       queryJobsInProgress().then(formatJobs => {
         setBanksJobsInProgress(formatJobs)
       })
+    } else {
+      setBanksJobsInProgress(EMPTY_ARRAY)
     }
   }, [jobsInProgress])
 

--- a/src/ducks/context/BanksContext.spec.jsx
+++ b/src/ducks/context/BanksContext.spec.jsx
@@ -1,0 +1,106 @@
+import React from 'react'
+
+import JobsProvider from '../context/JobsContext'
+import BanksProvider, { BanksContext } from '../context/BanksContext'
+import { render } from '@testing-library/react'
+import CozyClient from 'cozy-client'
+import CozyRealtime from 'cozy-realtime'
+import { KONNECTOR_DOCTYPE } from '../../doctypes'
+
+jest.mock('cozy-realtime')
+
+export const createKonnectorMsg = (state, konnector, account) => ({
+  worker: 'konnector',
+  state,
+  message: {
+    konnector,
+    account
+  }
+})
+
+const RUNNING = 'running'
+const KONNECTORS = [
+  { konnector: 'caissedepargne1', account: '1234' },
+  { konnector: 'boursorama83', account: '5678' }
+]
+
+describe('Jobs Context', () => {
+  const setup = ({ withKonnectors }) => {
+    const client = new CozyClient({})
+    client.query = jest.fn().mockImplementation(options => {
+      const { doctype } = options
+      if (doctype === KONNECTOR_DOCTYPE) {
+        return {
+          data: KONNECTORS.map(k => ({
+            account: k.account,
+            slug: k.konnector
+          }))
+        }
+      }
+    })
+    CozyRealtime.mockImplementation(() => {
+      return {
+        subscribe: (eventName, doctype, handleRealtime) => {
+          // There are 3 subscribers (created, updated, deleted)
+          // To simulate handle realtime we check if there are
+          // at least the first event and we call handleRealtime callbacks
+          if (eventName === 'created') {
+            if (withKonnectors) {
+              handleRealtime(
+                createKonnectorMsg(
+                  RUNNING,
+                  KONNECTORS[0].konnector,
+                  KONNECTORS[0].account
+                )
+              )
+              handleRealtime(
+                createKonnectorMsg(
+                  RUNNING,
+                  KONNECTORS[1].konnector,
+                  KONNECTORS[1].account
+                )
+              )
+            }
+          }
+        },
+        unsubscribe: () => {}
+      }
+    })
+
+    const children = (
+      <BanksContext.Consumer>
+        {({ jobsInProgress }) => {
+          return jobsInProgress.map(job => (
+            <div key={job.account}>
+              <span>{job.konnector}</span>
+              <span>{job.account}</span>
+            </div>
+          ))
+        }}
+      </BanksContext.Consumer>
+    )
+
+    const root = render(
+      <JobsProvider client={client} options={{}}>
+        <BanksProvider client={client}>{children}</BanksProvider>
+      </JobsProvider>
+    )
+
+    return root
+  }
+  it('should display job in progress', async () => {
+    const root = setup({ withKonnectors: true })
+    expect(await root.findByText('caissedepargne1')).toBeTruthy()
+    expect(await root.findByText('1234')).toBeTruthy()
+    expect(await root.findByText('boursorama83')).toBeTruthy()
+    expect(await root.findByText('5678')).toBeTruthy()
+  })
+
+  it('should not display job in progress', () => {
+    const root = setup({ withKonnectors: false })
+    expect(root.queryByText('caissedepargne1')).toBeNull()
+    expect(root.queryByText('1234')).toBeNull()
+    expect(root.queryByText('boursorama83')).toBeNull()
+    expect(root.queryByText('5678')).toBeNull()
+  })
+})

--- a/src/ducks/context/BanksContext.spec.jsx
+++ b/src/ducks/context/BanksContext.spec.jsx
@@ -25,7 +25,7 @@ const KONNECTORS = [
 ]
 
 describe('Jobs Context', () => {
-  const setup = ({ withKonnectors }) => {
+  const setup = ({ konnectors }) => {
     const client = new CozyClient({})
     client.query = jest.fn().mockImplementation(options => {
       const { doctype } = options
@@ -45,20 +45,9 @@ describe('Jobs Context', () => {
           // To simulate handle realtime we check if there are
           // at least the first event and we call handleRealtime callbacks
           if (eventName === 'created') {
-            if (withKonnectors) {
+            for (const konn of konnectors) {
               handleRealtime(
-                createKonnectorMsg(
-                  RUNNING,
-                  KONNECTORS[0].konnector,
-                  KONNECTORS[0].account
-                )
-              )
-              handleRealtime(
-                createKonnectorMsg(
-                  RUNNING,
-                  KONNECTORS[1].konnector,
-                  KONNECTORS[1].account
-                )
+                createKonnectorMsg(RUNNING, konn.konnector, konn.account)
               )
             }
           }
@@ -89,7 +78,7 @@ describe('Jobs Context', () => {
     return root
   }
   it('should display job in progress', async () => {
-    const root = setup({ withKonnectors: true })
+    const root = setup({ konnectors: [KONNECTORS[0], KONNECTORS[1]] })
     expect(await root.findByText('caissedepargne1')).toBeTruthy()
     expect(await root.findByText('1234')).toBeTruthy()
     expect(await root.findByText('boursorama83')).toBeTruthy()
@@ -97,7 +86,7 @@ describe('Jobs Context', () => {
   })
 
   it('should not display job in progress', () => {
-    const root = setup({ withKonnectors: false })
+    const root = setup({ konnectors: [] })
     expect(root.queryByText('caissedepargne1')).toBeNull()
     expect(root.queryByText('1234')).toBeNull()
     expect(root.queryByText('boursorama83')).toBeNull()

--- a/src/ducks/context/JobsContext.spec.jsx
+++ b/src/ducks/context/JobsContext.spec.jsx
@@ -17,9 +17,13 @@ export const createKonnectorMsg = (state, konnector, account) => ({
 })
 
 const RUNNING = 'running'
+const KONNECTORS = [
+  { konnector: 'caissedepargne1', account: '1234' },
+  { konnector: 'boursorama83', account: '5678' }
+]
 
-describe('Jobs Context', () => {
-  it('should display job in progress', async () => {
+describe('Banks Context', () => {
+  const setup = ({ konnectors }) => {
     const client = new CozyClient({})
     CozyRealtime.mockImplementation(() => {
       return {
@@ -28,10 +32,11 @@ describe('Jobs Context', () => {
           // To simulate handle realtime we check if there are
           // at least the first event and we call handleRealtime callbacks
           if (eventName === 'created') {
-            handleRealtime(
-              createKonnectorMsg(RUNNING, 'caissedepargne1', '1234')
-            )
-            handleRealtime(createKonnectorMsg(RUNNING, 'boursorama83', '5678'))
+            for (const konn of konnectors) {
+              handleRealtime(
+                createKonnectorMsg(RUNNING, konn.konnector, konn.account)
+              )
+            }
           }
         },
         unsubscribe: () => {}
@@ -56,9 +61,21 @@ describe('Jobs Context', () => {
         {children}
       </JobsProvider>
     )
+    return root
+  }
+  it('should display job in progress', async () => {
+    const root = setup({ konnectors: [KONNECTORS[0], KONNECTORS[1]] })
     expect(await root.findByText('caissedepargne1')).toBeTruthy()
     expect(await root.findByText('1234')).toBeTruthy()
     expect(await root.findByText('boursorama83')).toBeTruthy()
     expect(await root.findByText('5678')).toBeTruthy()
+  })
+
+  it('should not display job in progress', () => {
+    const root = setup({ konnectors: [] })
+    expect(root.queryByText('caissedepargne1')).toBeNull()
+    expect(root.queryByText('1234')).toBeNull()
+    expect(root.queryByText('boursorama83')).toBeNull()
+    expect(root.queryByText('5678')).toBeNull()
   })
 })


### PR DESCRIPTION
We check if there are items in jobsInProgress
but if there is none so we have to update with empty
value jobsInProgress

Otherwise in the user interface the last job in
progress remains displayed