### PR TITLE
fix: Add missing fetch polyfill for onOperationOrBillCreate service

### DIFF
--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -1,3 +1,5 @@
+import fetch from 'node-fetch'
+global.fetch = fetch
 import get from 'lodash/get'
 import set from 'lodash/set'
 


### PR DESCRIPTION
This will fix "ReferenceError: fetch is not defined" warning message in
this service which caused no bank operation link to bills since 19
March.

cozy-client needs this polyfill to be available in globals to work
properly