### PR TITLE
fix: Duplicate class on overrided style component

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -40,7 +40,8 @@ feature.
 https://material-ui.com/styles/api/#stylesprovider
 */
 const generateClassName = createGenerateClassName({
-  disableGlobal: true
+  disableGlobal: true,
+  productionPrefix: 'c'
 })
 
 const AppContainer = ({ store, lang, history, client }) => {


### PR DESCRIPTION
When overriding the application there is a problem
with class duplication in production.
Consequently, during the first display,
the override style is not applied.

<img width="157" alt="Capture d’écran 2021-06-08 à 14 46 50" src="https://user-images.githubusercontent.com/22611343/121187484-64e7d100-c868-11eb-8a99-25a3be1cba5c.png">

A solution found was to add a `productionPrefix` to avoid this issue.

This is a known problem:

Issue :
https://github.com/mui-org/material-ui/issues/11843

PR:
https://github.com/mui-org/material-ui/pull/11846