### PR TITLE
Improve recurrence detection

### DIFF
--- a/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
+++ b/src/ducks/brandDictionary/__snapshots__/index.spec.js.snap
@@ -502,6 +502,11 @@ Array [
   },
   Object {
     "isInstalled": false,
+    "name": "Spotify",
+    "regexp": "\\\\bspotify\\\\b",
+  },
+  Object {
+    "isInstalled": false,
     "konnectorSlug": "stickersdiscount",
     "name": "Stickers Discount",
     "regexp": "\\\\bakoufen angers\\\\b",
@@ -1093,6 +1098,11 @@ Array [
     "konnectorSlug": "spartoo",
     "name": "Spartoo",
     "regexp": "\\\\bspartoo\\\\b",
+  },
+  Object {
+    "isInstalled": false,
+    "name": "Spotify",
+    "regexp": "\\\\bspotify\\\\b",
   },
   Object {
     "isInstalled": false,

--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -427,6 +427,10 @@
     "konnectorSlug": "spartoo"
   },
   {
+    "name": "Spotify",
+    "regexp": "\\bspotify\\b"
+  },
+  {
     "name": "Stickers Discount",
     "regexp": "\\bakoufen angers\\b",
     "konnectorSlug": "stickersdiscount"

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -176,7 +176,6 @@ const BundleStats = ({ bundle }) => {
 }
 
 const RecurrenceBundle = ({ bundle }) => {
-  const client = useClient()
   const jsonData = useMemo(
     () => JSON.stringify(bundle.ops.map(o => dehydrate(o))),
     [bundle]

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -208,10 +208,11 @@ const makeTextFilter = (searchStr, accessor) => {
   }
 }
 
-const RecurrencePage = () => {
+const DebugRecurrencePage = () => {
   const transactionCol = useQuery(transactionsConn.query, transactionsConn)
   const { data: transactions } = transactionCol
-  const loading = isQueryLoading(transactionCol) && transactions.length === 0
+  const loading =
+    isQueryLoading(transactionCol) && transactions && transactions.length === 0
   const [rulesConfig, setRulesConfig, clearSavedConfig] = useStickyState(
     defaultConfig,
     'banks.recurrence-config'
@@ -413,4 +414,4 @@ const RecurrencePage = () => {
   )
 }
 
-export default RecurrencePage
+export default DebugRecurrencePage

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -5,7 +5,7 @@ import sortBy from 'lodash/sortBy'
 import clone from 'lodash/clone'
 import groupBy from 'lodash/groupBy'
 
-import { useQuery, useClient, isQueryLoading } from 'cozy-client'
+import { useQuery, useClient, isQueryLoading, dehydrate } from 'cozy-client'
 import Card from 'cozy-ui/transpiled/react/Card'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import Button from 'cozy-ui/transpiled/react/Button'
@@ -176,6 +176,11 @@ const BundleStats = ({ bundle }) => {
 }
 
 const RecurrenceBundle = ({ bundle }) => {
+  const client = useClient()
+  const jsonData = useMemo(
+    () => JSON.stringify(bundle.ops.map(o => dehydrate(o))),
+    [bundle]
+  )
   return (
     <Card
       className="u-m-half"
@@ -184,9 +189,12 @@ const RecurrenceBundle = ({ bundle }) => {
       <Typography variant="h5">
         {getAutomaticLabelFromBundle(bundle)}
       </Typography>
+      <input type="text" value={jsonData} />
       <p>
         categories: <CategoryNames bundle={bundle} />
         amounts: {bundle.amounts}
+        <br />
+        #operations: {bundle.ops.length}
         <br />
         {bundle.stats ? <BundleStats bundle={bundle} /> : null}
       </p>

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -52,7 +52,11 @@ const RuleInput = ({ ruleName, config, onChange }) => {
   }
   return (
     <div key={ruleName} className="u-m-half u-miw-6">
-      {ruleName} (<em>{ruleInfo.stage}</em>)
+      {ruleName} (
+      <em>
+        {ruleInfo.type} - {ruleInfo.stage}
+      </em>
+      )
       <Typography variant="caption" color="textSecondary">
         {ruleInfo.description}
       </Typography>
@@ -80,11 +84,17 @@ const Rules = ({ rulesConfig, onChangeConfig, onResetConfig }) => {
     },
     [rulesConfig, onChangeConfig]
   )
+  const entries = useMemo(() => {
+    return sortBy(
+      Object.entries(rulesConfig),
+      ([ruleName]) => rulesPerName[ruleName].stage
+    )
+  }, [rulesConfig])
   return (
     <Card className="u-mv-1">
       <RulesDetails />
       <div className="u-flex u-flex-wrap">
-        {Object.entries(rulesConfig).map(([ruleName, config]) => (
+        {entries.map(([ruleName, config]) => (
           <RuleInput
             key={ruleName}
             ruleName={ruleName}

--- a/src/ducks/recurrence/DebugRecurrencePage.jsx
+++ b/src/ducks/recurrence/DebugRecurrencePage.jsx
@@ -391,30 +391,32 @@ const DebugRecurrencePage = () => {
         label="reset bundles"
         busy={resettingBundles}
       />
-      {loading ? <Loading /> : null}
-      transactions: {transactions ? transactions.length : 0}
-      <br />
-      bundleTransactions: {bundlesTransactions.length}
-      <br />
-      newTransactions: {newTransactions.length}
-      <br />
-      elapsed time: {(end - start) / 1000}s<br />
-      bundle date:{' '}
-      <DateSlider date={bundlesDate} onChange={handleSetBundleDate} />
-      <br />
-      current date:{' '}
-      <DateSlider date={currentDate} onChange={handleSetCurrentDate} />
-      <br />
-      isLocked:{' '}
-      <input type="checkbox" checked={isLocked} onChange={handleSetLocked} />
-      <br />
-      bundle filter:{' '}
+      <p>
+        transactions: {transactions ? transactions.length : 0}
+        <br />
+        bundleTransactions: {bundlesTransactions.length}
+        <br />
+        newTransactions: {newTransactions.length}
+        <br />
+        elapsed time: {(end - start) / 1000}s<br />
+        bundle date:{' '}
+        <DateSlider date={bundlesDate} onChange={handleSetBundleDate} />
+        <br />
+        current date:{' '}
+        <DateSlider date={currentDate} onChange={handleSetCurrentDate} />
+        <br />
+        isLocked:{' '}
+        <input type="checkbox" checked={isLocked} onChange={handleSetLocked} />
+        <br />
+        bundle filter:{' '}
+      </p>
       <input
         type="text"
         value={bundleFilter}
         onChange={handleChangeBundleFilter}
       />
       <br />
+      {loading ? <Loading /> : null}
       <div className="u-flex" style={{ flexWrap: 'wrap' }}>
         {finalBundles.map((bundle, i) => (
           <RecurrenceBundle key={i} bundle={bundle} />

--- a/src/ducks/recurrence/__snapshots__/search.spec.js.snap
+++ b/src/ducks/recurrence/__snapshots__/search.spec.js.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`recurrence bundles should find new bundles (split brand necessary) 1`] = `
+"75 Netflix Com                                     |        -11 |     10 operations |  from 2020-09-01 to 2021-06-01 |      30
+Spotify P 127537 A 66                              |        -14 |      7 operations |  from 2020-10-01 to 2021-04-01 |      30"
+`;
+
 exports[`recurrence bundles should find new bundles 1`] = `
 "Cozy Cloud                                         |       3963 |      3 operations |  from 2018-06-01 to 2018-09-28 |    59.5
 Echeance Pret 03103 61893938                       |      -1281 |     11 operations |  from 2019-03-05 to 2020-01-06 |      31

--- a/src/ducks/recurrence/config.json
+++ b/src/ducks/recurrence/config.json
@@ -31,5 +31,8 @@
   },
   "addStats": {
     "active": true
+  },
+  "splitBrands": {
+    "active": true
   }
 }

--- a/src/ducks/recurrence/fixtures2.json
+++ b/src/ducks/recurrence/fixtures2.json
@@ -1,0 +1,768 @@
+{
+  "io.cozy.bank.operations": [
+    {
+      "_id": "22a8b311d849e0c12f9d237c922ee663",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999971384925496,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:18.514Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:18.514Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-01-04T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Spotify P127537A66",
+      "originalBankLabel": "CARTE 05/12/20 Spotify P127537A66",
+      "rawDate": "2021-01-04",
+      "realisationDate": "2020-12-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940072
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c922fc6d4",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999646742109971,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:00:09.406Z"
+      },
+      "currency": "EUR",
+      "date": "2020-12-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 SPOTIFY FRANCE",
+      "originalBankLabel": "CARTE 05/11/20 75 SPOTIFY FRANCE",
+      "rawDate": "2020-12-01",
+      "realisationDate": "2020-11-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940094
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c92312d9a",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999646742109971,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:00:10.430Z"
+      },
+      "currency": "EUR",
+      "date": "2020-11-02T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 SPOTIFY FRANCE",
+      "originalBankLabel": "CARTE 05/10/20 75 SPOTIFY FRANCE",
+      "rawDate": "2020-11-02",
+      "realisationDate": "2020-10-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940113
+    },
+    {
+      "_id": "5fbc76170f6f1aa40429a0e080aba603",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:05.439Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:05.439Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-03-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*7777",
+      "originalBankLabel": "CARTE 26/02/21 75 AMAZON PAYMENT CB*7777",
+      "rawDate": "2021-03-01",
+      "realisationDate": "2021-02-26T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3936732
+    },
+    {
+      "_id": "5fbc76170f6f1aa40429a0e080ac846f",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999974615842944,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:05.669Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:05.669Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-03-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Spotify P1350B8D41",
+      "originalBankLabel": "CARTE 05/02/21 Spotify P1350B8D41",
+      "rawDate": "2021-03-01",
+      "realisationDate": "2021-02-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940005
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a74033d",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:48:53.133Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:48:53.133Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-03-09T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*7777",
+      "originalBankLabel": "CARTE 08/03/21 75 AMAZON PAYMENT CB*7777",
+      "rawDate": "2021-03-09",
+      "realisationDate": "2021-03-08T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3936698
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a744502",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9994077564961484,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:48:50.820Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:48:50.820Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-04-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Spotify P13BE5EA4B",
+      "originalBankLabel": "CARTE 05/03/21 Spotify P13BE5EA4B",
+      "rawDate": "2021-04-01",
+      "realisationDate": "2021-03-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3939972
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a75ec51",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9827757086505744,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:15.340Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:15.340Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-02-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON MEDIA E CB*7777",
+      "originalBankLabel": "CARTE 29/01/21 75 AMAZON MEDIA E CB*7777",
+      "rawDate": "2021-02-01",
+      "realisationDate": "2021-01-29T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3936818
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a76e0f2",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999980388153271,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:15.680Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:15.680Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-02-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Spotify P12E615206",
+      "originalBankLabel": "CARTE 05/01/21 Spotify P12E615206",
+      "rawDate": "2021-02-01",
+      "realisationDate": "2021-01-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940035
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a7b8ebe",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9999964774213855,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:49.243Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:49.243Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2020-10-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Spotify P11300C562",
+      "originalBankLabel": "CARTE 05/09/20 Spotify P11300C562",
+      "rawDate": "2020-10-01",
+      "realisationDate": "2020-09-05T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940129
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a88209b",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9827757086505744,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:02:53.785Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-18T06:02:53.785Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2019-10-10T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON MEDIA E CB*8942",
+      "originalBankLabel": "CARTE 09/10/19 75 AMAZON MEDIA E CB*8942",
+      "rawDate": "2019-10-10",
+      "realisationDate": "2019-10-09T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3938202
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a88c487",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9827757086505744,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:05:30.126Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-18T06:05:30.126Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2019-09-27T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON MEDIA E CB*8942",
+      "originalBankLabel": "CARTE 26/09/19 75 AMAZON MEDIA E CB*8942",
+      "rawDate": "2019-09-27",
+      "realisationDate": "2019-09-26T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3938264
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a8ff6ee",
+      "amount": -14.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-19T06:04:32.115Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-19T06:04:32.115Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2019-02-18T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*8942",
+      "originalBankLabel": "CARTE 15022019 75 AMAZON PAYMENT CB*8942",
+      "rawDate": "2019-02-18",
+      "realisationDate": "2019-02-15T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3938953
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c9229a3f2",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:48:51.902Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:48:51.902Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-04-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 NETFLIX COM",
+      "originalBankLabel": "CARTE 25/03/21 75 NETFLIX COM",
+      "rawDate": "2021-04-01",
+      "realisationDate": "2021-03-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3939948
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c923039fb",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9886022767826702,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:00:10.404Z"
+      },
+      "currency": "EUR",
+      "date": "2020-11-02T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Netflix Netflix.com",
+      "originalBankLabel": "Netflix CARTE 25/10/20 Netflix.com",
+      "rawDate": "2020-11-02",
+      "realisationDate": "2020-10-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940103
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c9232659c",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9049163726557988,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:04:34.538Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-18T06:04:34.538Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2020-09-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Netflix.com",
+      "originalBankLabel": "CARTE 24/08/20 Netflix.com",
+      "rawDate": "2020-09-01",
+      "realisationDate": "2020-08-24T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940136
+    },
+    {
+      "_id": "22a8b311d849e0c12f9d237c9249e876",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-19T06:07:15.297Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-19T06:07:15.297Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2018-10-30T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*8942",
+      "originalBankLabel": "CARTE 27102018 75 AMAZON PAYMENT CB*8942",
+      "rawDate": "2018-10-30",
+      "realisationDate": "2018-10-27T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3939300
+    },
+    {
+      "_id": "5fbc76170f6f1aa40429a0e080ac030c",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:48:51.066Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:48:51.066Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-04-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 NETFLIX COM",
+      "originalBankLabel": "CARTE 25/02/21 75 NETFLIX COM",
+      "rawDate": "2021-04-01",
+      "realisationDate": "2021-02-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3939983
+    },
+    {
+      "_id": "5fbc76170f6f1aa40429a0e080ad5ebf",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:46:25.839Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:46:25.839Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-02-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 NETFLIX COM",
+      "originalBankLabel": "CARTE 25/01/21 75 NETFLIX COM",
+      "rawDate": "2021-02-01",
+      "realisationDate": "2021-01-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940014
+    },
+    {
+      "_id": "5fbc76170f6f1aa40429a0e080ae9231",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:17.684Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:17.684Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2021-01-04T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "92 NETFLIX COM",
+      "originalBankLabel": "CARTE 25/12/20 92 NETFLIX COM",
+      "rawDate": "2021-01-04",
+      "realisationDate": "2020-12-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940055
+    },
+    {
+      "_id": "7ea5e05ae174e48b24bc107cb321dce2",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-06-02T06:24:51.959Z"
+      },
+      "currency": "EUR",
+      "date": "2021-06-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "NETFLIX COM 4224229",
+      "originalBankLabel": "CARTE 25/05/21 NETFLIX COM 4224229",
+      "rawDate": "2021-06-01",
+      "realisationDate": "2021-05-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 4339485
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a71432e",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9973314863354402,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:45:11.737Z"
+      },
+      "currency": "EUR",
+      "date": "2021-05-03T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "NETFLIX COM 4224229",
+      "originalBankLabel": "CARTE 25/04/21 NETFLIX COM 4224229",
+      "rawDate": "2021-05-03",
+      "realisationDate": "2021-04-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3939899
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a78cde3",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9049163726557988,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-18T06:00:08.640Z"
+      },
+      "currency": "EUR",
+      "date": "2020-12-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Netflix.com",
+      "originalBankLabel": "CARTE 25/11/20 Netflix.com",
+      "rawDate": "2020-12-01",
+      "realisationDate": "2020-11-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940082
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a7b14fe",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9049163726557988,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:49:48.923Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:49:48.923Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2020-10-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "Netflix.com",
+      "originalBankLabel": "CARTE 25/09/20 Netflix.com",
+      "rawDate": "2020-10-01",
+      "realisationDate": "2020-09-25T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158502",
+      "vendorId": 3940123
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a7d97f3",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:47:29.360Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:47:29.360Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2020-07-16T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*7062",
+      "originalBankLabel": "CARTE 13/07/20 75 AMAZON PAYMENT CB*7062",
+      "rawDate": "2020-07-16",
+      "realisationDate": "2020-07-13T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3937261
+    },
+    {
+      "_id": "aacef934d5fcb303dd5a690a5a856427",
+      "amount": -11.99,
+      "automaticCategoryId": "0",
+      "cozyCategoryId": "400750",
+      "cozyCategoryProba": 0.9130120237450765,
+      "cozyMetadata": {
+        "updatedAt": "2021-05-17T09:51:45.497Z",
+        "updatedByApps": [
+          {
+            "date": "2021-05-17T09:51:45.497Z",
+            "slug": "maif",
+            "version": "1.31.11"
+          }
+        ]
+      },
+      "currency": "EUR",
+      "date": "2019-12-30T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "75 AMAZON PAYMENT CB*8942",
+      "originalBankLabel": "CARTE 26/12/19 75 AMAZON PAYMENT CB*8942",
+      "rawDate": "2019-12-30",
+      "realisationDate": "2019-12-26T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "158500",
+      "vendorId": 3937944
+    }
+  ]
+}

--- a/src/ducks/recurrence/rules.spec.js
+++ b/src/ducks/recurrence/rules.spec.js
@@ -1,4 +1,4 @@
-import { mergeBundles, mergeCategoryIds, sameLabel } from './rules'
+import { mergeBundles, mergeCategoryIds, sameLabel, brandSplit } from './rules'
 
 const ops1 = [
   { _id: 't1', date: '2020-08-01', manualCategoryId: '400140' },
@@ -84,5 +84,45 @@ describe('sameLabel bundle', () => {
   it('should return label from manual and automatic label', () => {
     expect(sameLabel(makeBundle([], undefined))).toEqual('Automatic Label')
     expect(sameLabel(makeBundle([], 'Manual label'))).toEqual('Manual label')
+  })
+})
+
+describe('brand split', () => {
+  it('should split bundle into several bundles based on brand', () => {
+    const bundle = {
+      ops: [
+        {
+          label: 'Spotify 1',
+          amount: 15,
+          categoryIds: ['400100']
+        },
+        {
+          label: 'Amazon 1',
+          amount: 15,
+          categoryIds: ['400100']
+        },
+        {
+          label: 'Amazon 2',
+          amount: 15,
+          categoryIds: ['400100']
+        },
+        {
+          label: 'Spotify 2',
+          amount: 15,
+          categoryIds: ['400100']
+        },
+        {
+          label: 'Spotify 3',
+          amount: 15,
+          categoryIds: ['400100']
+        }
+      ]
+    }
+    const bundles = brandSplit()(bundle)
+    expect(bundles.length).toBe(2)
+    expect(bundles[0].ops.length).toBe(3)
+    expect(bundles[0].brand).toBe('Spotify')
+    expect(bundles[1].ops.length).toBe(2)
+    expect(bundles[1].brand).toBe('Amazon')
   })
 })

--- a/src/ducks/recurrence/search.js
+++ b/src/ducks/recurrence/search.js
@@ -69,6 +69,11 @@ export const findRecurrences = (operations, rules) => {
       bundles = bundles.map(compose(rules))
     } else if (type === 'group') {
       bundles = groupBundles(bundles, rules)
+    } else if (type === 'split') {
+      if (rules.length > 1) {
+        throw new Error('Cannot have multiple split rules in one stage')
+      }
+      bundles = flatMap(bundles, rules[0])
     }
   }
 

--- a/src/ducks/recurrence/search.spec.js
+++ b/src/ducks/recurrence/search.spec.js
@@ -8,8 +8,9 @@ import { TRANSACTION_DOCTYPE } from 'doctypes'
 import { td, tr } from 'txt-table-utils'
 
 import { findAndUpdateRecurrences } from './search'
-import fixtures from './fixtures'
 import { getLabel, getAmount } from './utils'
+import fixtures from './fixtures.json'
+import fixtures2 from './fixtures2.json'
 
 const formatBundleExtent = bundle => {
   const oldestOp = minBy(bundle.ops, x => x.date)
@@ -49,6 +50,21 @@ const formatRecurrence = bundle =>
 describe('recurrence bundles', () => {
   it('should find new bundles', () => {
     const transactions = fixtures[TRANSACTION_DOCTYPE]
+    const recurrences = []
+    const updatedRecurrences = findAndUpdateRecurrences(
+      recurrences,
+      transactions
+    )
+
+    updatedRecurrences.forEach(assertValidRecurrence)
+    // eslint-disable
+    expect(
+      sortBy(updatedRecurrences.map(formatRecurrence)).join('\n')
+    ).toMatchSnapshot()
+  })
+
+  it('should find new bundles (split brand necessary)', () => {
+    const transactions = fixtures2[TRANSACTION_DOCTYPE]
     const recurrences = []
     const updatedRecurrences = findAndUpdateRecurrences(
       recurrences,

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -57,7 +57,9 @@ const BillChip = props => {
   // Bill's vendor can be a slug. We get the brand from our dictionary to be
   // sure that we show the brand name and not a konnector slug
   const [brand] = getBrands(
-    brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
+    brand =>
+      brand.name === bill.vendor ||
+      (brand.konnectorSlug && brand.konnectorSlug === bill.vendor)
   )
   const vendorName = brand && brand.name
 

--- a/src/ducks/transactions/actions/KonnectorAction/match.js
+++ b/src/ducks/transactions/actions/KonnectorAction/match.js
@@ -7,7 +7,11 @@ const match = (transaction, { brands, urls }) => {
     return false
   }
 
-  return findMatchingBrandWithoutTrigger(transaction.label, brands)
+  const brand = findMatchingBrandWithoutTrigger(transaction.label, brands)
+  if (!brand || !brand.konnectorSlug) {
+    return false
+  }
+  return brand
 }
 
 export default match

--- a/test/jestUtils.js
+++ b/test/jestUtils.js
@@ -1,5 +1,7 @@
 const isDeprecatedLifecycleWarning = (msg, componentName) => {
   return (
+    msg &&
+    msg.includes &&
     msg.includes('has been renamed, and is not recommended for use') &&
     msg.includes(componentName)
   )


### PR DESCRIPTION
Add split brands rule to prevent any recurrence bundle to contain
operations from two different brands.

Since the first rule to group operations is a bit simple (amount
and categoryIds) are considered, we sometimes had cases where
operations from two different brands were mixed in the same bundle.
This would break the stats computations and the bundle was not
recognized.

Since we have a brand dictionary that already serves to detect if
an operation pertains to a particular brand, we can use this
detection mechanism to split any bundles containing operations
from more than one brand.