### PR TITLE
Fix recurrence

### DIFF
--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -10,6 +10,7 @@ import maxBy from 'lodash/maxBy'
 import uniq from 'lodash/uniq'
 import uniqBy from 'lodash/uniqBy'
 import getCategoryId from 'ducks/transactions/getCategoryId'
+import { getLabel } from './utils'
 
 const ONE_DAY = 86400 * 1000
 
@@ -121,8 +122,7 @@ export const sameLabel = bundle => {
   if (bundle.ops && bundle.ops.length > 0) {
     return bundle.ops[0].label
   } else {
-    // TODO use label helper
-    return bundle.manualLabel || bundle.automaticLabel
+    return getLabel(bundle)
   }
 }
 

--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -118,7 +118,7 @@ export const groupBundles = (bundles, rules) => {
 }
 
 export const sameLabel = bundle => {
-  if (bundle.ops) {
+  if (bundle.ops && bundle.ops.length > 0) {
     return bundle.ops[0].label
   } else {
     // TODO use label helper

--- a/src/ducks/recurrence/rules.spec.js
+++ b/src/ducks/recurrence/rules.spec.js
@@ -1,4 +1,4 @@
-import { mergeBundles } from './rules'
+import { mergeBundles, sameLabel } from './rules'
 
 const ops1 = [
   { _id: 't1', date: '2020-08-01', manualCategoryId: '400140' },
@@ -45,5 +45,24 @@ describe('merge hydrated bundles', () => {
     ]
     const merged = mergeBundles(bundles)
     expect(merged.categoryIds).toEqual(['400130', '400140', '400120'])
+  })
+})
+
+describe('sameLabel bundle', () => {
+  const makeBundle = (ops, manualLabel) => ({
+    ops,
+    manualLabel,
+    automaticLabel: 'automatic label'
+  })
+
+  it('should return label from ops bundle', () => {
+    expect(sameLabel(makeBundle([{ label: 'Operation label' }]))).toEqual(
+      'Operation label'
+    )
+  })
+
+  it('should return label from manual and automatic label', () => {
+    expect(sameLabel(makeBundle([], undefined))).toEqual('Automatic Label')
+    expect(sameLabel(makeBundle([], 'Manual label'))).toEqual('Manual label')
   })
 })


### PR DESCRIPTION
The recurrence service no longer worked. (Otherwise we have an error of the type: Cannot read property 'label' of undefined)

Before we filtered if there were no upstream operations then on updated the recurrences
```
const recurrences = (await fetchHydratedBundles(client)).filter(
      x => x.ops.length > 0
    )

findAndUpdateRecurrences(...)
```
Now we do it after, so it's necessary to check if there is at least one value in ops.
Because access to a property is impossible if the array is empty.

