### PR TITLE
fix: Remove during tests warning

### DIFF
--- a/src/ducks/transactions/TransactionRecurrenceEditor.jsx
+++ b/src/ducks/transactions/TransactionRecurrenceEditor.jsx
@@ -68,6 +68,7 @@ export const makeOptionFromRecurrence = (rec, t, accountsById) => {
   return {
     _id: rec._id,
     _type: RECURRENCE_DOCTYPE,
+    key: rec._id,
     title: getLabel(rec),
     icon: <CategoryIcon categoryId={getCategories(rec)[0]} />,
     description: [freqDescription, amountDescription, accountDescription]


### PR DESCRIPTION
NestedSelect options are keyed by the title of the option
or by the key attribute of the option. Since both
options had the same title "Salaire", we had a warning
during tests because two react keys were the same.

To remove the warning, we can set "key" as the _id of each recurrence in
in the NestedSelect options.