### PR TITLE
fix: Send transaction greater and balance lower notifications

### DIFF
--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -21,7 +21,7 @@ export const findSuggestionForTransaction = (
   const matchingBrand = findMatchingBrand(brands, getLabel(transaction))
 
   if (!matchingBrand) {
-    log('info', `No matching brand found for transaction ${transaction._id}`)
+    log('debug', `No matching brand found for transaction ${transaction._id}`)
     return null
   }
 
@@ -32,11 +32,11 @@ export const findSuggestionForTransaction = (
   let suggestion
 
   if (originalSuggestion) {
-    log('info', `Using existing suggestion for ${matchingBrand.konnectorSlug}`)
+    log('debug', `Using existing suggestion for ${matchingBrand.konnectorSlug}`)
     suggestion = originalSuggestion
   } else {
     log(
-      'info',
+      'debug',
       `No existing suggestion for ${matchingBrand.konnectorSlug}. Creating a new one`
     )
     suggestion = AppSuggestion.init(

--- a/src/ducks/appSuggestions/services.js
+++ b/src/ducks/appSuggestions/services.js
@@ -34,7 +34,7 @@ export const findSuggestionForTransaction = (
   if (originalSuggestion) {
     log('debug', `Using existing suggestion for ${matchingBrand.konnectorSlug}`)
     suggestion = originalSuggestion
-  } else {
+  } else if (matchingBrand.konnectorSlug) {
     log(
       'debug',
       `No existing suggestion for ${matchingBrand.konnectorSlug}. Creating a new one`
@@ -43,6 +43,8 @@ export const findSuggestionForTransaction = (
       matchingBrand.konnectorSlug,
       'FOUND_TRANSACTION'
     )
+  } else {
+    return null
   }
 
   AppSuggestion.linkTransaction(suggestion, transaction)

--- a/src/ducks/appSuggestions/services.spec.js
+++ b/src/ducks/appSuggestions/services.spec.js
@@ -60,6 +60,15 @@ describe('findSuggestionForTransaction', () => {
 
     expect(suggestion).toBe(null)
   })
+
+  it('should return null if no the app suggested has no konnectorSlug', async () => {
+    const suggestion = await findSuggestionForTransaction(
+      { _id: 'o1', label: 'spotify' },
+      brands,
+      []
+    )
+    expect(suggestion).toBe(null)
+  })
 })
 
 describe('normalizeSuggestions', () => {

--- a/src/targets/services/helpers.js
+++ b/src/targets/services/helpers.js
@@ -38,7 +38,8 @@ export const fetchChangesOrAll = async (client, doctype, lastSeq) => {
     return { documents, newLastSeq: lastChanges.newLastSeq }
   } else {
     return collection.fetchChanges({
-      since: lastSeq
+      since: lastSeq,
+      include_docs: true
     })
   }
 }

--- a/src/targets/services/helpers.spec.js
+++ b/src/targets/services/helpers.spec.js
@@ -135,7 +135,8 @@ describe('fetchChangesOrAll', () => {
     await fetchChangesOrAll(client, 'io.cozy.todos', 'abcd')
 
     expect(DocumentCollection.prototype.fetchChanges).toHaveBeenCalledWith({
-      since: 'abcd'
+      since: 'abcd',
+      include_docs: true
     })
     expect(DocumentCollection.prototype.all).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
Recently, the code was changed to use DocumentCollection.fetchChanges and
the include_docs: true option was forgotten.

Without include_docs, docs are not fetched when retrieving changes, and 
this leads to the return value of fetchChanges to have no documents. Since
notifications are sent based on changes, there were no more notifications
sent for transactionGreater/balanceLower.

See https://github.com/cozy/cozy-client/issues/966 to discuss about the
ergonomics of fetchChanges.


---

Also, a small regression was introduced recently for appSuggestions since
now we can have brands without konnectorSlug.