### PR TITLE
fix: Use isQueryLoading

### DIFF
--- a/src/ducks/future/useEstimatedBudget.jsx
+++ b/src/ducks/future/useEstimatedBudget.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
-import { useQuery } from 'cozy-client'
+import { isQueryLoading, useQuery } from 'cozy-client'
 
 import sumBy from 'lodash/sumBy'
 
@@ -11,24 +11,17 @@ import { getPlannedTransactions } from './selectors'
 
 /** Returns estimatedBalance and number of planned transactions for currently filtered accounts */
 const useEstimatedBudget = () => {
-  const { fetchStatus: recurrenceFetchStatus } = useQuery(
-    recurrenceConn.query,
-    recurrenceConn
-  )
+  const recurrenceCol = useQuery(recurrenceConn.query, recurrenceConn)
   // Do not use the result of this query but make sure accounts are loaded since
   // we use a selector on them afterwards
-  const { fetchStatus: accountsFetchStatus } = useQuery(
-    accountsConn.query,
-    accountsConn
-  )
+  const accountsCol = useQuery(accountsConn.query, accountsConn)
   const transactions = useSelector(getPlannedTransactions)
   const accounts = useSelector(getFilteredAccounts)
   const sumTransactions = useMemo(() => sumBy(transactions, x => x.amount), [
     transactions
   ])
   const sumAccounts = useMemo(() => sumBy(accounts, x => x.balance), [accounts])
-  const isLoading =
-    accountsFetchStatus === 'loading' || recurrenceFetchStatus === 'loading'
+  const isLoading = isQueryLoading(recurrenceCol) || isQueryLoading(accountsCol)
   return {
     isLoading: isLoading,
     estimatedBalance: isLoading ? null : sumAccounts + sumTransactions,

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy'
 import clone from 'lodash/clone'
 import groupBy from 'lodash/groupBy'
 
-import { useQuery, useClient } from 'cozy-client'
+import { useQuery, useClient, isQueryLoading } from 'cozy-client'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -207,13 +207,9 @@ const makeTextFilter = (searchStr, accessor) => {
 }
 
 const RecurrencePage = () => {
-  const { data: transactions, fetchStatus } = useQuery(
-    transactionsConn.query,
-    transactionsConn
-  )
-
-  const loading = fetchStatus === 'loading' && transactions.length === 0
-
+  const transactionCol = useQuery(transactionsConn.query, transactionsConn)
+  const { data: transactions } = transactionCol
+  const loading = isQueryLoading(transactionCol) && transactions.length === 0
   const [rulesConfig, setRulesConfig, clearSavedConfig] = useStickyState(
     defaultConfig,
     'banks.recurrence-config'

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect } from 'react'
 import sortBy from 'lodash/sortBy'
-import { Query, useClient, Q, useQuery } from 'cozy-client'
+import { Query, useClient, Q, useQuery, isQueryLoading } from 'cozy-client'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -285,8 +285,9 @@ export const GroupSettings = props => {
             {t('Groups.accounts')}
           </Typography>
           <Query query={accountsConn.query} as={accountsConn.as}>
-            {({ data: accounts, fetchStatus }) => {
-              if (fetchStatus === 'loading') {
+            {accountsCol => {
+              const { data: accounts } = accountsCol
+              if (isQueryLoading(accountsCol)) {
                 return <Loading />
               }
 
@@ -302,12 +303,12 @@ export const GroupSettings = props => {
 
 const ExistingGroupSettings = props => {
   const { groupId } = useParams()
-  const { data: group, fetchStatus } = useQuery(
-    Q(GROUP_DOCTYPE).getById(groupId),
-    { as: `io.cozy.bank.groups__${groupId}`, singleDocData: true }
-  )
+  const groupCol = useQuery(Q(GROUP_DOCTYPE).getById(groupId), {
+    as: `io.cozy.bank.groups__${groupId}`,
+    singleDocData: true
+  })
 
-  if (fetchStatus === 'loading' || fetchStatus === 'pending') {
+  if (isQueryLoading(groupCol)) {
     return (
       <>
         <BarTheme theme="primary" />
@@ -316,6 +317,7 @@ const ExistingGroupSettings = props => {
     )
   }
 
+  const { data: group } = groupCol
   return (
     <>
       <BarTheme theme="primary" />

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -70,16 +70,16 @@ const HarvestLoader = ({ connectionId, children }) => {
               fetchPolicy={fetchPolicy}
             >
               {({ data, fetchStatus, lastUpdate }) => {
-                if (!data) {
-                  return null
-                }
-
                 if (fetchStatus === 'loading' && !lastUpdate) {
                   return <HarvestSpinner />
                 }
 
                 if (fetchStatus === 'error') {
                   return <HarvestError />
+                }
+
+                if (!data) {
+                  return null
                 }
 
                 const { attributes: konnector } = data

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -88,14 +88,19 @@ const HarvestLoader = ({ connectionId, children }) => {
                 // Related issue : https://github.com/cozy/cozy-client/issues/767
                 return (
                   <Query query={Q(TRIGGER_DOCTYPE)} as="triggers">
-                    {({ data: allTriggers, fetchStatus, lastUpdate }) => {
+                    {triggerCol => {
+                      const {
+                        data: allTriggers,
+                        fetchStatus,
+                        lastUpdate
+                      } = triggerCol
                       const triggers = allTriggers.filter(trigger => {
                         return (
                           trigger.message &&
                           trigger.message.account === account._id
                         )
                       })
-                      if (fetchStatus === 'loading' && !lastUpdate) {
+                      if (isQueryLoading(triggerCol) && !lastUpdate) {
                         return <HarvestSpinner />
                       } else if (fetchStatus === 'error') {
                         return <HarvestError />

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-import CozyClient, { Q, Query } from 'cozy-client'
+import CozyClient, { isQueryLoading, Q, Query } from 'cozy-client'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Dialog from 'cozy-ui/transpiled/react/Dialog'
@@ -50,12 +50,13 @@ const HarvestLoader = ({ connectionId, children }) => {
       as={`accounts/${connectionId}`}
       fetchPolicy={fetchPolicy}
     >
-      {({ data: account, fetchStatus, lastUpdate }) => {
+      {accountCol => {
+        const { data: account, fetchStatus, lastUpdate } = accountCol
         // Can happen for a short while when the account is deleted
         if (!account) {
           return null
         }
-        if (fetchStatus === 'loading' && !lastUpdate) {
+        if (isQueryLoading(accountCol) && !lastUpdate) {
           return <HarvestSpinner />
         } else if (fetchStatus === 'error') {
           return <HarvestError />
@@ -69,17 +70,14 @@ const HarvestLoader = ({ connectionId, children }) => {
               as={`konnectors/${connectionId}`}
               fetchPolicy={fetchPolicy}
             >
-              {({ data, fetchStatus, lastUpdate }) => {
-                if (fetchStatus === 'loading' && !lastUpdate) {
+              {konnectorKol => {
+                const { data, fetchStatus, lastUpdate } = konnectorKol
+                if (isQueryLoading(konnectorKol) && !lastUpdate) {
                   return <HarvestSpinner />
                 }
 
                 if (fetchStatus === 'error') {
                   return <HarvestError />
-                }
-
-                if (!data) {
-                  return null
                 }
 
                 const { attributes: konnector } = data

--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -70,6 +70,10 @@ const HarvestLoader = ({ connectionId, children }) => {
               fetchPolicy={fetchPolicy}
             >
               {({ data, fetchStatus, lastUpdate }) => {
+                if (!data) {
+                  return null
+                }
+
                 if (fetchStatus === 'loading' && !lastUpdate) {
                   return <HarvestSpinner />
                 }


### PR DESCRIPTION
If fetch status is pending or loading so show spinner, it avoids to try access at "attributes" which is undefined and provokes this error.

For further, I also changed several fetchStatus === 'loading' by isQueryLoading because since this [Cozy Client PR](https://github.com/cozy/cozy-client/pull/925) fetchStatus through pending and after loading.
So it is therefore preferable to use this function which checks if it is pending or loading

![Capture d’écran 2021-04-20 à 12 06 31](https://user-images.githubusercontent.com/22611343/115378535-ef00ab00-a1d0-11eb-877d-759c8deee263.png)
