### PR TITLE
Fixes to categories page

### DIFF
--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -8,6 +8,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Stack from 'cozy-ui/transpiled/react/Stack'
 import Empty from 'cozy-ui/transpiled/react/Empty'
+import SadCozyIcon from 'cozy-ui/transpiled/react/Icons/SadCozy'
 
 import { useSelector, useDispatch } from 'react-redux'
 
@@ -187,13 +188,12 @@ const CategoriesHeader = props => {
             </LegalMention>
 
             {!hasData && !isFetching && !isFetchingNewData && (
-              <div className={styles.NoAccount_empty}>
-                <Empty
-                  icon={emptyIcon}
-                  title=""
-                  text={t('Categories.title.empty-text')}
-                />
-              </div>
+              <Empty
+                className={cx('u-mt-3', styles.NoAccount_empty)}
+                icon={emptyIcon}
+                title=""
+                text={t('Categories.title.empty-text')}
+              />
             )}
             {incomeToggle && chart ? <Padded>{chart}</Padded> : null}
           </Header>
@@ -249,13 +249,21 @@ const CategoriesHeader = props => {
         ) : null}
       </Header>
       <HeaderLoadingProgress isFetching={!!isFetchingNewData && !isFetching} />
+      {!hasData && !isFetching && !isFetchingNewData ? (
+        <Empty
+          className={styles.NoAccount_empty}
+          icon={emptyIcon}
+          title=""
+          text={t('Categories.title.empty-text')}
+        />
+      ) : null}
     </>
   )
 }
 
 CategoriesHeader.defaultProps = {
   chartSize: 182,
-  emptyIcon: 'cozy',
+  emptyIcon: SadCozyIcon,
   classes: {
     header: '',
     legalMention: 'u-mt-2 u-pt-1',

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -52,6 +52,9 @@
     height: 140px
     display: flex
 
+    svg
+        fill var(--secondaryTextColor)
+
 .CategoriesHeader__Toggle
     > span
         margin-right 1em

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -297,6 +297,9 @@ const enhance = Component => props => {
       : setAutoUpdate(initialConn)
   }, [initialConn, period])
   const transactions = useFullyLoadedQuery(conn.query, conn)
+
+  // This is used for loaded transactions to stay rendered while
+  // next/previous month transactions are loaded
   const col = useLast(transactions, (last, cur) => {
     return !last || (cur.lastUpdate && !cur.hasMore)
   })

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -241,11 +241,12 @@ const autoUpdateOptions = {
 }
 
 const addPeriodToConn = (baseConn, period) => {
-  const { query: baseQuery, as: baseAs, ...rest } = baseConn
+  const { query: mkBaseQuery, as: baseAs, ...rest } = baseConn
   const d = new Date(period)
   const startDate = period.length === 7 ? startOfMonth(d) : startOfYear(d)
   const endDate = period.length === 7 ? endOfMonth(d) : endOfYear(d)
-  const query = Q(baseQuery().doctype)
+  const baseQuery = mkBaseQuery()
+  const query = Q(baseQuery.doctype)
     .where(
       merge(
         {

--- a/src/ducks/settings/GroupSettings.jsx
+++ b/src/ducks/settings/GroupSettings.jsx
@@ -97,7 +97,7 @@ export const AccountLine = props => {
       <td className={styles.GrpStg__accntNumber}>{account.number}</td>
       {!isMobile ? (
         <td className={styles.GrpStg__accntGroups}>
-          {groups.map(g => g.label).join(', ')}
+          {groups.map(g => getGroupLabel(g, t)).join(', ')}
         </td>
       ) : null}
       <td className={styles.GrpStg__accntToggle}>


### PR DESCRIPTION
- Categories: Display Empty in desktop when no transactions in the period in categories page
- Categories: Transaction select dates min/max dates were not correct
- Categories: Take into account the filter to load categories page transactions
- Settings: Correctly display auto group labels