### PR TITLE
chore: Remove post/pre push/commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,11 +75,6 @@
   },
   "husky": {
     "hooks": {
-      "post-merge": "yarnhook",
-      "post-checkout": "yarnhook",
-      "post-rewrite": "yarnhook",
-      "commit-msg": "commitlint -e $GIT_PARAMS",
-      "pre-commit": "lint-staged",
       "pre-push": "yarn test:changes"
     }
   },


### PR DESCRIPTION
To speed up local git manipulations 🙏 . We still have the CI as safety net