### PR TITLE
fix: Send APK message to mattermost

### DIFF
--- a/scripts/ci/mattermost_comment.sh
+++ b/scripts/ci/mattermost_comment.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This script is used to comment on mattermost
 
-set -e
+set -eux
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
   FROM="pull request [#$TRAVIS_PULL_REQUEST](https://github.com/$TRAVIS_PULL_REQUEST_SLUG/pull/$TRAVIS_PULL_REQUEST)"
@@ -12,4 +12,4 @@ else
 fi
 
 export MATTERMOST_CHANNEL="gangsters"
-curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"$MATTERMOST_CHANNEL\"}" $MATTERMOST_HOOK_URL
+curl -f -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"$MATTERMOST_CHANNEL\"}" $MATTERMOST_HOOK_URL

--- a/scripts/ci/mattermost_comment.sh
+++ b/scripts/ci/mattermost_comment.sh
@@ -11,5 +11,5 @@ else
   FROM="master"
 fi
 
-MATTERMOST_CHANNEL=${MATTERMOST_CHANNEL:-"gangsters"}
+export MATTERMOST_CHANNEL="gangsters"
 curl -i -X POST -H "Content-Type: application/json" -d "{\"text\": \"🎁 [Click here]($APK_URL) to download the latest Android APK from $FROM\", \"icon_url\": \"https://travis-ci.com/images/logos/TravisCI-Mascot-1.png\", \"username\": \"Travis\", \"channel\": \"$MATTERMOST_CHANNEL\"}" $MATTERMOST_HOOK_URL


### PR DESCRIPTION
MATTERMOST_CHANNEL is a JSON dump like : `{"dev":"Gangsters", "beta": "gangsters,publication", "stable": "gangsters,publication"}`
that allows to target multiple channels following the type of release.

Since MATTERMOST_CHANNEL contains a config object with channels for
each release mode (dev, beta, stable), we cannot use it here.

Since we want the message for the APK to be sent directly to the gangsters
channel, we can hardcode it.