### PR TITLE
fix: Duplicate pendingUpdate param

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.jsx
+++ b/src/components/KonnectorUpdateInfo/index.jsx
@@ -58,7 +58,7 @@ const KonnectorUpdateInfo = ({ outdatedKonnectors }) => {
             className="u-mh-0"
             label={t('KonnectorUpdateInfo.cta')}
             icon="openwith"
-            href={`${url}&pendingUpdate=true`}
+            href={url}
           />
         }
         title={t('KonnectorUpdateInfo.title')}

--- a/src/components/KonnectorUpdateInfo/index.spec.jsx
+++ b/src/components/KonnectorUpdateInfo/index.spec.jsx
@@ -22,7 +22,7 @@ describe('KonnectorUpdateInfo', () => {
 
   it('should display button with valid url', () => {
     useRedirectionURL.mockReturnValue([
-      'http://store.cozy.tools:8080/#/discover/?type=konnector&category=banking'
+      'http://store.cozy.tools:8080/#/discover/?type=konnector&category=banking&pendingUpdate=true'
     ])
     const { root } = setup({
       outdatedKonnectors: { data: [{ categories: 'banking' }] }


### PR DESCRIPTION
We had a param duplicate`&pendingUpdate=true&pendingUpdate=true`in url

This param is include in useRedirectionURL.