### PR TITLE
feat: Load less data for home page

### DIFF
--- a/src/components/__snapshots__/AppRoute.spec.jsx.snap
+++ b/src/components/__snapshots__/AppRoute.spec.jsx.snap
@@ -99,7 +99,13 @@ exports[`App route should be a function returning a route 1`] = `
           component={[Function]}
         />
         <Route
-          component={[Function]}
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "compare": null,
+              "type": [Function],
+            }
+          }
           path="accounts"
         />
         <Route
@@ -235,7 +241,13 @@ exports[`App route should have renderExtraRoutes 1`] = `
           component={[Function]}
         />
         <Route
-          component={[Function]}
+          component={
+            Object {
+              "$$typeof": Symbol(react.memo),
+              "compare": null,
+              "type": [Function],
+            }
+          }
           path="accounts"
         />
         <Route

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -1,5 +1,6 @@
 import fromPairs from 'lodash/fromPairs'
 import CozyClient, { QueryDefinition, HasManyInPlace, Q } from 'cozy-client'
+import subYears from 'date-fns/sub_years'
 
 export const RECIPIENT_DOCTYPE = 'io.cozy.bank.recipients'
 export const ACCOUNT_DOCTYPE = 'io.cozy.bank.accounts'
@@ -212,6 +213,25 @@ export const transactionsConn = {
       .include(['bills', 'account', 'reimbursements', 'recurrence']),
   as: 'transactions',
   fetchPolicy: older30s
+}
+
+export const makeBalanceTransactionsConn = () => {
+  const fromDate = subYears(new Date(), 1).toISOString()
+  return {
+    as: 'home/transactions',
+    query: () =>
+      Q(TRANSACTION_DOCTYPE)
+        .limitBy(1000)
+        .where({
+          date: {
+            $gt: fromDate
+          }
+        })
+        .sortBy([{ date: 'asc' }])
+        .indexFields(['date'])
+        .select(['date', 'amount', 'account']),
+    fetchPolicy: older30s
+  }
 }
 
 export const appsConn = {

--- a/src/ducks/balance/BalanceHeader.jsx
+++ b/src/ducks/balance/BalanceHeader.jsx
@@ -1,16 +1,16 @@
 import React, { memo } from 'react'
-import compose from 'lodash/flowRight'
-import { useI18n } from 'cozy-ui/transpiled/react'
 
-import { transactionsConn } from 'doctypes'
+import { useQuery } from 'cozy-client'
+import flag from 'cozy-flags'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { transactionsConn, makeBalanceTransactionsConn } from 'doctypes'
 import Padded from 'components/Padded'
 import Header from 'components/Header'
 import KonnectorUpdateInfo from 'components/KonnectorUpdateInfo'
 import History, { HistoryFallback } from 'ducks/balance/History'
 import HeaderTitle from 'ducks/balance/HeaderTitle'
 import Delayed from 'components/Delayed'
-import { queryConnect } from 'cozy-client'
-import flag from 'cozy-flags'
 
 import styles from 'ducks/balance/BalanceHeader.styl'
 import LegalMention from 'ducks/legal/LegalMention'
@@ -20,9 +20,12 @@ const BalanceHeader = ({
   accountsBalance,
   accounts,
   subtitleParams,
-  onClickBalance,
-  transactions
+  onClickBalance
 }) => {
+  const conn = flag('banks.perf.use-balance-transactions-conn')
+    ? makeBalanceTransactionsConn()
+    : transactionsConn
+  const transactions = useQuery(conn.query, conn)
   const { t } = useI18n()
   const subtitle = subtitleParams
     ? t('BalanceHistory.checked-accounts', subtitleParams)
@@ -60,9 +63,4 @@ const BalanceHeader = ({
 
 export const DumbBalanceHeader = BalanceHeader
 
-export default compose(
-  memo,
-  queryConnect({
-    transactions: transactionsConn
-  })
-)(BalanceHeader)
+export default memo(BalanceHeader)

--- a/src/ducks/balance/History.jsx
+++ b/src/ducks/balance/History.jsx
@@ -69,12 +69,13 @@ class History extends Component {
   }
 
   getTransactionsFilteredHelper(transactions) {
+    const filteredTransactions = transactions.data.filter(t => {
+      // Use .date as to get the debit date
+      return t && t.date && isAfter(new Date(t.date), oneYearBefore)
+    })
     return {
       ...transactions,
-      data: transactions.data.filter(t => {
-        // Use .date as to get the debit date
-        return t && t.date && isAfter(new Date(t.date), oneYearBefore)
-      })
+      data: filteredTransactions
     }
   }
 

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { memo } from 'react'
 
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
@@ -63,4 +63,4 @@ const AccountsSettings = () => {
   )
 }
 
-export default AccountsSettings
+export default memo(AccountsSettings)

--- a/src/utils/currencySymbol.js
+++ b/src/utils/currencySymbol.js
@@ -13,11 +13,11 @@ export const getCurrencySymbol = currency => {
   if (typeof currency === 'object') {
     // currency :
     // { crypto, datetime, id, marketcap, name, precision, prefix, symbol }
-    return (
-      currency.symbol ||
-      CURRENCY_TO_SYMBOL[currency.id] ||
-      DEFAULT_CURRENCY_SYMBOL
-    )
+    return currency
+      ? currency.symbol ||
+          CURRENCY_TO_SYMBOL[currency.id] ||
+          DEFAULT_CURRENCY_SYMBOL
+      : DEFAULT_CURRENCY_SYMBOL
   }
 
   return DEFAULT_CURRENCY_SYMBOL


### PR DESCRIPTION
Part of the effort to decrease the data loaded by banks (see https://github.com/cozy/cozy-banks/issues/2101).

Here, the request for the chart showing the evolution of the account is changed : only the last year transactions are loaded and only relevant fields for the graph are fetched (account, currency) etc..