### PR TITLE
Check if obj or src has operations in recurrency service

### DIFF
--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -4,6 +4,7 @@ import sum from 'lodash/sum'
 import mergeWith from 'lodash/mergeWith'
 import isArray from 'lodash/isArray'
 import isString from 'lodash/isString'
+import isEmpty from 'lodash/isEmpty'
 import compose from 'lodash/flowRight'
 import some from 'lodash/some'
 import maxBy from 'lodash/maxBy'
@@ -75,6 +76,9 @@ export const overEvery = predicates => item => {
 const getTransactionDate = x => x.date
 
 export const mergeCategoryIds = (obj, src) => {
+  if (isEmpty(obj.ops) || isEmpty(src.ops)) {
+    return []
+  }
   // When merging two bundles, we put the most recent categoryId in front
   const mostRecentObjOp = maxBy(obj.ops, getTransactionDate)
   const mostRecentSrcOp = maxBy(src.ops, getTransactionDate)
@@ -91,7 +95,7 @@ export const mergeCategoryIds = (obj, src) => {
 
 function customizer(objValue, srcValue, key, obj, src) {
   if (key === 'categoryIds') {
-    return mergeCategoryIds(objValue, srcValue, key, obj, src)
+    return mergeCategoryIds(obj, src)
   } else if (key == 'ops') {
     return uniqBy(objValue.concat(srcValue), x => x._id)
   } else if (isString(objValue)) {

--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -74,7 +74,7 @@ export const overEvery = predicates => item => {
 
 const getTransactionDate = x => x.date
 
-export const mergeCategoryIds = (objValue, srcValue, key, obj, src) => {
+export const mergeCategoryIds = (obj, src) => {
   // When merging two bundles, we put the most recent categoryId in front
   const mostRecentObjOp = maxBy(obj.ops, getTransactionDate)
   const mostRecentSrcOp = maxBy(src.ops, getTransactionDate)

--- a/src/ducks/recurrence/rules.spec.js
+++ b/src/ducks/recurrence/rules.spec.js
@@ -1,4 +1,4 @@
-import { mergeBundles, sameLabel } from './rules'
+import { mergeBundles, mergeCategoryIds, sameLabel } from './rules'
 
 const ops1 = [
   { _id: 't1', date: '2020-08-01', manualCategoryId: '400140' },
@@ -45,6 +45,26 @@ describe('merge hydrated bundles', () => {
     ]
     const merged = mergeBundles(bundles)
     expect(merged.categoryIds).toEqual(['400130', '400140', '400120'])
+  })
+})
+
+describe('mergeCategoryIds', () => {
+  const makeOps = ops => ({ ops })
+
+  it('should return empty array when no ops in src or obj', () => {
+    expect(mergeCategoryIds(makeOps([]), makeOps([]))).toEqual([])
+    expect(
+      mergeCategoryIds(
+        makeOps([]),
+        makeOps([{ date: '2020-12-02T12:00:00.000Z' }])
+      )
+    ).toEqual([])
+    expect(
+      mergeCategoryIds(
+        makeOps([{ date: '2020-12-02T12:00:00.000Z' }]),
+        makeOps([])
+      )
+    ).toEqual([])
   })
 })
 


### PR DESCRIPTION
In production the recurrency service we have type errors :
`TypeError: Cannot read property 'date'`

If there are no operations in either, we are not able to merge category ids so we return an empty array.