### PR TITLE
Draft: Stateful notifications

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -115,8 +115,8 @@
     "balance-lower": {
       "description": "Alert the user when his account balance is lower than a certain value",
       "collapsible": true,
-      "stateful": false,
-      "multiple": false,
+      "stateful": true,
+      "multiple": true,
       "default_priority": "normal",
       "templates": {}
     },

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -154,9 +154,9 @@
     },
     "budget-alerts": {
       "description": "Alert the user when sum of expenses goes higher than defined in settings",
-      "collapsible": false,
-      "stateful": false,
-      "multiple": false,
+      "collapsible": true,
+      "stateful": true,
+      "multiple": true,
       "default_priority": "normal",
       "templates": {}
     },

--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -1,7 +1,7 @@
 import logger from 'cozy-logger'
 import { findMatchingBrand, getNotInstalledBrands } from 'ducks/brandDictionary'
 import { getLabel } from 'ducks/transactions/helpers'
-import { getKonnectorFromTrigger } from 'utils/triggers'
+import { trigger as triggerLibs } from 'cozy-client/dist/models'
 import { BankTransaction } from 'cozy-doctypes'
 import AppSuggestion from './AppSuggestion'
 import Trigger from './Trigger'
@@ -11,6 +11,7 @@ import get from 'lodash/get'
 import set from 'lodash/set'
 
 const log = logger.namespace('app-suggestions')
+const { getKonnector } = triggerLibs.triggers
 
 export const findSuggestionForTransaction = (
   transaction,
@@ -90,7 +91,7 @@ export const findAppSuggestions = async setting => {
   set(setting, 'appSuggestions.lastSeq', transactionsToCheck.newLastSeq)
 
   log('info', 'Get not installed brands')
-  const installedSlugs = triggers.map(getKonnectorFromTrigger)
+  const installedSlugs = triggers.map(getKonnector)
   const brands = getNotInstalledBrands(installedSlugs)
 
   log('info', `${brands.length} not installed brands`)

--- a/src/ducks/appSuggestions/services.spec.js
+++ b/src/ducks/appSuggestions/services.spec.js
@@ -1,6 +1,19 @@
-import { findSuggestionForTransaction, normalizeSuggestions } from './services'
+import {
+  findSuggestionForTransaction,
+  normalizeSuggestions,
+  findAppSuggestions
+} from './services'
 import { TRANSACTION_DOCTYPE } from '../../doctypes'
 import { getBrands } from '../brandDictionary'
+import { Document } from 'cozy-doctypes'
+import CozyClient from 'cozy-client'
+import fetch from 'node-fetch'
+global.fetch = fetch
+
+const client = new CozyClient({
+  uri: 'http://localhost:8080'
+})
+Document.registerClient(client)
 
 describe('findSuggestionForTransaction', () => {
   const brands = getBrands()
@@ -85,5 +98,13 @@ describe('normalizeSuggestions', () => {
     ]
 
     expect(normalizeSuggestions(suggestions)).toMatchSnapshot()
+  })
+})
+
+describe('findAppSuggestions', () => {
+  it('should work with empty data', async () => {
+    Document.fetchAll = jest.fn().mockResolvedValue([])
+    Document.fetchChanges = jest.fn().mockResolvedValue({ documents: [] })
+    await findAppSuggestions({})
   })
 })

--- a/src/ducks/notifications/BalanceLower/index.js
+++ b/src/ducks/notifications/BalanceLower/index.js
@@ -140,6 +140,9 @@ class BalanceLower extends NotificationView {
       data: {
         route: '/balances'
       },
+
+      // If there are new transactions for the account but the account balance
+      // does not change, there will be no alerts
       state: JSON.stringify({
         accounts: this.templateData.accounts
           .map(account => ({
@@ -148,6 +151,8 @@ class BalanceLower extends NotificationView {
           }))
           .sort(byIdSorter)
       }),
+
+      // The category of the alert is made of the rule doc + the threshold
       categoryId: this.templateData.matchingRules
         .map(({ rule }) =>
           rule.accountOrGroup

--- a/src/ducks/notifications/BalanceLower/index.js
+++ b/src/ducks/notifications/BalanceLower/index.js
@@ -3,11 +3,13 @@ import flatten from 'lodash/flatten'
 import uniqBy from 'lodash/uniqBy'
 import groupBy from 'lodash/groupBy'
 import map from 'lodash/map'
+import mapValues from 'lodash/mapValues'
 import merge from 'lodash/merge'
 import log from 'cozy-logger'
 import { getAccountBalance } from 'ducks/account/helpers'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import { getCurrentDate } from 'ducks/notifications/utils'
+import { isNew as isNewTransaction } from 'ducks/transactions/helpers'
 import template from './template.hbs'
 import { toText } from 'cozy-notifications'
 import { ruleAccountFilter } from 'ducks/settings/ruleUtils'
@@ -53,6 +55,8 @@ const customToText = cozyHTMLEmail => {
   return toText(cozyHTMLEmail, getContent)
 }
 
+const byIdSorter = (acc1, acc2) => (acc1._id > acc2._id ? 1 : -1)
+
 class BalanceLower extends NotificationView {
   constructor(config) {
     super(config)
@@ -74,13 +78,22 @@ class BalanceLower extends NotificationView {
    * Rules that do not match any accounts are discarded
    */
   findMatchingRules() {
+    const nbNewTransactionsByAccountId = mapValues(
+      groupBy(
+        this.data.transactions.filter(
+          process.env.NODE_ENV === 'test' ? () => true : isNewTransaction
+        ),
+        tr => tr.account
+      ),
+      transactions => transactions.length
+    )
     return this.rules
       .filter(rule => rule.enabled)
       .map(rule => ({
         rule,
-        accounts: this.data.accounts.filter(acc =>
-          this.filterForRule(rule, acc)
-        )
+        accounts: this.data.accounts
+          .filter(account => nbNewTransactionsByAccountId[account._id] > 0)
+          .filter(acc => this.filterForRule(rule, acc))
       }))
       .filter(({ accounts }) => accounts.length > 0)
   }
@@ -111,20 +124,37 @@ class BalanceLower extends NotificationView {
 
     log('info', `BalanceLower: ${accounts.length} accountsFiltered`)
 
-    return {
+    this.templateData = {
       matchingRules,
       accounts,
       institutions: groupAccountsByInstitution(accounts),
       date: getCurrentDate(),
       ...this.urls
     }
+
+    return this.templateData
   }
 
   getExtraAttributes() {
     return merge(super.getExtraAttributes(), {
       data: {
         route: '/balances'
-      }
+      },
+      state: JSON.stringify({
+        accounts: this.templateData.accounts
+          .map(account => ({
+            _id: account._id,
+            balance: account.balance
+          }))
+          .sort(byIdSorter)
+      }),
+      categoryId: this.templateData.matchingRules
+        .map(({ rule }) =>
+          rule.accountOrGroup
+            ? `${rule.accountOrGroup._type}:${rule.accountOrGroup._id}:${rule.value}`
+            : `all:${rule.value}`
+        )
+        .join(',')
     })
   }
 

--- a/src/ducks/notifications/BalanceLower/index.spec.js
+++ b/src/ducks/notifications/BalanceLower/index.spec.js
@@ -47,6 +47,7 @@ describe('balance lower', () => {
         }
       ],
       data: {
+        transactions: operations,
         accounts: fixtures['io.cozy.bank.accounts'],
         groups: fixtures['io.cozy.bank.groups']
       },
@@ -140,6 +141,21 @@ describe('balance lower', () => {
       expect(unique(accounts.map(getIDFromAccount))).toEqual(['comptelou1'])
       expect(minValueBy(accounts, getAccountBalance)).toBeLessThan(500)
       expect(maxValueBy(accounts, getAccountBalance)).toBe(325.24)
+    })
+
+    it('should compute correct state', async () => {
+      const { notification } = setup({
+        value: 500,
+        accountOrGroup: isabelleGroup
+      })
+      await notification.buildData()
+      const extraAttributes = await notification.getExtraAttributes()
+      expect(extraAttributes).toEqual(
+        expect.objectContaining({
+          categoryId: 'io.cozy.bank.groups:isabelle:500',
+          state: '{"accounts":[{"_id":"comptelou1","balance":325.24}]}'
+        })
+      )
     })
   })
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -59,12 +59,12 @@ const customToText = cozyHTMLEmail => {
 }
 
 class LateHealthReimbursement extends NotificationView {
-  constructor(config) {
-    super(config)
-    this.interval = config.value
+  constructor(options) {
+    super(options)
+    this.interval = options.value
   }
 
-  async getTransactions() {
+  async fetchTransactions() {
     const DATE_FORMAT = 'YYYY-MM-DD'
     const today = new Date()
     const lt = formatDate(subDays(today, this.interval), DATE_FORMAT)
@@ -130,7 +130,7 @@ class LateHealthReimbursement extends NotificationView {
     return toNotify
   }
 
-  getAccounts(transactions) {
+  fetchAccounts(transactions) {
     const accountIds = uniq(
       transactions.map(transaction => transaction.account)
     )
@@ -138,7 +138,7 @@ class LateHealthReimbursement extends NotificationView {
   }
 
   async fetchData() {
-    const transactions = await this.getTransactions()
+    const transactions = await this.fetchTransactions()
 
     if (transactions.length === 0) {
       log('info', 'No late health reimbursement')
@@ -148,7 +148,7 @@ class LateHealthReimbursement extends NotificationView {
     log('info', `${transactions.length} late health reimbursements`)
 
     log('info', 'Fetching accounts for late health reimbursements')
-    const accounts = await this.getAccounts(transactions)
+    const accounts = await this.fetchAccounts(transactions)
     log(
       'info',
       `${accounts.length} accounts fetched for late health reimbursements`

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -123,7 +123,7 @@ class LateHealthReimbursement extends NotificationView {
         !isAlreadyNotified(lateReimbursement, LateHealthReimbursement)
     )
 
-    log('info', `${toNotify} need to be notified`)
+    log('info', `${toNotify.length} need to be notified`)
 
     this.toNotify = toNotify
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -186,10 +186,13 @@ class LateHealthReimbursement extends NotificationView {
   }
 
   /**
+   * Saves last notification date to transactions for which there was
+   * the notification.
+   *
    * Executed by `Notification` when the notification has been successfuly sent
    * See `Notification::sendNotification`
    */
-  async onSendNotificationSuccess() {
+  async onSuccess() {
     this.toNotify.forEach(reimb => {
       if (!reimb.cozyMetadata) {
         reimb.cozyMetadata = {}

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -27,6 +27,17 @@ const SINGLE_TRANSACTION = 'single'
 const MULTI_TRANSACTION = 'multi'
 const MULTI_TRANSACTION_MULTI_RULES = 'multi-rules'
 
+/**
+ * @typedef {object} Rule
+ */
+
+/**
+ * @typedef {object} RuleResult
+ * @property {Rule} rule - The rule being matched
+ * @property {Array<Transaction>} transactions - Transactions that matched the rule
+ *
+ */
+
 // During tests, it is difficult to keep transactions with
 // first _rev since we replace replace existing transactions, this
 // is why we deactivate the isNewTransaction during tests
@@ -88,12 +99,22 @@ const makeAccountOrGroupFilter = (groups, accountOrGroup) => {
   }
 }
 
+/**
+ * Sends a notification when a transaction amount is greater than
+ * a threshold.
+ */
 class TransactionGreater extends NotificationView {
   constructor(config) {
     super(config)
     this.rules = config.rules
   }
 
+  /**
+   * Creates a filtering function from a rule
+   *
+   * @param  {Rule} rule - A rule
+   * @return {function(Transaction): Boolean} - Predicates that check if a transaction matches rule
+   */
   filterForRule(rule) {
     const fourDaysAgo = subDays(new Date(), 4)
 
@@ -114,9 +135,10 @@ class TransactionGreater extends NotificationView {
   }
 
   /**
-   * Returns a list of [{ rule, transactions }]
    * For each rule, returns a list of matching transactions
    * Rules that do not match any transactions are discarded
+   *
+   * @return {Array<RuleResult>}
    */
   findMatchingRules() {
     return this.rules
@@ -132,7 +154,7 @@ class TransactionGreater extends NotificationView {
     const { accounts } = this.data
     const matchingRules = this.findMatchingRules()
     const transactionsFiltered = uniqBy(
-      flatten(matchingRules.map(x => x.transactions)),
+      flatten(matchingRules.map(result => result.transactions)),
       getDocumentId
     )
     return {
@@ -189,6 +211,9 @@ class TransactionGreater extends NotificationView {
     }
   }
 
+  /**
+   * @return {string} - The title of the notification
+   */
   getTitle(templateData) {
     const { transactions, matchingRules } = templateData
     const onlyOne = transactions.length === 1

--- a/src/ducks/notifications/TransactionGreater/index.spec.js
+++ b/src/ducks/notifications/TransactionGreater/index.spec.js
@@ -15,10 +15,7 @@ const addId = doc => {
   return { ...doc, _id: doc._id || Math.random().toString() }
 }
 
-const prepareTransactionForTest = compose(
-  addRev,
-  addId
-)
+const prepareTransactionForTest = compose(addRev, addId)
 
 const unique = arr => Array.from(new Set(arr))
 
@@ -119,16 +116,17 @@ describe('transaction greater', () => {
     it('should compute relevant transactions', async () => {
       const { notification } = setup()
       const { transactions } = await notification.buildData()
-      expect(transactions).toHaveLength(116)
+      expect(transactions).toHaveLength(117)
     })
     it('should compute relevant transactions for a different value', async () => {
       const { notification } = setup({ value: 100 })
       const { transactions } = await notification.buildData()
-      expect(transactions).toHaveLength(22)
+      expect(transactions).toHaveLength(23)
       expect(unique(transactions.map(getAccountIDFromTransaction))).toEqual([
         'compteisa1',
         'compteisa3',
-        'comptegene1'
+        'comptegene1',
+        'compteisa4'
       ])
     })
   })

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -124,6 +124,10 @@ export const sendNotificationForClass = async (
   }
 }
 
+/**
+ * Fetches relevant data, instantiates enabled notification classes and
+ * sends push notifications
+ */
 export const sendNotifications = async (config, transactions) => {
   const enabledNotificationClasses = getEnabledNotificationClasses(config)
   const client = CozyClient.fromEnv(process.env)

--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -127,6 +127,9 @@ export const sendNotificationForClass = async (
 /**
  * Fetches relevant data, instantiates enabled notification classes and
  * sends push notifications
+ *
+ * @param {object} config - io.cozy.bank.settings document
+ * @param {object} transactions - Transactions that have changed
  */
 export const sendNotifications = async (config, transactions) => {
   const enabledNotificationClasses = getEnabledNotificationClasses(config)

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1435,6 +1435,15 @@
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
       "label": "maintenance"
+    },
+    {
+      "_id": "soldeinitialcompteisa4",
+      "account": "compteisa4",
+      "amount": 10000,
+      "manualCategoryId": "400140",
+      "currency": "€",
+      "date": "2018-06-21T00:00:00Z",
+      "label": "Solde initial"
     }
   ],
   "io.cozy.bills": [


### PR DESCRIPTION
To remove the possibility of duplicate notifications, we send a state
to the stack at the same time that we send the notification. When a
notification is declared as stateful in the manifest, the stack will
not send a notification if it has the same state as the previous one.

This PR is in draft as we have to work more on the state that we want
to store. Particularly for balance lower alerts, it might be better
to store all balances for all accounts instead of only the balance
for accounts for which there are changed transactions.

Since we have to work more on the spec, this PR is deprioritized
in favor of the quickfix "not sending the notification for a change
of category".