### PR TITLE
fix: Do not open transaction dialog when clicking on chip

### DIFF
--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -28,25 +28,33 @@ class Component extends React.Component {
     showIntentModal: false
   }
 
-  showInformativeDialog = () =>
+  showInformativeDialog = ev => {
+    ev.preventDefault()
     this.setState({
       showInformativeDialog: true
     })
+  }
 
-  hideInformativeDialog = () =>
+  hideInformativeDialog = ev => {
+    ev.preventDefault()
     this.setState({
       showInformativeDialog: false
     })
+  }
 
-  showIntentModal = () =>
+  showIntentModal = ev => {
+    ev.preventDefault()
     this.setState({
       showIntentModal: true
     })
+  }
 
-  hideIntentModal = () =>
+  hideIntentModal = ev => {
+    ev.preventDefault()
     this.setState({
       showIntentModal: false
     })
+  }
 
   onInformativeDialogConfirm = async () => {
     this.hideInformativeDialog()


### PR DESCRIPTION
Clicking on a transaction action chip should not open the transaction
dialog. Here, actions are responsible to call ev.preventDefault() on
their click event so that the transaction row can check ev.defaultPrevented.

A common solution is to check ev.currentTarget === ev.target to filter but this
does not work properly as I want to click everywhere on the row to 
open the transaction dialog, putting the check would remove this ability
since sometimes ev.currentTarget would be a `td` and not a `tr`.

I am not super pleased with this thing, if you see another solution, please
tell me.

Depends on https://github.com/cozy/cozy-ui/pull/1798