### PR TITLE
Fix bad open of transaction dialog

### DIFF
--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -155,6 +155,9 @@ export const RowDesktop = React.memo(function RowDesktop(props) {
       if (ev.defaultPrevented) {
         return
       }
+      if (!ev.currentTarget.contains(ev.target)) {
+        return
+      }
       showTransactionModal()
     },
     [showTransactionModal]

--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -29,28 +29,28 @@ class Component extends React.Component {
   }
 
   showInformativeDialog = ev => {
-    ev.preventDefault()
+    ev && ev.preventDefault()
     this.setState({
       showInformativeDialog: true
     })
   }
 
   hideInformativeDialog = ev => {
-    ev.preventDefault()
+    ev && ev.preventDefault()
     this.setState({
       showInformativeDialog: false
     })
   }
 
   showIntentModal = ev => {
-    ev.preventDefault()
+    ev && ev.preventDefault()
     this.setState({
       showIntentModal: true
     })
   }
 
   hideIntentModal = ev => {
-    ev.preventDefault()
+    ev && ev.preventDefault()
     this.setState({
       showIntentModal: false
     })


### PR DESCRIPTION
Again, a click on a modal that is displayed for a transaction action would trigger the transaction dialog. Here, we filter events that do not come from an element inside the row (like the modal and the portal).