### PR TITLE
feat: Add configuration id to io.cozy.bank.settings

### DIFF
--- a/src/ducks/settings/__snapshots__/helpers.spec.jsx.snap
+++ b/src/ducks/settings/__snapshots__/helpers.spec.jsx.snap
@@ -2,6 +2,7 @@
 
 exports[`defaulted settings should return defaulted settings 1`] = `
 Object {
+  "_id": "configuration",
   "_type": "io.cozy.bank.settings",
   "appSuggestions": Object {
     "lastSeq": 0,
@@ -22,6 +23,7 @@ Object {
       "enabled": true,
     },
   },
+  "id": "configuration",
   "linkMyselfToAccounts": Object {
     "processedAccounts": Array [],
   },

--- a/src/ducks/settings/constants.js
+++ b/src/ducks/settings/constants.js
@@ -3,6 +3,8 @@ export const COLLECTION_NAME = 'settings'
 
 export const DEFAULTS_SETTINGS = {
   _type: 'io.cozy.bank.settings',
+  _id: 'configuration',
+  id: 'configuration',
   autogroups: {
     processedAccounts: []
   },


### PR DESCRIPTION
Settings document now are all "named" with a specific id. It makes
it easier to find them and guarantees their unicity