### PR TITLE
fix: Hack to avoid slower transition in tabs

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -52,6 +52,7 @@ import { filterByAccounts } from 'ducks/filters'
 import { trackPage } from 'ducks/tracking/browser'
 import { isVirtualAccount } from 'ducks/balance/helpers'
 import ImportGroupPanel from 'ducks/balance/ImportGroupPanel'
+import Delayed from 'components/Delayed'
 
 const syncPouchImmediately = async client => {
   const pouchLink = client.links.find(link => link.pouches)
@@ -410,23 +411,30 @@ class Balance extends PureComponent {
           accounts={checkedAccounts}
           subtitleParams={subtitleParams}
         />
-        <Padded
-          className={cx({
-            [styles.Balance__panelsContainer]: true
-          })}
-        >
-          <ImportGroupPanel />
-          <BalancePanels
-            groups={groups}
-            panelsState={this.state.panels}
-            onSwitchChange={this.handleSwitchChange}
-            onPanelChange={this.debouncedHandlePanelChange}
-          />
-        </Padded>
+        <Delayed delay={this.props.delayContent}>
+          <Padded
+            className={cx({
+              [styles.Balance__panelsContainer]: true
+            })}
+          >
+            <ImportGroupPanel />
+            <BalancePanels
+              groups={groups}
+              panelsState={this.state.panels}
+              onSwitchChange={this.handleSwitchChange}
+              onPanelChange={this.debouncedHandlePanelChange}
+            />
+          </Padded>
+        </Delayed>
       </Fragment>
     )
   }
 }
+
+Balance.defaultProps = {
+  delayContent: 0
+}
+
 export const DumbBalance = Balance
 
 const actionCreators = {

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -35,6 +35,7 @@ import { getDate } from 'ducks/transactions/helpers'
 import { trackPage } from 'ducks/tracking/browser'
 import { TransactionsPageWithBackButton } from 'ducks/transactions'
 import { onSubcategory } from './utils'
+import Delayed from 'components/Delayed'
 
 const isCategoryDataEmpty = categoryData => {
   return categoryData[0] && isNaN(categoryData[0].percentage)
@@ -50,7 +51,7 @@ const goToCategory = (router, selectedCategory, subcategory) => {
   }
 }
 
-class CategoriesPage extends Component {
+export class CategoriesPage extends Component {
   componentDidMount() {
     const { filteringDoc, resetFilterByDoc } = this.props
     if (
@@ -158,33 +159,39 @@ class CategoriesPage extends Component {
           hasAccount={hasAccount}
           chart={!isSubcategory}
         />
-        {hasAccount &&
-          (isFetching ? (
-            <Padded className="u-pt-0">
-              <Loading loadingType="categories" />
-            </Padded>
-          ) : !isSubcategory ? (
-            <Categories
-              categories={sortedCategories}
-              selectedCategory={selectedCategory}
-              selectedCategoryName={categoryName}
-              selectCategory={(selectedCategory, subcategory) =>
-                goToCategory(router, selectedCategory, subcategory)
-              }
-              withIncome={showIncomeCategory}
-              filterWithInCome={this.filterWithInCome}
-            />
-          ) : (
-            <TransactionsPageWithBackButton
-              className="u-pt-0"
-              showFutureBalance={false}
-              showTriggerErrors={false}
-              showHeader={false}
-            />
-          ))}
+        <Delayed delay={this.props.delayContent}>
+          {hasAccount &&
+            (isFetching ? (
+              <Padded className="u-pt-0">
+                <Loading loadingType="categories" />
+              </Padded>
+            ) : !isSubcategory ? (
+              <Categories
+                categories={sortedCategories}
+                selectedCategory={selectedCategory}
+                selectedCategoryName={categoryName}
+                selectCategory={(selectedCategory, subcategory) =>
+                  goToCategory(router, selectedCategory, subcategory)
+                }
+                withIncome={showIncomeCategory}
+                filterWithInCome={this.filterWithInCome}
+              />
+            ) : (
+              <TransactionsPageWithBackButton
+                className="u-pt-0"
+                showFutureBalance={false}
+                showTriggerErrors={false}
+                showHeader={false}
+              />
+            ))}
+        </Delayed>
       </Fragment>
     )
   }
+}
+
+CategoriesPage.defaultProps = {
+  delayContent: 0
 }
 
 const mapDispatchToProps = dispatch => ({

--- a/src/ducks/settings/Settings.jsx
+++ b/src/ducks/settings/Settings.jsx
@@ -8,8 +8,9 @@ import Padded from 'components/Padded'
 import styles from 'ducks/settings/Settings.styl'
 import LegalMention from 'ducks/legal/LegalMention'
 import TabsHeader from 'ducks/settings/TabsHeader'
+import Delayed from 'components/Delayed'
 
-const Settings = ({ children }) => {
+const Settings = ({ children, delayContent }) => {
   const { isMobile } = useBreakpoints()
 
   return (
@@ -17,10 +18,12 @@ const Settings = ({ children }) => {
       <BarTheme theme="primary" />
       <TabsHeader />
 
-      <Padded className={styles.Settings__Content}>
-        <LegalMention className={isMobile ? 'u-mb-half ' : 'u-mt-1'} />
-        {children}
-      </Padded>
+      <Delayed delay={delayContent}>
+        <Padded className={styles.Settings__Content}>
+          <LegalMention className={isMobile ? 'u-mb-half ' : 'u-mt-1'} />
+          {children}
+        </Padded>
+      </Delayed>
       {__TARGET__ === 'mobile' && (
         <Padded>
           <AppVersion version={__APP_VERSION__} />
@@ -28,6 +31,10 @@ const Settings = ({ children }) => {
       )}
     </>
   )
+}
+
+Settings.defaultProps = {
+  delayContent: 0
 }
 
 export default Settings


### PR DESCRIPTION
in the case of override where we add a navigation
with tabs that have an animation. The user has an
impression of slowness / lag. To avoid this, we
use a delay which allows the content to be
 rendered a few ms later.

By default in banks There's no delay