### PR TITLE
fix: Do not bind onRef if its not passed

### DIFF
--- a/src/ducks/transactions/TransactionRow.jsx
+++ b/src/ducks/transactions/TransactionRow.jsx
@@ -123,7 +123,7 @@ export const RowDesktop = React.memo(function RowDesktop(props) {
   } = props
 
   const boundOnRef = useMemo(() => {
-    return onRef.bind(null, transaction._id)
+    return onRef ? onRef.bind(null, transaction._id) : null
   }, [onRef, transaction])
 
   const categoryId = getCategoryId(transaction)


### PR DESCRIPTION
onRef is not passed in the recurrence bundle page since it is not needed.
In those cases, TransactionRow should not try to bind the onRef function.