### PR TITLE
Upgrade harvest and fix display select date component

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "6.1.0",
+    "cozy-harvest-lib": "6.1.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",
     "cozy-konnector-libs": "4.30.3-beta.1",

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -234,7 +234,7 @@ CategoriesHeader.defaultProps = {
   classes: {
     header: '',
     legalMention: 'u-mt-2 u-pt-1',
-    selectDates: 'u-pt-0'
+    selectDates: 'u-pt-half'
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4934,10 +4934,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.1.0.tgz#ee921fc271ecad9cb8b9b1df5d047acd746216d3"
-  integrity sha512-ztqz1Zvi7bAmNQ9T1i9AuePRDA2XVq0fsaJpy8tdcnXfKK1RGM/3UhMlwgi4FKEnAEjBmB9RjDJGLGwVOaQYrg==
+cozy-harvest-lib@6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.1.1.tgz#c5566efb7d1f05f4e3aa2f9c15410548a555d06f"
+  integrity sha512-DI6m9LZ8KWV6VDC1cjYngQnpkB/xmA5GvW94TXRuZT+ePkGYWI0BuXjt0N9shVpZMnnGKMG6TxLfeHgVWoo1Gw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
- Upgrade harvest to 6.1.1
Contains : BI Two FA naming error + unit tests

- Display issue about SelectDate component (Page Analysis -> Categorisation)
<img width="457" alt="Capture d’écran 2021-06-02 à 14 26 36" src="https://user-images.githubusercontent.com/22611343/120481044-fca07780-c3af-11eb-9524-cbc2a955f6a2.png">
