### PR TITLE
fix: Add missing query string

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.jsx
+++ b/src/components/KonnectorUpdateInfo/index.jsx
@@ -58,7 +58,7 @@ const KonnectorUpdateInfo = ({ outdatedKonnectors }) => {
             className="u-mh-0"
             label={t('KonnectorUpdateInfo.cta')}
             icon="openwith"
-            href={url}
+            href={`${url}&pendingUpdate=true`}
           />
         }
         title={t('KonnectorUpdateInfo.title')}

--- a/src/components/KonnectorUpdateInfo/index.spec.jsx
+++ b/src/components/KonnectorUpdateInfo/index.spec.jsx
@@ -30,7 +30,7 @@ describe('KonnectorUpdateInfo', () => {
 
     const link = root.getByText('Update my banks').closest('a')
     expect(link.getAttribute('href')).toEqual(
-      'http://store.cozy.tools:8080/#/discover/?type=konnector&category=banking',
+      'http://store.cozy.tools:8080/#/discover/?type=konnector&category=banking&pendingUpdate=true',
       () => {}
     )
   })


### PR DESCRIPTION
fix: Add missing query string to show only pending update

Before we display all the store's bank connectors, now only those that are awaiting update