### PR TITLE
feat: Format floating amounts with 2 numbers after comma

### DIFF
--- a/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
+++ b/src/ducks/budgetAlerts/CategoryBudgetNotificationView.js
@@ -2,6 +2,9 @@ import sumBy from 'lodash/sumBy'
 import keyBy from 'lodash/keyBy'
 import merge from 'lodash/merge'
 
+import logger from 'cozy-logger'
+import { Q } from 'cozy-client'
+
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import NotificationView from 'ducks/notifications/BaseNotificationView'
 import { getCurrentDate } from 'ducks/notifications/utils'
@@ -12,10 +15,7 @@ import { getAccountLabel } from 'ducks/account/helpers'
 import template from './template.hbs'
 import { fetchCategoryAlerts } from './index'
 import { buildNotificationData } from './service'
-
-import logger from 'cozy-logger'
-
-import { Q } from 'cozy-client'
+import { formatAmount } from 'ducks/notifications/utils'
 
 const log = logger.namespace('category-budgets')
 
@@ -142,10 +142,14 @@ class CategoryBudget extends NotificationView {
       ? budgetAlerts
           .map(
             alert =>
-              `${alert.categoryLabel}: ${alert.currentAmount}€ > ${alert.maxThreshold}€`
+              `${alert.categoryLabel}: ${formatAmount(
+                alert.currentAmount
+              )}€ > ${alert.maxThreshold}€`
           )
           .join(', ')
-      : `${budgetAlerts[0].currentAmount}€ > ${budgetAlerts[0].maxThreshold}€`
+      : `${formatAmount(budgetAlerts[0].currentAmount)}€ > ${
+          budgetAlerts[0].maxThreshold
+        }€`
   }
 
   getExtraAttributes() {

--- a/src/ducks/budgetAlerts/service.spec.js
+++ b/src/ducks/budgetAlerts/service.spec.js
@@ -112,6 +112,9 @@ describe('service', () => {
         ]
       )
       expect(mockPostNotification).toHaveBeenCalledTimes(1)
+      expect(
+        mockPostNotification.mock.calls[0][0].data.attributes.message
+      ).toEqual('735€ > 100€')
     })
   })
 

--- a/src/ducks/future/useEstimatedBudget.spec.jsx
+++ b/src/ducks/future/useEstimatedBudget.spec.jsx
@@ -55,7 +55,7 @@ describe('useEstimatedBudget', () => {
     const { result } = renderHook(() => useEstimatedBudget(), { wrapper })
     expect(result.current).toEqual({
       isLoading: false,
-      estimatedBalance: 47833.45,
+      estimatedBalance: 47833.36,
       sumTransactions: 3870.54,
       currency: undefined,
       transactions: [

--- a/src/ducks/notifications/BalanceLower/index.js
+++ b/src/ducks/notifications/BalanceLower/index.js
@@ -7,7 +7,7 @@ import merge from 'lodash/merge'
 import log from 'cozy-logger'
 import { getAccountBalance } from 'ducks/account/helpers'
 import { getCurrencySymbol } from 'utils/currencySymbol'
-import { getCurrentDate } from 'ducks/notifications/utils'
+import { getCurrentDate, formatAmount } from 'ducks/notifications/utils'
 import template from './template.hbs'
 import { toText } from 'cozy-notifications'
 import { ruleAccountFilter } from 'ducks/settings/ruleUtils'
@@ -160,9 +160,9 @@ class BalanceLower extends NotificationView {
     return accounts
       .map(account => {
         const balance = getAccountBalance(account)
-        return `${account.label} ${
-          balance > 0 ? '+' : ''
-        }${balance}${getCurrencySymbol(account.currency)}`
+        return `${account.label} ${balance > 0 ? '+' : ''}${formatAmount(
+          balance
+        )}${getCurrencySymbol(account.currency)}`
       })
       .join(', ')
   }

--- a/src/ducks/notifications/BalanceLower/index.spec.js
+++ b/src/ducks/notifications/BalanceLower/index.spec.js
@@ -127,7 +127,7 @@ describe('balance lower', () => {
         'comptelou1'
       ])
       expect(minValueBy(accounts, getAccountBalance)).toBeLessThan(5000)
-      expect(maxValueBy(accounts, getAccountBalance)).toBe(3974.25)
+      expect(maxValueBy(accounts, getAccountBalance)).toBe(3974.2)
     })
 
     it('should compute relevant accounts for a different value', async () => {
@@ -186,7 +186,7 @@ describe('balance lower', () => {
           '4 accounts are below your threshold amount of 5000€'
         )
         expect(pushContent).toBe(
-          'PEE Isabelle +1421.22€, Compte courant Claude +4135.62€, Compte courant Isabelle +3974.25€, Compte jeune Louise +325.24€'
+          'PEE Isabelle +1421.20€, Compte courant Claude +4135.62€, Compte courant Isabelle +3974.20€, Compte jeune Louise +325.24€'
         )
       })
     })
@@ -198,7 +198,7 @@ describe('balance lower', () => {
         })
         expect(title).toBe('4 accounts are below their threshold amount')
         expect(pushContent).toBe(
-          'Compte jeune Louise +325.24€, PEE Isabelle +1421.22€, Compte courant Claude +4135.62€, Compte courant Isabelle +3974.25€'
+          'Compte jeune Louise +325.24€, PEE Isabelle +1421.20€, Compte courant Claude +4135.62€, Compte courant Isabelle +3974.20€'
         )
       })
     })

--- a/src/ducks/notifications/DelayedDebit/index.js
+++ b/src/ducks/notifications/DelayedDebit/index.js
@@ -1,5 +1,10 @@
 import NotificationView from '../BaseNotificationView'
 import logger from 'cozy-logger'
+import map from 'lodash/map'
+import groupBy from 'lodash/groupBy'
+import keyBy from 'lodash/keyBy'
+import merge from 'lodash/merge'
+
 import {
   getAccountBalance,
   getAccountType,
@@ -7,11 +12,8 @@ import {
 } from 'ducks/account/helpers'
 import { endOfMonth, subDays, isWithinRange } from 'date-fns'
 import { BankAccount } from 'cozy-doctypes'
-import map from 'lodash/map'
-import groupBy from 'lodash/groupBy'
-import keyBy from 'lodash/keyBy'
-import merge from 'lodash/merge'
 import { getAccountNewBalance } from 'ducks/notifications/helpers'
+import { formatAmount } from 'ducks/notifications/utils'
 import { getCurrentDate } from 'ducks/notifications/utils'
 import template from './template.hbs'
 import { toText } from 'cozy-notifications'
@@ -146,7 +148,7 @@ class DelayedDebit extends NotificationView {
   getTitle(templateData) {
     const account = templateData.institutions[0].accounts[0]
     return this.t('Notifications.delayed-debit.notification.title', {
-      balance: getAccountNewBalance(account),
+      balance: formatAmount(getAccountNewBalance(account)),
       currency: '€',
       label: getAccountLabel(account.checkingsAccount.data)
     })

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -1,21 +1,28 @@
 import { subDays } from 'date-fns'
-import NotificationView from 'ducks/notifications/BaseNotificationView'
-import fromPairs from 'lodash/fromPairs'
-import sortBy from 'lodash/sortBy'
-import log from 'cozy-logger'
-import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
-import { getAccountLabel } from 'ducks/account/helpers'
-import { isTransactionAmountGreaterThan } from 'ducks/notifications/helpers'
-import { getCurrencySymbol } from 'utils/currencySymbol'
-import template from './template.hbs'
-import { prepareTransactions, getCurrentDate } from 'ducks/notifications/utils'
-import { toText } from 'cozy-notifications'
 import uniqBy from 'lodash/uniqBy'
 import flatten from 'lodash/flatten'
 import overEvery from 'lodash/overEvery'
 import merge from 'lodash/merge'
 import groupBy from 'lodash/groupBy'
+import fromPairs from 'lodash/fromPairs'
+import sortBy from 'lodash/sortBy'
+
+import log from 'cozy-logger'
+import { toText } from 'cozy-notifications'
+
+import NotificationView from 'ducks/notifications/BaseNotificationView'
+import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
+import { getAccountLabel } from 'ducks/account/helpers'
+import { isTransactionAmountGreaterThan } from 'ducks/notifications/helpers'
+import { getCurrencySymbol } from 'utils/currencySymbol'
+import {
+  prepareTransactions,
+  getCurrentDate,
+  formatAmount
+} from 'ducks/notifications/utils'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
+
+import template from './template.hbs'
 
 const getDocumentId = x => x._id
 
@@ -199,13 +206,13 @@ class TransactionGreater extends NotificationView {
       notificationSubtype === SINGLE_TRANSACTION
         ? {
             firstTransaction: firstTransaction,
-            amount: Math.abs(firstTransaction.amount),
+            amount: formatAmount(Math.abs(firstTransaction.amount)),
             currency: getCurrencySymbol(firstTransaction.currency)
           }
         : notificationSubtype === MULTI_TRANSACTION
         ? {
             transactionsLength: transactions.length,
-            maxAmount: matchingRules[0].rule.value
+            maxAmount: formatAmount(matchingRules[0].rule.value)
           }
         : {
             transactionsLength: transactions.length,
@@ -230,9 +237,9 @@ class TransactionGreater extends NotificationView {
     const [transaction] = sortBy(transactions, getDate).reverse()
 
     if (notificationSubtype === SINGLE_TRANSACTION) {
-      return `${transaction.label} : ${transaction.amount}${getCurrencySymbol(
-        transaction.currency
-      )}`
+      return `${transaction.label} : ${formatAmount(
+        transaction.amount
+      )}${getCurrencySymbol(transaction.currency)}`
     } else {
       const transactionGroupedByAccount = groupBy(transactions, x => x.account)
       const groups = Object.entries(transactionGroupedByAccount).map(

--- a/src/ducks/notifications/utils.js
+++ b/src/ducks/notifications/utils.js
@@ -47,3 +47,6 @@ export const treatedByFormat = function(reimbursements, billsById) {
 export const getCurrentDate = () => {
   return new Date()
 }
+
+export const formatAmount = amount =>
+  amount % 1 !== 0 ? amount.toFixed(2) : amount

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -34,7 +34,7 @@
       "label": "PEE Isabelle",
       "institutionLabel": "HSBC (sans Secure Key)",
       "number": "{{int 1000000 9999999}}",
-      "balance": 1421.22,
+      "balance": 1421.20,
       "description": "Premier compte sans connaitre l id pour generer le doc",
       "type": "Savings",
       "cozyMetadata": {
@@ -67,7 +67,7 @@
       "label": "Compte courant Isabelle",
       "institutionLabel": "BNPP",
       "number": "{{int 1000000 9999999}}",
-      "balance": 3974.25,
+      "balance": 3974.20,
       "type": "Checkings",
       "cozyMetadata": {
         "createdByApp": "bnpparibas82"
@@ -78,7 +78,7 @@
       "label": "Livret A Isabelle",
       "institutionLabel": "La Banque Postale",
       "number": "{{int 1000000 9999999}}",
-      "balance": 11635.12,
+      "balance": 11635.10,
       "type": "Savings",
       "cozyMetadata": {
         "createdByApp": "bnpparibas82"
@@ -1549,7 +1549,7 @@
     {
       "vendor": "Harmonie",
       "subtype": "VIR COMPL SANTE",
-      "amount": 18,
+      "amount": 18.5,
       "isRefund": true,
       "date": "2017-07-18T00:00:00Z",
       "_id": "avrilrembourcomplcla32",


### PR DESCRIPTION
Amounts with a floating part should be formatted with 2 numbers after
the comma (before we could have 10.5) in the push notification

- TransactionGreater
- BalanceLower