### PR TITLE
fix: Do not crash when groups have not yet been loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cozy-device-helper": "1.12.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "2.4.0",
-    "cozy-harvest-lib": "6.2.0",
+    "cozy-harvest-lib": "6.3.0",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",
     "cozy-konnector-libs": "4.30.3-beta.1",

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -361,19 +361,20 @@ const AccountSwitch = props => {
   }, [dispatch, handleClose])
 
   const accounts = accountsCollection.data
-  const groups = [...groupsCollection.data, ...virtualGroups].map(group => ({
-    ...group,
-    label: getGroupLabel(group, t)
-  }))
 
-  // TODO remove if https://github.com/cozy/cozy-client/issues/834 is solved
-  // It seems there is a bug in cozy-client when we delete a document
-  // The document is removed in the store, but still referenced in the collection
-  // So we may get an undefined group. We filter it before sorting
-  const orderedGroups = useMemo(
-    () => sortBy(groups.filter(Boolean), x => x.label.toLowerCase()),
-    [groups]
-  )
+  const orderedGroups = useMemo(() => {
+    const groups = [...(groupsCollection.data || []), ...virtualGroups].map(
+      group => ({
+        ...group,
+        label: getGroupLabel(group, t)
+      })
+    )
+    // TODO remove the filter if https://github.com/cozy/cozy-client/issues/834 is solved
+    // It seems there is a bug in cozy-client when we delete a document
+    // The document is removed in the store, but still referenced in the collection
+    // So we may get an undefined group. We filter it before sorting
+    return sortBy(groups.filter(Boolean), x => x.label.toLowerCase())
+  }, [groupsCollection.data, t, virtualGroups])
 
   const selectProps = selectPropsBySize[size]
   const select = (

--- a/src/ducks/account/AccountSwitch.spec.jsx
+++ b/src/ducks/account/AccountSwitch.spec.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import pickBy from 'lodash/pickBy'
 import { fireEvent, render } from '@testing-library/react'
 import AccountSwitch from './AccountSwitch'
 
@@ -9,23 +10,25 @@ import fixtures from 'test/fixtures'
 import getClient from 'selectors/getClient'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 
-const accounts = fixtures[ACCOUNT_DOCTYPE]
-
 jest.mock('selectors/getClient', () => jest.fn())
 
 describe('account switch', () => {
-  const setup = () => {
+  const setup = ({ accountsData, groupsData }) => {
     const client = createMockClient({
-      queries: {
-        accounts: {
-          doctype: ACCOUNT_DOCTYPE,
-          data: accounts
+      queries: pickBy(
+        {
+          accounts: {
+            doctype: ACCOUNT_DOCTYPE,
+            data: accountsData
+          },
+          groups: {
+            doctype: GROUP_DOCTYPE,
+            data: groupsData
+          }
         },
-        groups: {
-          doctype: GROUP_DOCTYPE,
-          data: []
-        }
-      }
+        // eslint-disable-next-line no-unused-vars
+        (v, _) => v.data
+      )
     })
     getClient.mockReturnValue(client)
     const root = render(
@@ -36,8 +39,25 @@ describe('account switch', () => {
     return { root }
   }
 
-  it('should render correctly', async () => {
-    const { root } = setup()
+  it('should render correctly when there are no groups', async () => {
+    const accounts = fixtures[ACCOUNT_DOCTYPE]
+    const { root } = setup({
+      accountsData: accounts,
+      groupsData: []
+    })
+
+    const allAccounts = root.getByText('All accounts')
+    expect(allAccounts).toBeTruthy()
+    fireEvent.click(allAccounts)
+    expect(root.getByText('Checking accounts')).toBeTruthy()
+    expect(root.getByText('7 accounts')).toBeTruthy()
+  })
+
+  it('should render correctly when groups have not been loaded', async () => {
+    const accounts = fixtures[ACCOUNT_DOCTYPE]
+    const { root } = setup({
+      accountsData: accounts
+    })
 
     const allAccounts = root.getByText('All accounts')
     expect(allAccounts).toBeTruthy()

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,10 +4964,10 @@ cozy-flags@2.7.1:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.2.0.tgz#048a5785b1600aac42541f4ec2e2e14bd9193c7f"
-  integrity sha512-aKaf5yO30BV0LRxqpzc1f4K+P3S15squwFnW+vZs2kz0ktQvxjwOtupKcHb9E9ghIfh/UUxKnpbSFOyd5w/HKA==
+cozy-harvest-lib@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-6.3.0.tgz#315831c7cbf85b1c609ef9fd5124d9e6daff95e4"
+  integrity sha512-YAIHgLu4biuRU0ex1fvI6VGL3k+Q5BRhVHpX/0PqqHifubUvsKFfYPLaKG1qhUEcxIv6P+fx78cjUTZ1aqIETg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
If groups have not yet been loaded, groupsCollection.data is null and
cannot be spread.