### PR TITLE
feat: Upgrade harvest

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "5.10.1",
+    "cozy-harvest-lib": "6.1.0",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",
     "cozy-konnector-libs": "4.30.3-beta.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4813,10 +4813,10 @@ cozy-bar@8.1.1:
     redux-thunk "2.3.0"
     semver-compare "^1.0.0"
 
-cozy-bi-auth@0.0.20:
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.20.tgz#43cd81da9c63725789b75fb4d946cb7a9cd2b67f"
-  integrity sha512-ecz8gTKMDo7hRNAyvIuo0ejSkOqG/1GOIqTY/IFwZzFL3hX8j8fQ4Fq/JaijSD8Qr/T3NOhvqTYZOEdBj1CqUA==
+cozy-bi-auth@0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/cozy-bi-auth/-/cozy-bi-auth-0.0.21.tgz#f915a5798f402610e5de8cda53a23036adfc21e9"
+  integrity sha512-q4nho7WFwqPR+m5eIWpNM9Hk0frJdcw2eSIqJDh0DS1qry4IOnpg6N2DiY7QSsnvv3ck76MT7azYDMST6X7SUw==
   dependencies:
     cozy-logger "^1.3.0"
     lodash "^4.17.20"
@@ -4933,7 +4933,7 @@ cozy-doctypes@1.39.0:
     es6-promise-pool "2.5.0"
     lodash "4.17.11"
 
-cozy-doctypes@1.82.2:
+cozy-doctypes@1.82.2, cozy-doctypes@^1.82.2:
   version "1.82.2"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.82.2.tgz#7c7d6f44e3aaee18ba51253468e84d2d1a70fde6"
   integrity sha512-NWbQ6rKj2a+Rq19MX9uNa8GNlzwdlye9pxiC1V3jd+76T5fQMQN+tjHr9jK468V/NJvC/oQowAcWsRoMaB5A+Q==
@@ -4944,7 +4944,7 @@ cozy-doctypes@1.82.2:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.62.0, cozy-doctypes@^1.63.2, cozy-doctypes@^1.81.0:
+cozy-doctypes@^1.62.0, cozy-doctypes@^1.63.2:
   version "1.81.0"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.81.0.tgz#27a5eefdac269c4058ba3dade240620835208bdf"
   integrity sha512-JLocUEqt40/6N3mM3IosVfS0XhOPW0NDDtLaXtMRzR2a0WMHzQVRZLfUbtvYljvXu46lYylUVQQU1zdmg76XHw==
@@ -4976,15 +4976,15 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@5.10.1:
-  version "5.10.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-5.10.1.tgz#2b5cd59a511acd16955c19f5f2280b039a8eb8ac"
-  integrity sha512-YcTCg09IU2ZQ0E18kVRb4Z0NW9LdxPXjXFRwQxbGKEHbCj78kC0rxBavOq7ZwDOwQuHK0T15hIXdC31YWL1Peg==
+cozy-harvest-lib@6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.1.0.tgz#ee921fc271ecad9cb8b9b1df5d047acd746216d3"
+  integrity sha512-ztqz1Zvi7bAmNQ9T1i9AuePRDA2XVq0fsaJpy8tdcnXfKK1RGM/3UhMlwgi4FKEnAEjBmB9RjDJGLGwVOaQYrg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
-    cozy-bi-auth "0.0.20"
-    cozy-doctypes "^1.81.0"
+    cozy-bi-auth "0.0.21"
+    cozy-doctypes "^1.82.2"
     cozy-logger "^1.7.0"
     date-fns "^1.30.1"
     final-form "^4.18.5"


### PR DESCRIPTION
Allows you to have certain requested features, in particular :
- feat: Remove references to "cozy" in harvest locales
Makes it easier to customize and whitelabel the UI
- Show konnector error in both data and configuration tab in harvest
- Open external links in a new tab not to lose the Cozy context

BREAKING CHANGES
When using the TriggerManager outside the main Harvest Routes, you need to import { IntentTriggerManager } from 'cozy-harvest-lib', instead of `import { TriggerManager } from 'cozy-harvest-lib'.

For more information on features: 
[CHANGELOG](https://github.com/cozy/cozy-libs/blob/master/packages/cozy-harvest-lib/CHANGELOG.md)
