### PR TITLE
feat: Add possibility to select multiple transaction on desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "cozy-realtime": "3.11.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "23.13.1",
-    "cozy-ui": "50.9.0",
+    "cozy-ui": "51.0.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -11,8 +11,23 @@ import flag from 'cozy-flags'
 
 export const SelectionContext = createContext()
 
-export const useSelectionContext = () => {
-  return useContext(SelectionContext)
+export const useSelectionContext = item => {
+  const selectionContext = useContext(SelectionContext)
+
+  const isItemSelected = useMemo(() => selectionContext.isSelected(item), [
+    selectionContext,
+    item
+  ])
+
+  const toggleSelection = useCallback(() => {
+    if (selectionContext.isSelectionModeEnabled) {
+      isItemSelected
+        ? selectionContext.removeFromSelection(item)
+        : selectionContext.addToSelection(item)
+    }
+  }, [isItemSelected, item, selectionContext])
+
+  return { toggleSelection, isItemSelected, ...selectionContext }
 }
 
 // TODO: SelectionProvider stores the entire elements in an array

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -7,6 +7,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import Figure from 'cozy-ui/transpiled/react/Figure'
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
 
 import { TdSecondary } from 'components/Table'
 import TransactionActions from 'ducks/transactions/TransactionActions'
@@ -28,16 +29,23 @@ import ApplicationDateCaption from 'ducks/transactions/TransactionRow/Applicatio
 import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
 import TransactionDate from 'ducks/transactions/TransactionRow/TransactionDate'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
+import { useSelectionContext } from 'ducks/context/SelectionContext'
 
-const TransactionRowDesktop = props => {
+const TransactionRowDesktop = ({
+  transaction,
+  isExtraLarge,
+  filteringOnAccount,
+  onRef,
+  showRecurrence
+}) => {
   const { t } = useI18n()
+
   const {
-    transaction,
-    isExtraLarge,
-    filteringOnAccount,
-    onRef,
-    showRecurrence
-  } = props
+    isSelectionModeActive,
+    isSelectionModeEnabled,
+    toggleSelection,
+    isItemSelected: isTransactionSelected
+  } = useSelectionContext(transaction)
 
   const boundOnRef = useMemo(() => {
     return onRef ? onRef.bind(null, transaction._id) : null
@@ -66,9 +74,21 @@ const TransactionRowDesktop = props => {
   const handleClickCategory = useCallback(
     ev => {
       ev.preventDefault()
-      showTransactionCategoryModal()
+      if (isSelectionModeActive) {
+        toggleSelection()
+      } else {
+        showTransactionCategoryModal()
+      }
     },
-    [showTransactionCategoryModal]
+    [isSelectionModeActive, showTransactionCategoryModal, toggleSelection]
+  )
+
+  const handleClickCheckbox = useCallback(
+    ev => {
+      ev.preventDefault()
+      toggleSelection()
+    },
+    [toggleSelection]
   )
 
   const handleClickRow = useCallback(
@@ -79,9 +99,13 @@ const TransactionRowDesktop = props => {
       if (!ev.currentTarget.contains(ev.target)) {
         return
       }
-      showTransactionModal()
+      if (isSelectionModeActive) {
+        toggleSelection()
+      } else {
+        showTransactionModal()
+      }
     },
-    [showTransactionModal]
+    [isSelectionModeActive, showTransactionModal, toggleSelection]
   )
 
   // Virtual transactions, like those generated from recurrences, cannot be edited
@@ -94,11 +118,32 @@ const TransactionRowDesktop = props => {
         {...trRest}
         className={cx(
           styles.TransactionRow,
-          canEditTransaction ? styles['TransactionRow--editable'] : null
+          canEditTransaction ? styles['TransactionRow--editable'] : null,
+          {
+            [styles['TransactionRow--selected']]: isTransactionSelected
+          }
         )}
         onClick={canEditTransaction && handleClickRow}
       >
-        <td className={cx(styles.ColumnSizeDesc, 'u-pv-half', 'u-pl-1')}>
+        {isSelectionModeEnabled && (
+          <TdSecondary
+            className={cx(styles.ColumnSizeCheckbox, 'u-pl-0')}
+            onClick={handleClickCheckbox}
+          >
+            <Checkbox
+              data-testid={`TransactionRow-checkbox-${transaction._id}`}
+              checked={isTransactionSelected}
+              readOnly
+            />
+          </TdSecondary>
+        )}
+        <td
+          className={cx(
+            styles.ColumnSizeDesc,
+            'u-pv-half',
+            isSelectionModeEnabled ? 'u-pl-0' : 'u-pl-1'
+          )}
+        >
           <Media>
             <Img
               title={categoryTitle}
@@ -112,7 +157,7 @@ const TransactionRowDesktop = props => {
             <Bd className="u-pl-1">
               <ListItemText
                 className="u-pv-half"
-                onClick={canEditTransaction && showTransactionModal}
+                onClick={canEditTransaction && handleClickCategory}
               >
                 <Typography variant="body1">{getLabel(transaction)}</Typography>
                 {!filteringOnAccount && <AccountCaption account={account} />}
@@ -128,7 +173,7 @@ const TransactionRowDesktop = props => {
         </td>
         <TdSecondary
           className={styles.ColumnSizeDate}
-          onClick={showTransactionModal}
+          onClick={handleClickCategory}
         >
           <TransactionDate
             isExtraLarge={isExtraLarge}
@@ -137,7 +182,7 @@ const TransactionRowDesktop = props => {
         </TdSecondary>
         <TdSecondary
           className={styles.ColumnSizeAmount}
-          onClick={showTransactionModal}
+          onClick={handleClickCategory}
         >
           <Figure
             total={transaction.amount || 0}

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -40,13 +40,12 @@ const TransactionRowMobile = props => {
   const [rawShowTransactionModal, , transactionModal] = useTransactionModal(
     transaction
   )
+
   const {
-    isSelectionModeEnabled,
     isSelectionModeActive,
-    addToSelection,
-    isSelected,
-    removeFromSelection
-  } = useSelectionContext()
+    toggleSelection,
+    isItemSelected: isTransactionSelected
+  } = useSelectionContext(transaction)
 
   const boundOnRef = useMemo(() => {
     return onRef.bind(null, transaction._id)
@@ -69,44 +68,21 @@ const TransactionRowMobile = props => {
   const applicationDate = getApplicationDate(transaction)
   const recurrence = transaction.recurrence ? transaction.recurrence.data : null
 
-  const isTransactionSelected = useMemo(() => isSelected(transaction), [
-    isSelected,
-    transaction
-  ])
-
   const handleTap = useCallback(
     ev => {
       if (isSelectionModeActive) {
-        isTransactionSelected
-          ? removeFromSelection(transaction)
-          : addToSelection(transaction)
+        toggleSelection()
       } else {
         transaction._id && showTransactionModal(ev)
       }
     },
     [
-      addToSelection,
       isSelectionModeActive,
-      isTransactionSelected,
-      removeFromSelection,
       showTransactionModal,
-      transaction
+      toggleSelection,
+      transaction._id
     ]
   )
-
-  const handlePress = useCallback(() => {
-    if (isSelectionModeEnabled) {
-      isTransactionSelected
-        ? removeFromSelection(transaction)
-        : addToSelection(transaction)
-    }
-  }, [
-    addToSelection,
-    isSelectionModeEnabled,
-    isTransactionSelected,
-    removeFromSelection,
-    transaction
-  ])
 
   return (
     <>
@@ -116,7 +92,7 @@ const TransactionRowMobile = props => {
             <Img className="u-mr-half">
               <Tappable
                 onTap={handleTap}
-                onPress={handlePress}
+                onPress={toggleSelection}
                 pressDelay={250}
               >
                 <Checkbox checked={isTransactionSelected} readOnly />
@@ -135,7 +111,7 @@ const TransactionRowMobile = props => {
               >
                 <Tappable
                   onTap={handleTap}
-                  onPress={handlePress}
+                  onPress={toggleSelection}
                   pressDelay={250}
                 >
                   <CategoryIcon categoryId={getCategoryId(transaction)} />
@@ -144,7 +120,7 @@ const TransactionRowMobile = props => {
               <Bd className="u-mr-half">
                 <Tappable
                   onTap={handleTap}
-                  onPress={handlePress}
+                  onPress={toggleSelection}
                   pressDelay={250}
                 >
                   <ListItemText>
@@ -163,7 +139,7 @@ const TransactionRowMobile = props => {
               <Img className={styles.TransactionRowMobileImg}>
                 <Tappable
                   onTap={handleTap}
-                  onPress={handlePress}
+                  onPress={toggleSelection}
                   pressDelay={250}
                 >
                   <Figure

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -86,10 +86,18 @@ const TransactionRowMobile = props => {
 
   return (
     <>
-      <ListItem ref={boundOnRef} {...rowRest} button={!!transaction._id}>
+      <ListItem
+        ref={boundOnRef}
+        {...rowRest}
+        className={cx({
+          [styles['TransactionRow--selected']]: isTransactionSelected,
+          'u-pl-0': isSelectionModeActive
+        })}
+        button={!!transaction._id}
+      >
         <Media className="u-w-100">
           {isSelectionModeActive && (
-            <Img className="u-mr-half">
+            <Img>
               <Tappable
                 onTap={handleTap}
                 onPress={toggleSelection}

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -2,12 +2,14 @@
 @require '~styles/mixins.styl'
 @require 'settings/breakpoints'
 
+.ColumnSizeCheckbox
+    maxed-flex-basis 4%
+
 .ColumnSizeDesc
     maxed-flex-basis 40%
-    padding-left 4rem
 
 .ColumnSizeDate
-    maxed-flex-basis 15%
+    maxed-flex-basis 13%
     color var(--coolGrey)
     text-align right
 
@@ -16,7 +18,7 @@
     text-align right
 
 .ColumnSizeAction
-    maxed-flex-basis 25%
+    maxed-flex-basis 23%
 
 .TransactionTable
     color var(--primaryTextColor)
@@ -63,6 +65,20 @@
 
 .TransactionRow--editable
     cursor pointer
+
+    .ColumnSizeCheckbox span
+        visibility hidden
+    &:hover
+        .ColumnSizeCheckbox span
+            visibility visible
+
+.TransactionRow--selected
+    &
+    &:hover
+        background-color var(--zircon) !important
+
+    .ColumnSizeCheckbox span
+        visibility visible
 
 // For now, all mouvements from same category use the same icon
 categories = kids dailyLife educationAndTraining health homeAndRealEstate incomeCat activities excludeFromBudgetCat services tax transportation goingOutAndTravel uncategorized

--- a/src/ducks/transactions/header/TableHead.jsx
+++ b/src/ducks/transactions/header/TableHead.jsx
@@ -1,14 +1,18 @@
 import React from 'react'
-import { Table } from 'components/Table'
+import cx from 'classnames'
 
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import { Table } from 'components/Table'
+import { useSelectionContext } from 'ducks/context/SelectionContext'
+
 import transactionsStyles from 'ducks/transactions/Transactions.styl'
 
-const TableHead = props => {
+const TableHead = ({ isSubcategory }) => {
   const { t } = useI18n()
   const { isDesktop } = useBreakpoints()
-  const { isSubcategory } = props
+  const { isSelectionModeEnabled } = useSelectionContext()
 
   if (!isDesktop) {
     return null
@@ -18,6 +22,11 @@ const TableHead = props => {
     <Table>
       <thead>
         <tr>
+          {isSelectionModeEnabled && (
+            <td
+              className={cx(transactionsStyles.ColumnSizeCheckbox, 'u-pl-0')}
+            />
+          )}
           <td className={transactionsStyles.ColumnSizeDesc}>
             {isSubcategory
               ? t('Categories.headers.movements')

--- a/yarn.lock
+++ b/yarn.lock
@@ -5258,10 +5258,10 @@ cozy-ui@40.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@50.9.0:
-  version "50.9.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-50.9.0.tgz#7f863bb36813523270f0950e904d01f57c0213cc"
-  integrity sha512-ry2cZmeIp+MRfCmXLw2UpibvYd+ZwDcpPmgCxGDrO17GzOj7VefiKLaavFPwQO+2Z6iNd1h3yBWNyf1SO1rWBA==
+cozy-ui@51.0.0:
+  version "51.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.0.0.tgz#48047a827a2cba938dfa3f6b35e91fd75e81d144"
+  integrity sha512-Dor6pVJi3gOnXDOGkawQ23bHroHBsdER8J1GJ0Kimt/TWW0FVYZwEFUPVY15BVfNJLHz87soY+GeYSIP+Iu9YA==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
On souhaite pouvoir faire une sélection de plusieurs transaction afin de les catégoriser, également sur desktop (on a déjà la feature sur mobile)