### PR TITLE
Delete recurrence if there are no more transactions in it

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -8,7 +8,7 @@ import {
   RECURRENCE_DOCTYPE,
   BANK_ACCOUNT_STATS_DOCTYPE
 } from 'doctypes'
-import { removeRecurrenceIfEmpty } from 'ducks/recurrence/api'
+import { destroyRecurrenceIfEmpty } from 'ducks/recurrence/api'
 import { disableOutdatedNotifications } from 'ducks/settings/helpers'
 
 const removeAccountFromGroup = (group, account) => {
@@ -72,7 +72,7 @@ export const updateRecurrences = async (client, account, deletedOps) => {
     Q(RECURRENCE_DOCTYPE).getByIds(impactedRecurrenceIds)
   )
   for (const recurrence of recurrences) {
-    await removeRecurrenceIfEmpty(client, recurrence)
+    await destroyRecurrenceIfEmpty(client, recurrence)
   }
 }
 

--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -1,10 +1,14 @@
 import CozyClient, { Q } from 'cozy-client'
+import get from 'lodash/get'
+import uniq from 'lodash/uniq'
 import {
   GROUP_DOCTYPE,
   ACCOUNT_DOCTYPE,
   TRANSACTION_DOCTYPE,
+  RECURRENCE_DOCTYPE,
   BANK_ACCOUNT_STATS_DOCTYPE
 } from 'doctypes'
+import { removeRecurrenceIfEmpty } from 'ducks/recurrence/api'
 import { disableOutdatedNotifications } from 'ducks/settings/helpers'
 
 const removeAccountFromGroup = (group, account) => {
@@ -24,6 +28,8 @@ export const deleteOrphanOperations = async (client, account) => {
     TRANSACTION_DOCTYPE
   )
   let count
+
+  const res = []
   while (count === undefined || count === STACK_FIND_LIMIT) {
     const { data: orphanOperations } = await transactionCollection.find({
       account: account._id
@@ -31,8 +37,10 @@ export const deleteOrphanOperations = async (client, account) => {
     count = orphanOperations.length
     if (count > 0) {
       await transactionCollection.destroyAll(orphanOperations)
+      res.push.apply(res, orphanOperations)
     }
   }
+  return res
 }
 
 const removeAccountFromGroups = async (client, account) => {
@@ -56,11 +64,24 @@ export const removeStats = async (client, account) => {
   }
 }
 
+export const updateRecurrences = async (client, account, deletedOps) => {
+  const impactedRecurrenceIds = uniq(
+    deletedOps.map(op => get(op, 'relationships.recurrence.data._id'))
+  ).filter(Boolean)
+  const { data: recurrences } = await client.query(
+    Q(RECURRENCE_DOCTYPE).getByIds(impactedRecurrenceIds)
+  )
+  for (const recurrence of recurrences) {
+    await removeRecurrenceIfEmpty(client, recurrence)
+  }
+}
+
 export const DESTROY_ACCOUNT = 'DESTROY_ACCOUNT'
 const onAccountDelete = async (client, account) => {
-  await deleteOrphanOperations(client, account)
+  const deletedOps = await deleteOrphanOperations(client, account)
   await removeAccountFromGroups(client, account)
   await removeStats(client, account)
+  await updateRecurrences(client, account, deletedOps)
   await disableOutdatedNotifications(client)
 }
 

--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -1,5 +1,10 @@
 import CozyClient, { Q } from 'cozy-client'
-import { GROUP_DOCTYPE, ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
+import {
+  GROUP_DOCTYPE,
+  ACCOUNT_DOCTYPE,
+  TRANSACTION_DOCTYPE,
+  BANK_ACCOUNT_STATS_DOCTYPE
+} from 'doctypes'
 import { disableOutdatedNotifications } from 'ducks/settings/helpers'
 
 const removeAccountFromGroup = (group, account) => {
@@ -41,7 +46,7 @@ const removeAccountFromGroups = async (client, account) => {
 
 export const removeStats = async (client, account) => {
   const statsResponse = await client.query(
-    Q('io.cozy.bank.accounts.stats').where({
+    Q(BANK_ACCOUNT_STATS_DOCTYPE).where({
       'relationships.account.data._id': account._id
     })
   )

--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -134,6 +134,6 @@ JobsProvider.propTypes = {
   client: PropTypes.object.isRequired,
   options: PropTypes.shape({
     onSuccess: PropTypes.func,
-    onError: PropTypes.number
+    onError: PropTypes.func
   })
 }

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -15,11 +15,14 @@ import { transactionsConn } from 'doctypes'
 import tree from 'ducks/categories/tree'
 
 import defaultConfig from './config.json'
-import { saveHydratedBundles, resetBundles } from './api'
+import {
+  saveHydratedBundles,
+  resetBundles,
+  getAutomaticLabelFromBundle
+} from './api'
 import RulesDetails from './RulesDetails'
 import DateSlider from './DateSlider'
 import { getRulesFromConfig, rulesPerName } from './rules'
-import { getAutomaticLabelFromBundle } from './utils'
 import { findRecurrences, updateRecurrences } from './search'
 import useStickyState from './useStickyState'
 import CategoryIcon from 'ducks/categories/CategoryIcon'

--- a/src/ducks/recurrence/RecurrencePage.jsx
+++ b/src/ducks/recurrence/RecurrencePage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react'
+import React, { useCallback, useRef, useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import {
   useClient,
@@ -459,14 +459,25 @@ const BundleTransactions = ({ bundle }) => {
 
 const RecurrencePage = () => {
   const params = useParams()
+  const history = useHistory()
   const recurrenceCol = useQuery(recurrenceConn.query, recurrenceConn)
 
   const bundleId = params.bundleId
   const bundle = useDocument(RECURRENCE_DOCTYPE, bundleId)
+  const shouldShowLoading =
+    isQueryLoading(recurrenceCol) && !hasQueryBeenLoaded(recurrenceCol)
 
   useTrackPage('recurrences:details')
 
-  if (isQueryLoading(recurrenceCol) && !hasQueryBeenLoaded(recurrenceCol)) {
+  useEffect(() => {
+    // If the recurrence gets deleted, there is no bundle anymore and
+    // we redirect to the recurrence list
+    if (!shouldShowLoading && !bundle) {
+      history.push('/analysis/recurrence')
+    }
+  }, [shouldShowLoading, bundle, history])
+
+  if (shouldShowLoading) {
     return <Loading />
   }
 

--- a/src/ducks/recurrence/api.js
+++ b/src/ducks/recurrence/api.js
@@ -176,7 +176,7 @@ export const setStatusFinished = async (client, recurrence) => {
   return setStatus(client, recurrence, STATUS_FINISHED)
 }
 
-export const removeRecurrenceIfEmpty = async (client, partialRecurrence) => {
+export const destroyRecurrenceIfEmpty = async (client, partialRecurrence) => {
   const { data: recurrenceTransactions } = await client.query(
     queryRecurrenceTransactions(partialRecurrence)
   )

--- a/src/ducks/recurrence/api.js
+++ b/src/ducks/recurrence/api.js
@@ -19,7 +19,6 @@ import maxBy from 'lodash/maxBy'
 import get from 'lodash/get'
 import groupBy from 'lodash/groupBy'
 
-import { getAutomaticLabelFromBundle } from './utils'
 import {
   queryRecurrenceTransactions,
   queryRecurrencesTransactions
@@ -27,6 +26,14 @@ import {
 import { TRANSACTION_DOCTYPE, RECURRENCE_DOCTYPE } from 'doctypes'
 import { log } from './logger'
 import { NOT_RECURRENT_ID } from './constants'
+
+const mostFrequent = (iterable, fn) => {
+  const groups = groupBy(iterable, fn)
+  return maxBy(Object.entries(groups), ([, ops]) => ops.length)[0]
+}
+
+export const getAutomaticLabelFromBundle = bundle =>
+  mostFrequent(bundle.ops, op => op.label)
 
 const addRelationship = (doc, relationshipName, definition) => {
   return set(doc, ['relationships', relationshipName], { data: definition })

--- a/src/ducks/recurrence/api.js
+++ b/src/ducks/recurrence/api.js
@@ -25,6 +25,7 @@ import {
 } from './queries'
 import { TRANSACTION_DOCTYPE, RECURRENCE_DOCTYPE } from 'doctypes'
 import { log } from './logger'
+import { NOT_RECURRENT_ID } from './constants'
 
 const addRelationship = (doc, relationshipName, definition) => {
   return set(doc, ['relationships', relationshipName], { data: definition })
@@ -32,8 +33,6 @@ const addRelationship = (doc, relationshipName, definition) => {
 
 const getRecurrenceIdFromRawTransaction = tr =>
   get(tr, 'relationships.recurrence.data._id', null)
-
-export const NOT_RECURRENT_ID = 'not-recurrent'
 
 /**
  * Fetch bundles and associated transactions from CouchDB

--- a/src/ducks/recurrence/constants.js
+++ b/src/ducks/recurrence/constants.js
@@ -1,0 +1,1 @@
+export const NOT_RECURRENT_ID = 'not-recurrent'

--- a/src/ducks/recurrence/utils.js
+++ b/src/ducks/recurrence/utils.js
@@ -1,6 +1,4 @@
 import startCase from 'lodash/startCase'
-import maxBy from 'lodash/maxBy'
-import groupBy from 'lodash/groupBy'
 import addDays from 'date-fns/add_days'
 import parse from 'date-fns/parse'
 import differenceInDays from 'date-fns/difference_in_days'
@@ -15,14 +13,6 @@ const RECURRENCE_DOCTYPE = 'io.cozy.bank.recurrence'
 export const prettyLabel = label => {
   return label ? startCase(label.toLowerCase()) : ''
 }
-
-const mostFrequent = (iterable, fn) => {
-  const groups = groupBy(iterable, fn)
-  return maxBy(Object.entries(groups), ([, ops]) => ops.length)[0]
-}
-
-export const getAutomaticLabelFromBundle = bundle =>
-  mostFrequent(bundle.ops, op => op.label)
 
 export const getLabel = bundle => {
   if (bundle.manualLabel) {

--- a/src/ducks/transactions/TransactionRecurrenceEditor.jsx
+++ b/src/ducks/transactions/TransactionRecurrenceEditor.jsx
@@ -12,7 +12,7 @@ import {
   makeRecurrenceFromTransaction,
   getCategories
 } from 'ducks/recurrence/utils'
-import { NOT_RECURRENT_ID } from 'ducks/recurrence/api'
+import { NOT_RECURRENT_ID } from 'ducks/recurrence/constants'
 import { recurrenceConn, RECURRENCE_DOCTYPE } from 'doctypes'
 import { updateTransactionRecurrence } from 'ducks/transactions/helpers'
 import CategoryIcon from 'ducks/categories/CategoryIcon'

--- a/src/ducks/transactions/actions/AttachedDocsAction/index.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/index.jsx
@@ -37,7 +37,7 @@ class AttachedDocsAction extends React.PureComponent {
     const { transaction } = this.props
 
     return (
-      <ListItem divider alignItem="flex-start">
+      <ListItem divider alignItems="flex-start">
         <ListItemIcon>
           <Icon icon={<AttachmentIcon />} />
         </ListItemIcon>

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -2,12 +2,18 @@ import find from 'lodash/find'
 import findLast from 'lodash/findLast'
 import get from 'lodash/get'
 import sumBy from 'lodash/sumBy'
+
+import { Q } from 'cozy-client'
 import flag from 'cozy-flags'
+
 import { differenceInDays, parse as parseDate } from 'date-fns'
 import {
   isHealthExpense,
   isProfessionalExpense
 } from 'ducks/categories/helpers'
+import { queryRecurrenceTransactions } from 'ducks/recurrence/queries'
+import { NOT_RECURRENT_ID } from 'ducks/recurrence/api'
+
 export { default as getCategoryId } from './getCategoryId'
 
 const prevRecurRx = /\bPRLV SEPA RECU RCUR\b/
@@ -243,6 +249,7 @@ export const updateTransactionRecurrence = async (
   transaction,
   recurrence
 ) => {
+  const oldRecurrence = get(transaction, 'relationships.recurrence.data')
   const recurrenceRelationshipData = {
     _id: recurrence._id,
     _type: recurrence._type
@@ -250,6 +257,21 @@ export const updateTransactionRecurrence = async (
   transaction.recurrence.set(recurrenceRelationshipData)
 
   const { data } = await client.save(transaction)
+
+  // Check if we need to delete an empty recurrence
+  if (oldRecurrence && oldRecurrence._id !== NOT_RECURRENT_ID) {
+    const { data: recurrenceTransactions } = await client.query(
+      queryRecurrenceTransactions(oldRecurrence)
+    )
+    if (recurrenceTransactions.length === 0) {
+      const qdef = Q(oldRecurrence._type).getById(oldRecurrence._id)
+      const { data: recurrence } = await client.query(qdef)
+      if (recurrence) {
+        await client.destroy(recurrence)
+      }
+    }
+  }
+
   return data
 }
 

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -10,7 +10,7 @@ import {
   isHealthExpense,
   isProfessionalExpense
 } from 'ducks/categories/helpers'
-import { removeRecurrenceIfEmpty } from 'ducks/recurrence/api'
+import { destroyRecurrenceIfEmpty } from 'ducks/recurrence/api'
 import { NOT_RECURRENT_ID } from 'ducks/recurrence/constants'
 
 export { default as getCategoryId } from './getCategoryId'
@@ -259,7 +259,7 @@ export const updateTransactionRecurrence = async (
 
   // Check if we need to delete an empty recurrence
   if (oldRecurrence && oldRecurrence._id !== NOT_RECURRENT_ID) {
-    await removeRecurrenceIfEmpty(client, oldRecurrence)
+    await destroyRecurrenceIfEmpty(client, oldRecurrence)
   }
 
   return data

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -12,7 +12,7 @@ import {
   isProfessionalExpense
 } from 'ducks/categories/helpers'
 import { queryRecurrenceTransactions } from 'ducks/recurrence/queries'
-import { NOT_RECURRENT_ID } from 'ducks/recurrence/api'
+import { NOT_RECURRENT_ID } from 'ducks/recurrence/constants'
 
 export { default as getCategoryId } from './getCategoryId'
 


### PR DESCRIPTION
When a transaction is set as not recurrent, we check if the recurrence
still contains transactions. If it's empty, we remove it.