### PR TITLE
fix: Use queryAll to fetch all recurrence bundle transactions

### DIFF
--- a/src/ducks/recurrence/api.js
+++ b/src/ducks/recurrence/api.js
@@ -50,10 +50,9 @@ const getRecurrenceIdFromRawTransaction = tr =>
  * @return {Promise<HydratedRecurrences>}
  */
 export const fetchHydratedBundles = async client => {
-  const recurrenceCol = client.collection(RECURRENCE_DOCTYPE)
-  const { data: recurrences } = await recurrenceCol.all()
-  const { data: transactions } = await client.query(
-    queryRecurrencesTransactions(recurrences)
+  const recurrences = await client.queryAll(Q(RECURRENCE_DOCTYPE).limitBy(1000))
+  const transactions = await client.queryAll(
+    queryRecurrencesTransactions(recurrences).limitBy(1000)
   )
   const byRecurrence = groupBy(transactions, getRecurrenceIdFromRawTransaction)
   return recurrences.map(rec => ({

--- a/src/ducks/recurrence/api.spec.js
+++ b/src/ducks/recurrence/api.spec.js
@@ -1,0 +1,34 @@
+import { fetchHydratedBundles } from './api'
+import CozyClient from 'cozy-client'
+import fixtures from 'test/fixtures'
+import { TRANSACTION_DOCTYPE, RECURRENCE_DOCTYPE } from 'doctypes'
+
+describe('fetch hydrated bundles', () => {
+  const setup = () => {
+    const client = new CozyClient()
+    client.queryAll = jest.fn().mockImplementation(async qdef => {
+      if (qdef.doctype === TRANSACTION_DOCTYPE) {
+        return fixtures[TRANSACTION_DOCTYPE]
+      } else if (qdef.doctype === RECURRENCE_DOCTYPE) {
+        return fixtures[RECURRENCE_DOCTYPE]
+      } else {
+        throw new Error(`Unexpected doctype ${qdef.doctype} in queryAll`)
+      }
+    })
+    return { client }
+  }
+
+  it('should use query all to fetch more than the default pagination limit', async () => {
+    const { client } = setup()
+    await fetchHydratedBundles(client)
+    expect(client.queryAll).toHaveBeenCalledTimes(2)
+  })
+
+  it('should use put operations pertaining to the bundle inside the ops attribute', async () => {
+    const { client } = setup()
+    const bundles = await fetchHydratedBundles(client)
+    expect(bundles.length).toBe(2)
+    expect(bundles[0].ops.length).toEqual(3)
+    expect(bundles[1].ops.length).toEqual(0)
+  })
+})


### PR DESCRIPTION
Previously, we'd use the default 100 limit when fetching bundle
transactions. When more than 100 transactions were linked to bundles,
some recurrences were fetched with the wrong number of transactions,
possibly 0. If a bundle was fetched with 0 transactions, it would
be deleted.

To prevent this problem, we use queryAll to fetch all documents
regardless of the pagination limit. The limitBy is increased to 1000
since we are in the context of a service, this not a problem fetch
large document batches.