### PR TITLE
useFullyLoadedQuery infinite loop

### DIFF
--- a/src/ducks/balance/AccountRow.jsx
+++ b/src/ducks/balance/AccountRow.jsx
@@ -151,13 +151,7 @@ const AccountRow = props => {
   }
 
   return (
-    <ListItem
-      ref={ref}
-      button
-      disableRipple
-      classes={classes}
-      onClick={handleClick}
-    >
+    <ListItem ref={ref} button classes={classes} onClick={handleClick}>
       <ListItemIcon>
         <AccountRowIcon account={account} />
       </ListItemIcon>

--- a/src/hooks/useFullyLoadedQuery.jsx
+++ b/src/hooks/useFullyLoadedQuery.jsx
@@ -1,15 +1,37 @@
-import { useEffect } from 'react'
+import { useEffect, useState, useRef } from 'react'
 import { useQuery } from 'cozy-client'
+
+const useIsMounted = () => {
+  const mounted = useRef()
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+  return mounted
+}
+
 /**
  * Will run fetchMore on the query until the query is fully loaded
  */
 const useFullyLoadedQuery = (query, options) => {
   const res = useQuery(query, options)
+  const [fetching, setFetching] = useState(false)
+  const mounted = useIsMounted()
   useEffect(() => {
-    if (res.fetchStatus === 'loaded' && res.hasMore) {
-      res.fetchMore()
+    const checkToFetchMore = async () => {
+      if (res.fetchStatus === 'loaded' && res.hasMore && !fetching) {
+        setFetching(true)
+        await res.fetchMore()
+        if (mounted.current) {
+          setFetching(false)
+        }
+      }
     }
-  }, [res.fetchStatus, res.fetchMore, res])
+    checkToFetchMore()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [res.hasMore, res.fetchStatus, fetching])
   return res
 }
 

--- a/src/hooks/useFullyLoadedQuery.spec.jsx
+++ b/src/hooks/useFullyLoadedQuery.spec.jsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import { renderHook } from '@testing-library/react-hooks'
+import { CozyProvider, Q } from 'cozy-client'
+import { createMockClient } from 'cozy-client/dist/mock'
+import useFullyLoadedQuery from './useFullyLoadedQuery'
+
+const sleep = delay => new Promise(resolve => setTimeout(resolve, delay))
+
+describe('useFullyLoadedQuery', () => {
+  const setup = ({ todosResult }) => {
+    const client = createMockClient({
+      queries: {
+        todos: todosResult
+      }
+    })
+    client.query.mockImplementation(async () => {
+      // give a little time for hook to be re-rendered several times
+      await sleep(10)
+      return {
+        data: [{ _id: '2', done: false }],
+        next: false
+      }
+    })
+    const wrapper = ({ children }) => (
+      <CozyProvider client={client}>{children}</CozyProvider>
+    )
+    const query = Q('io.cozy.todos')
+    const options = {
+      as: 'todos'
+    }
+    const hook = renderHook(() => useFullyLoadedQuery(query, options), {
+      wrapper
+    })
+    return { client, wrapper, hook }
+  }
+
+  it('should run only 1 fetch more even if the hook is rendered-multiple times', () => {
+    const {
+      client,
+      hook: { result, rerender }
+    } = setup({
+      todosResult: {
+        data: [{ _id: '1', done: true }],
+        next: true,
+        doctype: 'io.cozy.todos'
+      }
+    })
+    expect(result.error).toBeFalsy()
+    rerender()
+    rerender()
+    rerender()
+    rerender()
+
+    // one for the initial query and one for the fetchMore
+    expect(client.query).toHaveBeenCalledTimes(2)
+  })
+
+  it('should not run fetch if there are no more results', () => {
+    const {
+      client,
+      hook: { result, rerender }
+    } = setup({
+      todosResult: {
+        data: [{ _id: '1', done: true }],
+        next: false,
+        doctype: 'io.cozy.todos'
+      }
+    })
+    expect(result.error).toBeFalsy()
+    rerender()
+    rerender()
+    rerender()
+    rerender()
+
+    // one for the initial query and one for the fetchMore
+    expect(client.query).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
There were no guard against multiple fetch more calls inside
useFullyLoadedQuery. This seemed to trigger infinite loops. It is
not exactly clear why but with the additional checks that were
added, the infinite loop behavior could not be reproduced.

Added checks:

- do not call fetchMore() while already running
- do not call the effect with res as dependency, only with the
  the fetchStatus and hasMore