### PR TITLE
feat: Add select all button in selection bar

### DIFF
--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -21,19 +21,18 @@ export const useSelectionContext = () => {
 // But an improvement would be to store only the ids.
 const SelectionProvider = ({ children }) => {
   const [selected, setSelected] = useState([])
+  const selectedRef = useRef(selected)
+  selectedRef.current = selected
 
   const isSelectionModeEnabled = flag('banks.selectionMode.enabled')
 
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
   const isSelected = useCallback(item => selected.includes(item), [selected])
-  const selectedRef = useRef(selected)
 
   const isSelectionModeActiveFn = useCallback(() => {
     return selectedRef.current.length > 0
   }, [])
-
-  selectedRef.current = selected
 
   const toggleSelection = useCallback(
     item => {

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -28,6 +28,8 @@ const SelectionProvider = ({ children }) => {
 
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
+  const fillSelectionWith = useCallback(arr => setSelected(arr), [setSelected])
+
   const isSelected = useCallback(item => selected.includes(item), [selected])
 
   const isSelectionModeActiveFn = useCallback(() => {
@@ -58,7 +60,8 @@ const SelectionProvider = ({ children }) => {
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
-      toggleSelection
+      toggleSelection,
+      fillSelectionWith
     }),
     [
       selected,
@@ -66,7 +69,8 @@ const SelectionProvider = ({ children }) => {
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
-      toggleSelection
+      toggleSelection,
+      fillSelectionWith
     ]
   )
 

--- a/src/ducks/selection/SelectionBar.jsx
+++ b/src/ducks/selection/SelectionBar.jsx
@@ -8,12 +8,13 @@ import { useSelectionContext } from 'ducks/context/SelectionContext'
 import { makeSelectionBarActions } from 'ducks/selection/helpers'
 import { useTransactionCategoryModal } from 'ducks/transactions/TransactionRow'
 
-const SelectionBar = () => {
+const SelectionBar = ({ transactions }) => {
   const {
     isSelectionModeEnabled,
     isSelectionModeActive,
     selected,
-    emptySelection
+    emptySelection,
+    fillSelectionWith
   } = useSelectionContext()
 
   const { t } = useI18n()
@@ -40,9 +41,18 @@ const SelectionBar = () => {
     afterUpdates
   })
 
+  const fillSelection = useCallback(() => fillSelectionWith(transactions), [
+    fillSelectionWith,
+    transactions
+  ])
+
   const actions = useMemo(
-    () => makeSelectionBarActions(showTransactionCategoryModal),
-    [showTransactionCategoryModal]
+    () =>
+      makeSelectionBarActions({
+        showTransactionCategoryModal,
+        fillSelection
+      }),
+    [fillSelection, showTransactionCategoryModal]
   )
 
   if (!isSelectionModeEnabled) return null

--- a/src/ducks/selection/helpers.js
+++ b/src/ducks/selection/helpers.js
@@ -1,11 +1,20 @@
 import GraphCircleIcon from 'cozy-ui/transpiled/react/Icons/GraphCircle'
+import SelectAllIcon from 'cozy-ui/transpiled/react/Icons/SelectAll'
 
-export const makeSelectionBarActions = showTransactionCategoryModal => {
+export const makeSelectionBarActions = ({
+  showTransactionCategoryModal,
+  fillSelection
+}) => {
   return {
     categorize: {
       action: () => showTransactionCategoryModal(),
       displayCondition: selected => selected.length > 0,
       icon: GraphCircleIcon
+    },
+    selectAll: {
+      action: () => fillSelection(),
+      displayCondition: selected => selected.length > 0,
+      icon: SelectAllIcon
     }
   }
 }

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -221,7 +221,7 @@ export class TransactionsDumb extends React.Component {
 
     return (
       <>
-        <SelectionBar />
+        <SelectionBar transactions={transactions} />
         <InfiniteScroll
           manual={false}
           canLoadAtTop={false}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -923,6 +923,7 @@
   "SelectionBar": {
     "selected_count": "item selected |||| items selected",
     "close": "Close",
-    "categorize": "Categorize"
+    "categorize": "Categorize",
+    "selectAll": "Select all"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -925,6 +925,7 @@
   "SelectionBar": {
     "selected_count": "élément sélectionné |||| éléments sélectionnés",
     "close": "Fermer",
-    "categorize": "Categorisation"
+    "categorize": "Catégorisation",
+    "selectAll": "Tout sélectionner"
   }
 }


### PR DESCRIPTION
On souhaite avoir un bouton dans la barre de sélection qui permet de sélectionner toutes les transactions visibles.

![image](https://user-images.githubusercontent.com/67680939/124250942-a6953000-db25-11eb-9dab-790d3f2a0245.png)

![image](https://user-images.githubusercontent.com/67680939/124250982-b3b21f00-db25-11eb-9d37-4421635fb8f5.png)
