### PR TITLE
feat: Do not trigger onOperationOrBillCreate on change of category

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -67,7 +67,7 @@
     "onOperationOrBillCreate": {
       "type": "node",
       "file": "onOperationOrBillCreate.js",
-      "trigger": "@event io.cozy.bills:CREATED io.cozy.bank.operations:UPDATED:!=:manualCategoryId",
+      "trigger": "@event io.cozy.bills:CREATED",
       "debounce": "75s"
     },
     "categorization": {


### PR DESCRIPTION
This would trigger unwanted notifications, a paper Notifications doublées dans Banks describes in more detail the problem.