### PR TITLE
Fix 2 crashes

### DIFF
--- a/src/ducks/transactions/TransactionModal.jsx
+++ b/src/ducks/transactions/TransactionModal.jsx
@@ -560,6 +560,10 @@ const TransactionModal = ({ requestClose, transactionId, ...props }) => {
     [location, requestClose]
   )
 
+  if (!transaction) {
+    return null // transaction is being deleted
+  }
+
   return (
     <RawContentDialog
       size="medium"

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -52,7 +52,7 @@ describe('transaction modal', () => {
     tracker.trackPage.mockReset()
   })
 
-  const setup = ({ router: routerOption } = {}) => {
+  const setup = ({ router: routerOption, transactionId } = {}) => {
     const router = routerOption || {
       params: {}
     }
@@ -61,7 +61,7 @@ describe('transaction modal', () => {
       <TrackerProvider value={tracker}>
         <AppLike client={client} router={router}>
           <TransactionModal
-            transactionId={data[TRANSACTION_DOCTYPE][1]._id}
+            transactionId={transactionId || data[TRANSACTION_DOCTYPE][1]._id}
             showCategoryChoice={() => {}}
             requestClose={() => {}}
             urls={{}}
@@ -89,6 +89,12 @@ describe('transaction modal', () => {
     expect(root.getByText('Edf Particuliers')).toBeTruthy()
     expect(root.getByText('-77.50')).toBeTruthy()
     expect(root.getByText('Saturday 26 August')).toBeTruthy()
+  })
+
+  it('should render null if transaction cannot be found in store (happens when transaction just has been deleted)', () => {
+    trackPage('mon_compte:compte')
+    const { root } = setup({ transactionId: 'not-existing' })
+    expect(root.queryByText('Occasional transaction')).toBeFalsy()
   })
 
   it('should send correct tracking events (balance page)', () => {

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -41,6 +41,12 @@ export const makeFilteredTransactionsConn = options => {
         indexFields = ['date', 'account']
         whereClause = { account: filteringDoc._id }
         sortByClause = [{ date: 'desc' }, { account: 'desc' }]
+      } else if (Array.isArray(filteringDoc)) {
+        indexFields = ['date', 'account']
+        whereClause = {
+          $or: filteringDoc.map(a => ({ account: a }))
+        }
+        sortByClause = [{ date: 'desc' }, { account: 'desc' }]
       } else {
         throw new Error('Unsupported filtering doc to create transaction query')
       }

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -77,4 +77,28 @@ describe('makeFilteredTransactionsConn', () => {
       })
     )
   })
+
+  it('should work with array of account ids (when clicking account balance header, filteringDoc is an array of account ids)', () => {
+    const conn1 = makeFilteredTransactionsConn({
+      groups: {
+        lastUpdate: Date.now(),
+        data: []
+      },
+      accounts: {
+        lastUpdate: Date.now()
+      },
+      filteringDoc: ['a1', 'a2', 'a3']
+    })
+    expect(conn1.enabled).toBe(true)
+    const query = conn1.query()
+    expect(query).toEqual(
+      expect.objectContaining({
+        indexedFields: ['date', 'account'],
+        selector: {
+          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }]
+        },
+        sort: [{ date: 'desc' }, { account: 'desc' }]
+      })
+    )
+  })
 })


### PR DESCRIPTION
* When a transaction just has been deleted, the transaction modal is still
rendered while it requests to be closed by its parent. At this point, the
transaction is no longer in the store, thus the TransactionModal should not
render anything instead of crashing.

*  When clicking on balance page top amount,
   filteringDoc is an array of account ids and the query
   maker for the transaction page should handle this case