### PR TITLE
SelectionContext optimisations

### DIFF
--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -11,23 +11,8 @@ import flag from 'cozy-flags'
 
 export const SelectionContext = createContext()
 
-export const useSelectionContext = item => {
-  const selectionContext = useContext(SelectionContext)
-
-  const isItemSelected = useMemo(() => selectionContext.isSelected(item), [
-    selectionContext,
-    item
-  ])
-
-  const toggleSelection = useCallback(() => {
-    if (selectionContext.isSelectionModeEnabled) {
-      isItemSelected
-        ? selectionContext.removeFromSelection(item)
-        : selectionContext.addToSelection(item)
-    }
-  }, [isItemSelected, item, selectionContext])
-
-  return { toggleSelection, isItemSelected, ...selectionContext }
+export const useSelectionContext = () => {
+  return useContext(SelectionContext)
 }
 
 // TODO: SelectionProvider stores the entire elements in an array
@@ -68,6 +53,15 @@ const SelectionProvider = ({ children }) => {
 
   const isSelected = useCallback(item => selected.includes(item), [selected])
 
+  const toggleSelection = useCallback(
+    item => {
+      if (isSelectionModeEnabled) {
+        isSelected(item) ? removeFromSelection(item) : addToSelection(item)
+      }
+    },
+    [addToSelection, removeFromSelection, isSelected]
+  )
+
   useEffect(() => {
     if (isSelectionModeActive && selected.length === 0) {
       deactivateSelectionMode()
@@ -90,7 +84,8 @@ const SelectionProvider = ({ children }) => {
       isSelected,
       emptySelection,
       removeFromSelection,
-      isSelectionModeEnabled
+      isSelectionModeEnabled,
+      toggleSelection
     }),
     [
       addToSelection,
@@ -99,7 +94,8 @@ const SelectionProvider = ({ children }) => {
       isSelectionModeActive,
       isSelectionModeEnabled,
       removeFromSelection,
-      selected
+      selected,
+      toggleSelection
     ]
   )
 

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -59,7 +59,7 @@ const SelectionProvider = ({ children }) => {
         isSelected(item) ? removeFromSelection(item) : addToSelection(item)
       }
     },
-    [addToSelection, removeFromSelection, isSelected]
+    [isSelectionModeEnabled, isSelected, removeFromSelection, addToSelection]
   )
 
   useEffect(() => {
@@ -78,23 +78,19 @@ const SelectionProvider = ({ children }) => {
 
   const value = useMemo(
     () => ({
-      isSelectionModeActive,
       selected,
-      addToSelection,
+      isSelectionModeActive,
+      isSelectionModeEnabled,
       isSelected,
       emptySelection,
-      removeFromSelection,
-      isSelectionModeEnabled,
       toggleSelection
     }),
     [
-      addToSelection,
-      emptySelection,
-      isSelected,
+      selected,
       isSelectionModeActive,
       isSelectionModeEnabled,
-      removeFromSelection,
-      selected,
+      isSelected,
+      emptySelection,
       toggleSelection
     ]
   )

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -3,7 +3,8 @@ import React, {
   useState,
   useCallback,
   useContext,
-  useMemo
+  useMemo,
+  useRef
 } from 'react'
 
 import flag from 'cozy-flags'
@@ -26,6 +27,13 @@ const SelectionProvider = ({ children }) => {
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
   const isSelected = useCallback(item => selected.includes(item), [selected])
+  const selectedRef = useRef(selected)
+
+  const isSelectionModeActiveFn = useCallback(() => {
+    return selectedRef.current.length > 0
+  }, [])
+
+  selectedRef.current = selected
 
   const toggleSelection = useCallback(
     item => {
@@ -46,6 +54,8 @@ const SelectionProvider = ({ children }) => {
     () => ({
       selected,
       isSelectionModeActive: selected.length > 0,
+      // Only used this in callbacks since its value is not reactive
+      isSelectionModeActiveFn,
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
@@ -53,6 +63,7 @@ const SelectionProvider = ({ children }) => {
     }),
     [
       selected,
+      isSelectionModeActiveFn,
       isSelectionModeEnabled,
       isSelected,
       emptySelection,

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -2,7 +2,6 @@ import React, {
   createContext,
   useState,
   useCallback,
-  useEffect,
   useContext,
   useMemo
 } from 'react'
@@ -20,20 +19,9 @@ export const useSelectionContext = () => {
 // imagine that there are quite few elements.
 // But an improvement would be to store only the ids.
 const SelectionProvider = ({ children }) => {
-  const [isSelectionModeActive, setIsSelectionModeActive] = useState(false)
   const [selected, setSelected] = useState([])
 
   const isSelectionModeEnabled = flag('banks.selectionMode.enabled')
-
-  const activateSelectionMode = useCallback(
-    () => isSelectionModeEnabled && setIsSelectionModeActive(true),
-    [isSelectionModeEnabled]
-  )
-
-  const deactivateSelectionMode = useCallback(
-    () => setIsSelectionModeActive(false),
-    [setIsSelectionModeActive]
-  )
 
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
@@ -54,24 +42,10 @@ const SelectionProvider = ({ children }) => {
     [isSelectionModeEnabled]
   )
 
-  useEffect(() => {
-    if (isSelectionModeActive && selected.length === 0) {
-      deactivateSelectionMode()
-    }
-    if (!isSelectionModeActive && selected.length > 0) {
-      activateSelectionMode()
-    }
-  }, [
-    selected,
-    activateSelectionMode,
-    isSelectionModeActive,
-    deactivateSelectionMode
-  ])
-
   const value = useMemo(
     () => ({
       selected,
-      isSelectionModeActive,
+      isSelectionModeActive: selected.length > 0,
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
@@ -79,7 +53,6 @@ const SelectionProvider = ({ children }) => {
     }),
     [
       selected,
-      isSelectionModeActive,
       isSelectionModeEnabled,
       isSelected,
       emptySelection,

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -35,31 +35,23 @@ const SelectionProvider = ({ children }) => {
     [setIsSelectionModeActive]
   )
 
-  const addToSelection = useCallback(
-    item => {
-      setSelected(v => [...v, item])
-    },
-    [setSelected]
-  )
-
-  const removeFromSelection = useCallback(
-    item => {
-      setSelected(v => v.filter(e => e._id !== item._id))
-    },
-    [setSelected]
-  )
-
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
   const isSelected = useCallback(item => selected.includes(item), [selected])
 
   const toggleSelection = useCallback(
     item => {
-      if (isSelectionModeEnabled) {
-        isSelected(item) ? removeFromSelection(item) : addToSelection(item)
+      if (!isSelectionModeEnabled) {
+        return
       }
+      return setSelected(selected => {
+        const found = selected.includes(item)
+        return found
+          ? selected.filter(elem => elem !== item)
+          : [...selected, item]
+      })
     },
-    [isSelectionModeEnabled, isSelected, removeFromSelection, addToSelection]
+    [isSelectionModeEnabled]
   )
 
   useEffect(() => {

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -37,6 +37,7 @@ export const useSelectionContext = item => {
 const SelectionProvider = ({ children }) => {
   const [isSelectionModeActive, setIsSelectionModeActive] = useState(false)
   const [selected, setSelected] = useState([])
+
   const isSelectionModeEnabled = flag('banks.selectionMode.enabled')
 
   const activateSelectionMode = useCallback(
@@ -44,7 +45,10 @@ const SelectionProvider = ({ children }) => {
     [isSelectionModeEnabled]
   )
 
-  const deactivateSelectionMode = () => setIsSelectionModeActive(false)
+  const deactivateSelectionMode = useCallback(
+    () => setIsSelectionModeActive(false),
+    [setIsSelectionModeActive]
+  )
 
   const addToSelection = useCallback(
     item => {
@@ -55,9 +59,9 @@ const SelectionProvider = ({ children }) => {
 
   const removeFromSelection = useCallback(
     item => {
-      setSelected(selected.filter(e => e._id !== item._id))
+      setSelected(v => v.filter(e => e._id !== item._id))
     },
-    [selected]
+    [setSelected]
   )
 
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
@@ -71,7 +75,12 @@ const SelectionProvider = ({ children }) => {
     if (!isSelectionModeActive && selected.length > 0) {
       activateSelectionMode()
     }
-  }, [selected, activateSelectionMode, isSelectionModeActive])
+  }, [
+    selected,
+    activateSelectionMode,
+    isSelectionModeActive,
+    deactivateSelectionMode
+  ])
 
   const value = useMemo(
     () => ({

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -44,8 +44,8 @@ const TransactionRowDesktop = ({
     isSelectionModeActive,
     isSelectionModeEnabled,
     toggleSelection,
-    isItemSelected: isTransactionSelected
-  } = useSelectionContext(transaction)
+    isSelected
+  } = useSelectionContext()
 
   const boundOnRef = useMemo(() => {
     return onRef ? onRef.bind(null, transaction._id) : null
@@ -75,20 +75,25 @@ const TransactionRowDesktop = ({
     ev => {
       ev.preventDefault()
       if (isSelectionModeActive) {
-        toggleSelection()
+        toggleSelection(transaction)
       } else {
         showTransactionCategoryModal()
       }
     },
-    [isSelectionModeActive, showTransactionCategoryModal, toggleSelection]
+    [
+      isSelectionModeActive,
+      showTransactionCategoryModal,
+      toggleSelection,
+      transaction
+    ]
   )
 
   const handleClickCheckbox = useCallback(
     ev => {
       ev.preventDefault()
-      toggleSelection()
+      toggleSelection(transaction)
     },
-    [toggleSelection]
+    [toggleSelection, transaction]
   )
 
   const handleClickRow = useCallback(
@@ -100,12 +105,12 @@ const TransactionRowDesktop = ({
         return
       }
       if (isSelectionModeActive) {
-        toggleSelection()
+        toggleSelection(transaction)
       } else {
         showTransactionModal()
       }
     },
-    [isSelectionModeActive, showTransactionModal, toggleSelection]
+    [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
   )
 
   // Virtual transactions, like those generated from recurrences, cannot be edited
@@ -120,7 +125,7 @@ const TransactionRowDesktop = ({
           styles.TransactionRow,
           canEditTransaction ? styles['TransactionRow--editable'] : null,
           {
-            [styles['TransactionRow--selected']]: isTransactionSelected
+            [styles['TransactionRow--selected']]: isSelected(transaction)
           }
         )}
         onClick={canEditTransaction && handleClickRow}
@@ -132,7 +137,7 @@ const TransactionRowDesktop = ({
           >
             <Checkbox
               data-testid={`TransactionRow-checkbox-${transaction._id}`}
-              checked={isTransactionSelected}
+              checked={isSelected(transaction)}
               readOnly
             />
           </TdSecondary>

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -29,23 +29,19 @@ import ApplicationDateCaption from 'ducks/transactions/TransactionRow/Applicatio
 import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
 import TransactionDate from 'ducks/transactions/TransactionRow/TransactionDate'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
-import { useSelectionContext } from 'ducks/context/SelectionContext'
 
 const TransactionRowDesktop = ({
   transaction,
   isExtraLarge,
   filteringOnAccount,
   onRef,
-  showRecurrence
+  showRecurrence,
+  isSelected,
+  isSelectionModeActiveFn,
+  isSelectionModeEnabled,
+  toggleSelection
 }) => {
   const { t } = useI18n()
-
-  const {
-    isSelectionModeActiveFn,
-    isSelectionModeEnabled,
-    toggleSelection,
-    isSelected
-  } = useSelectionContext()
 
   const boundOnRef = useMemo(() => {
     return onRef ? onRef.bind(null, transaction._id) : null
@@ -130,7 +126,7 @@ const TransactionRowDesktop = ({
           styles.TransactionRow,
           canEditTransaction ? styles['TransactionRow--editable'] : null,
           {
-            [styles['TransactionRow--selected']]: isSelected(transaction)
+            [styles['TransactionRow--selected']]: isSelected
           }
         )}
         onClick={canEditTransaction && handleClickRow}
@@ -142,7 +138,7 @@ const TransactionRowDesktop = ({
           >
             <Checkbox
               data-testid={`TransactionRow-checkbox-${transaction._id}`}
-              checked={isSelected(transaction)}
+              checked={isSelected}
               readOnly
             />
           </TdSecondary>

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -41,7 +41,7 @@ const TransactionRowDesktop = ({
   const { t } = useI18n()
 
   const {
-    isSelectionModeActive,
+    isSelectionModeActiveFn,
     isSelectionModeEnabled,
     toggleSelection,
     isSelected
@@ -74,14 +74,14 @@ const TransactionRowDesktop = ({
   const handleClickCategory = useCallback(
     ev => {
       ev.preventDefault()
-      if (isSelectionModeActive) {
+      if (isSelectionModeActiveFn()) {
         toggleSelection(transaction)
       } else {
         showTransactionCategoryModal()
       }
     },
     [
-      isSelectionModeActive,
+      isSelectionModeActiveFn,
       showTransactionCategoryModal,
       toggleSelection,
       transaction
@@ -104,13 +104,18 @@ const TransactionRowDesktop = ({
       if (!ev.currentTarget.contains(ev.target)) {
         return
       }
-      if (isSelectionModeActive) {
+      if (isSelectionModeActiveFn()) {
         toggleSelection(transaction)
       } else {
         showTransactionModal()
       }
     },
-    [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
+    [
+      isSelectionModeActiveFn,
+      showTransactionModal,
+      toggleSelection,
+      transaction
+    ]
   )
 
   // Virtual transactions, like those generated from recurrences, cannot be edited

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -44,8 +44,13 @@ const TransactionRowMobile = props => {
   const {
     isSelectionModeActive,
     toggleSelection,
-    isItemSelected: isTransactionSelected
-  } = useSelectionContext(transaction)
+    isSelected
+  } = useSelectionContext()
+
+  const toggleTransactionSelection = useCallback(
+    () => toggleSelection(transaction),
+    [toggleSelection, transaction]
+  )
 
   const boundOnRef = useMemo(() => {
     return onRef.bind(null, transaction._id)
@@ -71,17 +76,12 @@ const TransactionRowMobile = props => {
   const handleTap = useCallback(
     ev => {
       if (isSelectionModeActive) {
-        toggleSelection()
+        toggleSelection(transaction)
       } else {
         transaction._id && showTransactionModal(ev)
       }
     },
-    [
-      isSelectionModeActive,
-      showTransactionModal,
-      toggleSelection,
-      transaction._id
-    ]
+    [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
   )
 
   return (
@@ -90,7 +90,7 @@ const TransactionRowMobile = props => {
         ref={boundOnRef}
         {...rowRest}
         className={cx({
-          [styles['TransactionRow--selected']]: isTransactionSelected,
+          [styles['TransactionRow--selected']]: isSelected(transaction),
           'u-pl-0': isSelectionModeActive
         })}
         button={!!transaction._id}
@@ -100,10 +100,10 @@ const TransactionRowMobile = props => {
             <Img>
               <Tappable
                 onTap={handleTap}
-                onPress={toggleSelection}
+                onPress={toggleTransactionSelection}
                 pressDelay={250}
               >
-                <Checkbox checked={isTransactionSelected} readOnly />
+                <Checkbox checked={isSelected(transaction)} readOnly />
               </Tappable>
             </Img>
           )}
@@ -119,7 +119,7 @@ const TransactionRowMobile = props => {
               >
                 <Tappable
                   onTap={handleTap}
-                  onPress={toggleSelection}
+                  onPress={toggleTransactionSelection}
                   pressDelay={250}
                 >
                   <CategoryIcon categoryId={getCategoryId(transaction)} />
@@ -128,7 +128,7 @@ const TransactionRowMobile = props => {
               <Bd className="u-mr-half">
                 <Tappable
                   onTap={handleTap}
-                  onPress={toggleSelection}
+                  onPress={toggleTransactionSelection}
                   pressDelay={250}
                 >
                   <ListItemText>
@@ -147,7 +147,7 @@ const TransactionRowMobile = props => {
               <Img className={styles.TransactionRowMobileImg}>
                 <Tappable
                   onTap={handleTap}
-                  onPress={toggleSelection}
+                  onPress={toggleTransactionSelection}
                   pressDelay={250}
                 >
                   <Figure

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -32,20 +32,33 @@ import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
 import { useSelectionContext } from 'ducks/context/SelectionContext'
 
-const TransactionRowMobile = props => {
+const RowCheckbox = ({ isSelected, onTap, onPress }) => {
+  const { isSelectionModeActive } = useSelectionContext()
+
+  return isSelectionModeActive ? (
+    <Img style={{ marginLeft: '-1rem' }}>
+      <Tappable onTap={onTap} onPress={onPress} pressDelay={250}>
+        <Checkbox checked={isSelected} readOnly />
+      </Tappable>
+    </Img>
+  ) : null
+}
+
+const TransactionRowMobile = ({
+  transaction,
+  filteringOnAccount,
+  onRef,
+  showRecurrence,
+  isSelected,
+  isSelectionModeActiveFn,
+  toggleSelection
+}) => {
   const { t } = useI18n()
-  const { transaction, filteringOnAccount, onRef, showRecurrence } = props
   const account = transaction.account.data
   const rowRest = {}
   const [rawShowTransactionModal, , transactionModal] = useTransactionModal(
     transaction
   )
-
-  const {
-    isSelectionModeActive,
-    toggleSelection,
-    isSelected
-  } = useSelectionContext()
 
   const toggleTransactionSelection = useCallback(
     () => toggleSelection(transaction),
@@ -75,13 +88,18 @@ const TransactionRowMobile = props => {
 
   const handleTap = useCallback(
     ev => {
-      if (isSelectionModeActive) {
+      if (isSelectionModeActiveFn()) {
         toggleSelection(transaction)
       } else {
         transaction._id && showTransactionModal(ev)
       }
     },
-    [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
+    [
+      isSelectionModeActiveFn,
+      showTransactionModal,
+      toggleSelection,
+      transaction
+    ]
   )
 
   return (
@@ -90,23 +108,16 @@ const TransactionRowMobile = props => {
         ref={boundOnRef}
         {...rowRest}
         className={cx({
-          [styles['TransactionRow--selected']]: isSelected(transaction),
-          'u-pl-0': isSelectionModeActive
+          [styles['TransactionRow--selected']]: isSelected
         })}
         button={!!transaction._id}
       >
         <Media className="u-w-100">
-          {isSelectionModeActive && (
-            <Img>
-              <Tappable
-                onTap={handleTap}
-                onPress={toggleTransactionSelection}
-                pressDelay={250}
-              >
-                <Checkbox checked={isSelected(transaction)} readOnly />
-              </Tappable>
-            </Img>
-          )}
+          <RowCheckbox
+            isSelected={isSelected}
+            onTap={handleTap}
+            onPress={toggleTransactionSelection}
+          />
           <Bd>
             <Media className="u-w-100">
               <Img

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -24,6 +24,7 @@ import TransactionRowDesktop from 'ducks/transactions/TransactionRow/Transaction
 import { getDate } from 'ducks/transactions/helpers'
 import useVisible from 'hooks/useVisible'
 import SelectionBar from 'ducks/selection/SelectionBar'
+import { useSelectionContext } from 'ducks/context/SelectionContext'
 
 export const sortByDate = (transactions = []) =>
   sortBy(transactions, getDate).reverse()
@@ -87,10 +88,19 @@ const TransactionContainerMobile = props => {
  * Groups transactions by date and renders them as a list
  * On desktop, the section headers will not be shown
  */
-const TransactionSections = props => {
-  const { filteringOnAccount, className, transactions, onRowRef } = props
-
+const TransactionSections = ({
+  filteringOnAccount,
+  className,
+  transactions,
+  onRowRef
+}) => {
   const { isDesktop, isExtraLarge } = useBreakpoints()
+  const {
+    isSelected,
+    isSelectionModeActiveFn,
+    isSelectionModeEnabled,
+    toggleSelection
+  } = useSelectionContext()
 
   const transactionsGrouped = useMemo(() => groupByDate(transactions), [
     transactions
@@ -114,6 +124,10 @@ const TransactionSections = props => {
                   transaction={transaction}
                   isExtraLarge={isExtraLarge}
                   filteringOnAccount={filteringOnAccount}
+                  isSelected={isSelected(transaction)}
+                  isSelectionModeActiveFn={isSelectionModeActiveFn}
+                  isSelectionModeEnabled={isSelectionModeEnabled}
+                  toggleSelection={toggleSelection}
                 />
               )
             })}

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -164,6 +164,11 @@ export class TransactionsDumb extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    const { emptySelection } = this.props
+    emptySelection()
+  }
+
   updateTransactions(transactions) {
     this.transactionsById = keyBy(transactions, '_id')
     this.transactions = sortByDate(transactions)
@@ -251,6 +256,10 @@ TransactionsDumb.defaultProps = {
   TransactionSections
 }
 
-const Transactions = TransactionsDumb
+const Transactions = props => {
+  const { emptySelection } = useSelectionContext()
+
+  return <TransactionsDumb emptySelection={emptySelection} {...props} />
+}
 
 export const TransactionList = withBreakpoints()(Transactions)

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -124,6 +124,7 @@ describe('SelectionBar', () => {
           breakpoints={{ isDesktop: false }}
           transactions={mockTransactions}
           showTriggerErrors={false}
+          emptySelection={() => null}
         />
       </AppLike>
     )


### PR DESCRIPTION
Optimisation du fonctionnement du SelectionContext pour éviter des re-render intempestifs, et notamment éviter de re-render toutes les lignes de transactions à la modification d'une seule ligne.

Ajout également du fait de vider le context en sortant de la page en cours.