### PR TITLE
fix: Wrong order of transactions for credit card accounts

### DIFF
--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -161,10 +161,7 @@ const TransactionRowDesktop = ({
               />
             </Img>
             <Bd className="u-pl-1">
-              <ListItemText
-                className="u-pv-half"
-                onClick={canEditTransaction && handleClickCategory}
-              >
+              <ListItemText className="u-pv-half">
                 <Typography variant="body1">{getLabel(transaction)}</Typography>
                 {!filteringOnAccount && <AccountCaption account={account} />}
                 {applicationDate ? (

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.spec.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.spec.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import AppLike from 'test/AppLike'
+import fixtures from 'test/fixtures'
+import TransactionRowDesktop from './TransactionRowDesktop'
+
+describe('TransactionRowDesktop', () => {
+  const setup = () => {
+    const transaction = fixtures['io.cozy.bank.operations'][0]
+    const root = render(
+      <AppLike>
+        <TransactionRowDesktop transaction={transaction} />
+      </AppLike>
+    )
+    return { root }
+  }
+
+  it('should render', () => {
+    const { root } = setup()
+    expect(root.getByText('25 Aug 2017')).toBeTruthy()
+    expect(root.getByText('Remboursement Pret Lcl')).toBeTruthy()
+  })
+})

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -216,7 +216,6 @@ export class TransactionsDumb extends React.Component {
       showTriggerErrors,
       filteringOnAccount,
       className,
-      transactions,
       TransactionSections,
       onReachTop,
       onReachBottom,
@@ -225,7 +224,7 @@ export class TransactionsDumb extends React.Component {
 
     return (
       <>
-        <SelectionBar transactions={transactions} />
+        <SelectionBar transactions={this.transactions} />
         <InfiniteScroll
           manual={false}
           canLoadAtTop={false}
@@ -239,7 +238,7 @@ export class TransactionsDumb extends React.Component {
           <TransactionSections
             filteringOnAccount={filteringOnAccount}
             className={className}
-            transactions={transactions}
+            transactions={this.transactions}
             onRowRef={this.handleRefRow}
           />
         </InfiniteScroll>

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -11,7 +11,6 @@ import cx from 'classnames'
 
 import { isIOSApp } from 'cozy-device-helper'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -259,10 +258,14 @@ TransactionsDumb.defaultProps = {
   TransactionSections
 }
 
-const Transactions = props => {
+export const TransactionList = props => {
   const { emptySelection } = useSelectionContext()
-
-  return <TransactionsDumb emptySelection={emptySelection} {...props} />
+  const breakpoints = useBreakpoints()
+  return (
+    <TransactionsDumb
+      emptySelection={emptySelection}
+      breakpoints={breakpoints}
+      {...props}
+    />
+  )
 }
-
-export const TransactionList = withBreakpoints()(Transactions)

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -33,12 +33,12 @@ jest.mock('cozy-ui/transpiled/react/Alerter', () => ({
   success: jest.fn()
 }))
 
+const mockTransactions = data['io.cozy.bank.operations'].map((x, i) => ({
+  _id: `transaction-id-${i++}`,
+  ...x
+}))
+
 describe('Transactions', () => {
-  let i = 0
-  const mockTransactions = data['io.cozy.bank.operations'].map(x => ({
-    _id: `transaction-id-${i++}`,
-    ...x
-  }))
   const setup = ({ showTriggerErrors }) => {
     const Wrapper = ({ transactions = mockTransactions }) => {
       return (
@@ -97,12 +97,6 @@ describe('SelectionBar', () => {
   beforeEach(() => {
     Alerter.success.mockReset()
   })
-
-  let i = 0
-  const mockTransactions = data['io.cozy.bank.operations'].map(x => ({
-    _id: `transaction-id-${i++}`,
-    ...x
-  }))
 
   // Mock tappable so that key down fires its onPress event
   Tappable.mockImplementation(({ children, onPress, onTap }) => {

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -33,6 +33,14 @@ jest.mock('cozy-ui/transpiled/react/Alerter', () => ({
   success: jest.fn()
 }))
 
+// Mock useVisible so that intersection observer is not used
+// in test, useVisible is static here
+jest.mock('hooks/useVisible', () => {
+  return initialState => {
+    return [null, initialState]
+  }
+})
+
 const mockTransactions = data['io.cozy.bank.operations'].map((x, i) => ({
   _id: `transaction-id-${i++}`,
   ...x
@@ -130,30 +138,30 @@ describe('SelectionBar', () => {
     const { root, client } = setup({ isDesktop: false })
     const { getByText, getByTestId, queryByTestId } = root
 
-    fireEvent.keyDown(getByText('Remboursement Pret Lcl'))
+    fireEvent.keyDown(getByText('Maintenance'))
     expect(queryByTestId('selectionBar')).toBeTruthy()
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '1 item selected'
     )
 
     // should remove the selection bar
-    fireEvent.click(getByText('Remboursement Pret Lcl'))
+    fireEvent.click(getByText('Maintenance'))
     expect(queryByTestId('selectionBar')).toBeFalsy()
 
     // should show 2 transactions selected
-    fireEvent.keyDown(getByText('Remboursement Pret Lcl'))
+    fireEvent.keyDown(getByText('Maintenance'))
     expect(queryByTestId('selectionBar')).toBeTruthy()
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '2 items selected'
     )
 
     // should unselected transaction
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '1 item selected'
     )
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '2 items selected'
     )
@@ -175,30 +183,30 @@ describe('SelectionBar', () => {
     const { root, client } = setup({ isDesktop: true })
     const { getByText, getByTestId, queryByTestId } = root
 
-    fireEvent.click(getByTestId('TransactionRow-checkbox-reimbursement'))
+    fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
     expect(queryByTestId('selectionBar')).toBeTruthy()
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '1 item selected'
     )
 
     // should remove the selection bar
-    fireEvent.click(getByText('Remboursement Pret Lcl'))
+    fireEvent.click(getByText('Maintenance'))
     expect(queryByTestId('selectionBar')).toBeFalsy()
 
     // should show 2 transactions selected
-    fireEvent.click(getByTestId('TransactionRow-checkbox-reimbursement'))
+    fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
     expect(queryByTestId('selectionBar')).toBeTruthy()
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '2 items selected'
     )
 
     // should unselected transaction
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '1 item selected'
     )
-    fireEvent.click(getByText('Edf Particuliers'))
+    fireEvent.click(getByText('Franprix St Lazare Pr'))
     expect(queryByTestId('selectionBar-count').textContent).toBe(
       '2 items selected'
     )

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -3,14 +3,15 @@
 import React from 'react'
 import Tappable from 'react-tappable/lib/Tappable'
 import { render, fireEvent, wait } from '@testing-library/react'
-import flag from 'cozy-flags'
+import { within } from '@testing-library/dom'
 
+import flag from 'cozy-flags'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
+import { createMockClient } from 'cozy-client/dist/mock'
 
 import data from 'test/fixtures'
 import AppLike from 'test/AppLike'
-import { createMockClient } from 'cozy-client/dist/mock'
 
 import TransactionPageErrors from 'ducks/transactions/TransactionPageErrors'
 import { TransactionsDumb, sortByDate } from './Transactions'
@@ -47,7 +48,7 @@ const mockTransactions = data['io.cozy.bank.operations'].map((x, i) => ({
 }))
 
 describe('Transactions', () => {
-  const setup = ({ showTriggerErrors }) => {
+  const setup = ({ showTriggerErrors, renderFn }) => {
     const Wrapper = ({ transactions = mockTransactions }) => {
       return (
         <AppLike>
@@ -60,27 +61,30 @@ describe('Transactions', () => {
         </AppLike>
       )
     }
-    const root = mount(<Wrapper />)
+    const root = renderFn(<Wrapper />)
 
     return { root, transactions: mockTransactions }
   }
 
   describe('when showTriggerErrors is false', () => {
     it('should not show transaction errors', () => {
-      const { root } = setup({ showTriggerErrors: false })
+      const { root } = setup({ showTriggerErrors: false, renderFn: mount })
       expect(root.find(TransactionPageErrors).length).toBe(0)
     })
   })
 
   describe('when showTriggerErrors is true', () => {
     it('should show transaction errors', () => {
-      const { root } = setup({ showTriggerErrors: true })
+      const { root } = setup({ showTriggerErrors: true, renderFn: mount })
       expect(root.find(TransactionPageErrors).length).toBe(1)
     })
   })
 
   it('should sort transactions from props on mount and on update', () => {
-    const { root, transactions } = setup({ isOnSubcategory: false })
+    const { root, transactions } = setup({
+      isOnSubcategory: false,
+      renderFn: mount
+    })
 
     const instance = root.find(TransactionsDumb).instance()
     expect(instance.transactions).toEqual(sortByDate(transactions))
@@ -93,7 +97,7 @@ describe('Transactions', () => {
   })
 })
 
-describe('SelectionBar', () => {
+describe('Interactions', () => {
   beforeAll(() => {
     flag('banks.selectionMode.enabled', true)
   })
@@ -115,16 +119,28 @@ describe('SelectionBar', () => {
     )
   })
 
-  const setup = ({ isDesktop = false } = {}) => {
-    const client = createMockClient({})
+  const setup = ({
+    isDesktop = false,
+    transactions = mockTransactions
+  } = {}) => {
+    const client = createMockClient({
+      queries: {
+        // The transaction modal gets its transactions through cozy-client
+        // store. This is why the transactions should be in there.
+        fakeTransactions: {
+          data: transactions,
+          doctype: 'io.cozy.bank.operations'
+        }
+      }
+    })
     client.save.mockImplementation(doc => ({ data: doc }))
     useBreakpoints.mockReturnValue({ isDesktop })
-
+    const router = { location: 'fakeLocation' }
     const root = render(
-      <AppLike client={client}>
+      <AppLike client={client} router={router}>
         <TransactionsDumb
           breakpoints={{ isDesktop: false }}
-          transactions={mockTransactions}
+          transactions={transactions}
           showTriggerErrors={false}
           emptySelection={() => null}
         />
@@ -134,93 +150,110 @@ describe('SelectionBar', () => {
     return { root, client }
   }
 
-  it('should show selection bar and open category modal', async () => {
-    const { root, client } = setup({ isDesktop: false })
-    const { getByText, getByTestId, queryByTestId } = root
-
-    fireEvent.keyDown(getByText('Maintenance'))
-    expect(queryByTestId('selectionBar')).toBeTruthy()
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '1 item selected'
-    )
-
-    // should remove the selection bar
-    fireEvent.click(getByText('Maintenance'))
-    expect(queryByTestId('selectionBar')).toBeFalsy()
-
-    // should show 2 transactions selected
-    fireEvent.keyDown(getByText('Maintenance'))
-    expect(queryByTestId('selectionBar')).toBeTruthy()
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '2 items selected'
-    )
-
-    // should unselected transaction
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '1 item selected'
-    )
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '2 items selected'
-    )
-
-    // selecting a category
-    fireEvent.click(getByTestId('selectionBar-action-categorize'))
-    fireEvent.click(getByText('Everyday life'))
-    fireEvent.click(getByText('Supermarket'))
-
-    // should remove the selection bar and show a success alert
-    expect(queryByTestId('selectionBar')).toBeFalsy()
-    await wait(() => expect(client.save).toHaveBeenCalledTimes(2))
-    expect(Alerter.success).toHaveBeenCalledWith(
-      '2 operations have been recategorized'
-    )
+  describe('Transaction modal', () => {
+    it('should show transaction modal on click on label', async () => {
+      const { root } = setup({
+        isDesktop: true,
+        transactions: mockTransactions.slice(0, 1)
+      })
+      const label = root.getByText('Remboursement Pret Lcl')
+      expect(root.queryByRole('dialog')).toBeFalsy()
+      fireEvent.click(label)
+      const dialog = root.getByRole('dialog')
+      expect(dialog).toBeTruthy()
+      expect(within(dialog).getByText('Assigned to Aug 2017'))
+    })
   })
 
-  it('should show selection bar and open category modal on desktop', async () => {
-    const { root, client } = setup({ isDesktop: true })
-    const { getByText, getByTestId, queryByTestId } = root
+  describe('SelectionBar', () => {
+    it('should show selection bar and open category modal', async () => {
+      const { root, client } = setup({ isDesktop: false })
+      const { getByText, getByTestId, queryByTestId } = root
 
-    fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
-    expect(queryByTestId('selectionBar')).toBeTruthy()
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '1 item selected'
-    )
+      fireEvent.keyDown(getByText('Maintenance'))
+      expect(queryByTestId('selectionBar')).toBeTruthy()
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '1 item selected'
+      )
 
-    // should remove the selection bar
-    fireEvent.click(getByText('Maintenance'))
-    expect(queryByTestId('selectionBar')).toBeFalsy()
+      // should remove the selection bar
+      fireEvent.click(getByText('Maintenance'))
+      expect(queryByTestId('selectionBar')).toBeFalsy()
 
-    // should show 2 transactions selected
-    fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
-    expect(queryByTestId('selectionBar')).toBeTruthy()
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '2 items selected'
-    )
+      // should show 2 transactions selected
+      fireEvent.keyDown(getByText('Maintenance'))
+      expect(queryByTestId('selectionBar')).toBeTruthy()
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '2 items selected'
+      )
 
-    // should unselected transaction
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '1 item selected'
-    )
-    fireEvent.click(getByText('Franprix St Lazare Pr'))
-    expect(queryByTestId('selectionBar-count').textContent).toBe(
-      '2 items selected'
-    )
+      // should unselected transaction
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '1 item selected'
+      )
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '2 items selected'
+      )
 
-    // selecting a category
-    fireEvent.click(getByText('Categorize'))
-    fireEvent.click(getByText('Everyday life'))
-    fireEvent.click(getByText('Supermarket'))
+      // selecting a category
+      fireEvent.click(getByTestId('selectionBar-action-categorize'))
+      fireEvent.click(getByText('Everyday life'))
+      fireEvent.click(getByText('Supermarket'))
 
-    // should remove the selection bar and show a success alert
-    expect(queryByTestId('selectionBar')).toBeFalsy()
-    await wait(() => expect(client.save).toHaveBeenCalledTimes(2))
-    expect(Alerter.success).toHaveBeenCalledWith(
-      '2 operations have been recategorized'
-    )
+      // should remove the selection bar and show a success alert
+      expect(queryByTestId('selectionBar')).toBeFalsy()
+      await wait(() => expect(client.save).toHaveBeenCalledTimes(2))
+      expect(Alerter.success).toHaveBeenCalledWith(
+        '2 operations have been recategorized'
+      )
+    })
+
+    it('should show selection bar and open category modal on desktop', async () => {
+      const { root, client } = setup({ isDesktop: true })
+      const { getByText, getByTestId, queryByTestId } = root
+
+      fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
+      expect(queryByTestId('selectionBar')).toBeTruthy()
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '1 item selected'
+      )
+
+      // should remove the selection bar
+      fireEvent.click(getByText('Maintenance'))
+      expect(queryByTestId('selectionBar')).toBeFalsy()
+
+      // should show 2 transactions selected
+      fireEvent.click(getByTestId('TransactionRow-checkbox-maintenance'))
+      expect(queryByTestId('selectionBar')).toBeTruthy()
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '2 items selected'
+      )
+
+      // should unselected transaction
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '1 item selected'
+      )
+      fireEvent.click(getByText('Franprix St Lazare Pr'))
+      expect(queryByTestId('selectionBar-count').textContent).toBe(
+        '2 items selected'
+      )
+
+      // selecting a category
+      fireEvent.click(getByText('Categorize'))
+      fireEvent.click(getByText('Everyday life'))
+      fireEvent.click(getByText('Supermarket'))
+
+      // should remove the selection bar and show a success alert
+      expect(queryByTestId('selectionBar')).toBeFalsy()
+      await wait(() => expect(client.save).toHaveBeenCalledTimes(2))
+      expect(Alerter.success).toHaveBeenCalledWith(
+        '2 operations have been recategorized'
+      )
+    })
   })
 })

--- a/test/fixtures/unit-tests.json
+++ b/test/fixtures/unit-tests.json
@@ -1426,7 +1426,8 @@
       "manualCategoryId": "400420",
       "currency": "€",
       "date": "2018-06-21T00:00:00Z",
-      "label": "FRANPRIX ST LAZARE PR"
+      "label": "FRANPRIX ST LAZARE PR",
+      "_id": "franprix-st-lazare"
     },
     {
       "_id": "maintenance",


### PR DESCRIPTION
Transactions should be re-sorted after coming from the stack since we
display the realisationDate for credit cards. If transactions are sorted
"only" by date, the order of displayed transactions seems wrong since the
date that the user sees is the realisationDate. For delayed debit card
accounts, the realisation date can be at the beginning of the month whereas
the date is at the end of the month.

After the switch to incremental queries, the wrong transactions were used,
here we switch to using transactions from before, transactions that are
sorted by displayed date.

The test has to be updated to account for that since now even in the UI 
test, transactions are sorted by displayed date. Since only the top 
transactions are really displayed, we could not click on transactions that
were at the bottom.