### PR TITLE
chore: Remove post/pre push/commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,16 +73,6 @@
     "service": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/services/cli.js",
     "service:autogroups": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/targets/services/autogroups.js"
   },
-  "husky": {
-    "hooks": {
-      "post-merge": "yarnhook",
-      "post-checkout": "yarnhook",
-      "post-rewrite": "yarnhook",
-      "commit-msg": "commitlint -e $GIT_PARAMS",
-      "pre-commit": "lint-staged",
-      "pre-push": "yarn test:changes"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cozy/cozy-banks.git"


### PR DESCRIPTION
To speed up local git manipulations. We still have the CI as safety net