### PR TITLE
fix: HeaderLoadingProgress at wrong place on categories page mobile

### DIFF
--- a/src/ducks/categories/Categories.jsx
+++ b/src/ducks/categories/Categories.jsx
@@ -1,3 +1,4 @@
+import compose from 'lodash/flowRight'
 import React, { Component } from 'react'
 import { withRouter } from 'react-router'
 import cx from 'classnames'
@@ -5,14 +6,14 @@ import { translate } from 'cozy-ui/transpiled/react/I18n'
 import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import { Bd, Img, Media } from 'cozy-ui/transpiled/react/Media'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import Figure from 'cozy-ui/transpiled/react/Figure'
+
 import CategoryIcon from 'ducks/categories/CategoryIcon'
 import { Table, TdSecondary } from 'components/Table'
-import Figure from 'cozy-ui/transpiled/react/Figure'
 import styles from 'ducks/categories/styles.styl'
-import compose from 'lodash/flowRight'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import PercentageLine from 'components/PercentageLine'
-import Typography from 'cozy-ui/transpiled/react/Typography'
 
 const stAmount = styles['bnk-table-amount']
 const stCategory = styles['bnk-table-category-category']

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -7,6 +7,7 @@ import Breadcrumb from 'cozy-ui/transpiled/react/Breadcrumbs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Stack from 'cozy-ui/transpiled/react/Stack'
+import Empty from 'cozy-ui/transpiled/react/Empty'
 
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -26,10 +27,10 @@ import AddAccountButton from 'ducks/categories/AddAccountButton'
 import { onSubcategory } from 'ducks/categories/utils'
 import catStyles from 'ducks/categories/styles.styl'
 
+import HeaderLoadingProgress from 'components/HeaderLoadingProgress'
 import Table from 'components/Table'
 import { useParams } from 'components/RouterContext'
 import LegalMention from 'ducks/legal/LegalMention'
-import Empty from 'cozy-ui/transpiled/react/Empty'
 import DateSelectorHeader from 'ducks/categories/DateSelectorHeader'
 import CategoryAccountSwitch from 'ducks/categories/CategoryAccountSwitch'
 import IncomeToggle from 'ducks/categories/IncomeToggle'
@@ -103,6 +104,7 @@ const CategoriesHeader = props => {
     categories,
     chartSize,
     isFetching,
+    isFetchingNewData,
     categoryName,
     subcategoryName,
     classes
@@ -177,6 +179,9 @@ const CategoriesHeader = props => {
             })}
             theme={isMobile ? 'normal' : 'inverted'}
           >
+            <HeaderLoadingProgress
+              isFetching={!!isFetchingNewData && !isFetching}
+            />
             <LegalMention className="u-flex u-flex-items-center u-flex-justify-around u-mr-1">
               {incomeToggle}
             </LegalMention>
@@ -207,41 +212,44 @@ const CategoriesHeader = props => {
   }
 
   return (
-    <Header theme="inverted" fixed>
-      <Padded
-        className={cx(styles.CategoriesHeader, {
-          [styles.NoAccount]: !hasAccount
-        })}
-      >
+    <>
+      <Header theme="inverted" fixed>
+        <Padded
+          className={cx(styles.CategoriesHeader, {
+            [styles.NoAccount]: !hasAccount
+          })}
+        >
+          {hasAccount ? (
+            <>
+              <div>
+                <Stack spacing="m">
+                  <CategoryAccountSwitch
+                    selectedCategory={selectedCategory}
+                    breadcrumbItems={breadcrumbItems}
+                  />
+                  {dateSelector}
+                </Stack>
+                {breadcrumbItems.length > 1 && (
+                  <Fade in>
+                    <Breadcrumb className="u-mt-1" items={breadcrumbItems} />
+                  </Fade>
+                )}
+                {incomeToggle}
+              </div>
+              {chart}
+            </>
+          ) : (
+            <AddAccountButton label={t('Accounts.add-bank')} />
+          )}
+        </Padded>
         {hasAccount ? (
-          <>
-            <div>
-              <Stack spacing="m">
-                <CategoryAccountSwitch
-                  selectedCategory={selectedCategory}
-                  breadcrumbItems={breadcrumbItems}
-                />
-                {dateSelector}
-              </Stack>
-              {breadcrumbItems.length > 1 && (
-                <Fade in>
-                  <Breadcrumb className="u-mt-1" items={breadcrumbItems} />
-                </Fade>
-              )}
-              {incomeToggle}
-            </div>
-            {chart}
-          </>
-        ) : (
-          <AddAccountButton label={t('Accounts.add-bank')} />
-        )}
-      </Padded>
-      {hasAccount ? (
-        <Table className={stTableCategory}>
-          <CategoriesTableHead selectedCategory={selectedCategory} />
-        </Table>
-      ) : null}
-    </Header>
+          <Table className={stTableCategory}>
+            <CategoriesTableHead selectedCategory={selectedCategory} />
+          </Table>
+        ) : null}
+      </Header>
+      <HeaderLoadingProgress isFetching={!!isFetchingNewData && !isFetching} />
+    </>
   )
 }
 

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -186,7 +186,7 @@ const CategoriesHeader = props => {
               {incomeToggle}
             </LegalMention>
 
-            {!hasData && (
+            {!hasData && !isFetching && !isFetchingNewData && (
               <div className={styles.NoAccount_empty}>
                 <Empty
                   icon={emptyIcon}

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -1,9 +1,6 @@
 import React, { Component, Fragment, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
-import getCategoryId from 'ducks/transactions/getCategoryId'
-import { getCategoryIdFromName } from 'ducks/categories/helpers'
-
 import startOfMonth from 'date-fns/start_of_month'
 import endOfMonth from 'date-fns/end_of_month'
 import startOfYear from 'date-fns/start_of_year'
@@ -16,6 +13,8 @@ import some from 'lodash/some'
 import merge from 'lodash/merge'
 import sortBy from 'lodash/sortBy'
 
+import getCategoryId from 'ducks/transactions/getCategoryId'
+import { getCategoryIdFromName } from 'ducks/categories/helpers'
 import CategoriesHeader from 'ducks/categories/CategoriesHeader'
 import {
   useClient,
@@ -44,11 +43,10 @@ import { computeCategoriesData } from 'ducks/categories/selectors'
 import { getDate } from 'ducks/transactions/helpers'
 import { trackPage } from 'ducks/tracking/browser'
 import { TransactionList } from 'ducks/transactions/Transactions'
-import { onSubcategory } from './utils'
 import Delayed from 'components/Delayed'
-import HeaderLoadingProgress from 'components/HeaderLoadingProgress'
 import useLast from 'hooks/useLast'
 import useFullyLoadedQuery from 'hooks/useFullyLoadedQuery'
+import { onSubcategory } from './utils'
 
 const isCategoryDataEmpty = categoryData => {
   return categoryData[0] && isNaN(categoryData[0].percentage)
@@ -199,10 +197,10 @@ export class CategoriesPage extends Component {
           onWithIncomeToggle={this.onWithIncomeToggle}
           categories={sortedCategories}
           isFetching={isFetching}
+          isFetchingNewData={isFetchingNewData}
           hasAccount={hasAccount}
           chart={!isSubcategory}
         />
-        <HeaderLoadingProgress isFetching={!!isFetchingNewData} />
         <Delayed delay={this.props.delayContent}>
           {hasAccount &&
             (isFetching ? (


### PR DESCRIPTION
On mobile, the bar showing data loading was placed in the middle of the page, below the chart.

HeaderLoadingProgress is now displayed by CategoriesHeader as it was
not possible to control correctly where to display the progress bar
if it was rendered inside the categories page (since we need on mobile to
display the progress bar above the chart, whereas on desktop it needs
to be below the header).

The progress bar is also now hidden if the round spinner is displayed.
The progress bar is thus only shown if there is already some data
showing and we are loading new data.

mobile first load

![image](https://user-images.githubusercontent.com/465582/122229463-0dc1ac00-ceb9-11eb-9e93-a50208ce8011.png)

mobile previous/next month load

![image](https://user-images.githubusercontent.com/465582/122229500-187c4100-ceb9-11eb-9fbc-59b7d4083aea.png)

desktop first load

![image](https://user-images.githubusercontent.com/465582/122229515-1b773180-ceb9-11eb-97c0-3931254f2e03.png)

desktop previous/next month load

![image](https://user-images.githubusercontent.com/465582/122229540-2205a900-ceb9-11eb-9664-ddfaf1cca123.png)

(the progress bar is very faint here since the load happened quickly)
