### PR TITLE
Improve planned transactions page

### DIFF
--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -132,11 +132,15 @@ const PlannedTransactionsPage = ({ emptyIcon }) => {
               />
             ) : null}
             {budget.transactions && budget.transactions.length === 0 ? (
-              <Empty
-                icon={emptyIcon}
-                title=""
-                text={t('EstimatedBudget.no-planned-transactions')}
-              />
+              <div className={isMobile ? 'u-mh-half' : ''}>
+                <Empty
+                  icon={emptyIcon}
+                  title={t('EstimatedBudget.no-planned-transactions.title')}
+                  text={
+                    <>✨ {t('EstimatedBudget.no-planned-transactions.text')}</>
+                  }
+                />
+              </div>
             ) : null}
           </>
         )}

--- a/src/ducks/future/selectors.js
+++ b/src/ducks/future/selectors.js
@@ -4,6 +4,7 @@ import isAfter from 'date-fns/is_after'
 import parse from 'date-fns/parse'
 import differenceInDays from 'date-fns/difference_in_days'
 import get from 'lodash/get'
+import orderBy from 'lodash/orderBy'
 
 import { getRecurrences } from 'selectors'
 import { getFilteredAccountIds } from 'ducks/filters'
@@ -82,6 +83,6 @@ export const getPlannedTransactions = createSelector(
       })
       res.push(transaction)
     }
-    return res
+    return orderBy(res, ['date'], ['desc'])
   }
 )

--- a/src/ducks/future/useEstimatedBudget.spec.jsx
+++ b/src/ducks/future/useEstimatedBudget.spec.jsx
@@ -58,21 +58,29 @@ describe('useEstimatedBudget', () => {
       estimatedBalance: 48833.36,
       sumTransactions: 4870.54,
       currency: undefined,
+
+      // transactions should be sorted
       transactions: [
         expect.objectContaining({
           _type: 'io.cozy.bank.operations',
-          label: 'Salaire',
-          amount: 3870.54,
-          date: expect.any(String),
+          label: 'A recurrence that should be listed first',
+          amount: 1000,
+
+          // future date should happen on the 5th day of the month
+          // since the latest day of the recurrence was a 5th
+          date: expect.stringMatching(/05T/),
           manualCategoryId: '200110',
           account: 'compteisa1',
           automaticCategoryId: '200110'
         }),
         expect.objectContaining({
           _type: 'io.cozy.bank.operations',
-          label: 'A recurrence that should be listed first',
-          amount: 1000,
-          date: expect.any(String),
+          label: 'Salaire',
+          amount: 3870.54,
+
+          // future date should happen on the 1st day of the month
+          // since the latest date of the recurrence was a 1st
+          date: expect.stringMatching(/01T/),
           manualCategoryId: '200110',
           account: 'compteisa1',
           automaticCategoryId: '200110'

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -897,7 +897,10 @@
   },
 
   "EstimatedBudget": {
-    "no-planned-transactions": "There are no planned transactions in the next 30 days.",
+    "no-planned-transactions": {
+      "title": "No planned transactions in the next 30 days",
+      "text": "You can set any operation as \"recurrent\" to help the prediction."
+    },
     "30-day-balance": "30-day balance",
     "page-title": "Planned transactions",
     "numberEstimatedTransactions": "%{smart_count} planned transaction |||| %{smart_count} planned transactions"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -898,7 +898,10 @@
   },
 
   "EstimatedBudget": {
-    "no-planned-transactions": "Il n'y a pas d'opérations prévues dans les 30 prochains jours.",
+    "no-planned-transactions": {
+      "title": "Pas d'opérations prévues à 30 jours",
+      "text": "Vous pouvez désigner toute opération d'un compte comme \"récurrente\" pour aider la prévision"
+    },
     "30-day-balance": "Solde à 30 jours",
     "page-title": "Dépenses prévues",
     "numberEstimatedTransactions": "%{smart_count} opération prévue |||| %{smart_count} opérations prévues"

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1704,7 +1704,7 @@
       "automaticLabel": "recurrence-starting-with-a",
       "amounts": [1000],
       "accounts": ["compteisa1"],
-      "latestDate": "2018-06-01T00:00:00Z",
+      "latestDate": "2018-06-05T00:00:00Z",
       "stats": {
         "deltas": {
           "median": 30


### PR DESCRIPTION
- Order planned transactions by descending date
- Add suggestion to mark operations as recurrent to improve prediction