### PR TITLE
fix: Delayed credit card transactions weren't displayed in analysis page

### DIFF
--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -1,16 +1,8 @@
 import React, { Component, Fragment, useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-
-import startOfMonth from 'date-fns/start_of_month'
-import endOfMonth from 'date-fns/end_of_month'
-import startOfYear from 'date-fns/start_of_year'
-import endOfYear from 'date-fns/end_of_year'
-import format from 'date-fns/format'
-
 import includes from 'lodash/includes'
 import maxBy from 'lodash/maxBy'
 import some from 'lodash/some'
-import merge from 'lodash/merge'
 import sortBy from 'lodash/sortBy'
 
 import getCategoryId from 'ducks/transactions/getCategoryId'
@@ -20,8 +12,7 @@ import {
   useClient,
   isQueryLoading,
   hasQueryBeenLoaded,
-  useQuery,
-  Q
+  useQuery
 } from 'cozy-client'
 
 import { useParams } from 'components/RouterContext'
@@ -37,7 +28,10 @@ import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 import Categories from 'ducks/categories/Categories'
 import { accountsConn, settingsConn, groupsConn } from 'doctypes'
 
-import { makeFilteredTransactionsConn } from 'ducks/transactions/queries'
+import {
+  makeFilteredTransactionsConn,
+  addPeriodToConn
+} from 'ducks/transactions/queries'
 import BarTheme from 'ducks/bar/BarTheme'
 import { computeCategoriesData } from 'ducks/categories/selectors'
 import { getDate } from 'ducks/transactions/helpers'
@@ -240,39 +234,6 @@ const autoUpdateOptions = {
   update: true
 }
 
-const addPeriodToConn = (baseConn, period) => {
-  const { query: mkBaseQuery, as: baseAs, ...rest } = baseConn
-  const d = new Date(period)
-  const startDate = period.length === 7 ? startOfMonth(d) : startOfYear(d)
-  const endDate = period.length === 7 ? endOfMonth(d) : endOfYear(d)
-  const baseQuery = mkBaseQuery()
-  const query = Q(baseQuery.doctype)
-    .where(
-      merge(
-        {
-          date: {
-            $lte: format(endDate, 'YYYY-MM-DD'),
-            $gte: format(startDate, 'YYYY-MM-DD')
-          }
-        },
-        baseQuery.selector
-      )
-    )
-    .indexFields(['date', 'account'])
-    .sortBy([{ date: 'desc' }, { account: 'desc' }])
-    .limitBy(500)
-  const as = `${baseAs}-${format(startDate, 'YYYY-MM')}-${format(
-    endDate,
-    'YYYY-MM'
-  )}`
-  return {
-    query,
-    as,
-    autoUpdate: autoUpdateOptions,
-    ...rest
-  }
-}
-
 const setAutoUpdate = conn => ({ ...conn, autoUpdate: autoUpdateOptions })
 
 const enhance = Component => props => {
@@ -293,7 +254,7 @@ const enhance = Component => props => {
   })
   const conn = useMemo(() => {
     return period
-      ? addPeriodToConn(initialConn, period)
+      ? setAutoUpdate(addPeriodToConn(initialConn, period))
       : setAutoUpdate(initialConn)
   }, [initialConn, period])
   const transactions = useFullyLoadedQuery(conn.query, conn)

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -139,8 +139,8 @@ export const addPeriodToConn = (baseConn, period) => {
       merge(
         {
           date: {
-            $lte: format(endDate, 'YYYY-MM-DD'),
-            $gte: format(startDate, 'YYYY-MM-DD')
+            $lte: format(endDate, 'YYYY-MM-DD[T]HH:mm'),
+            $gte: format(startDate, 'YYYY-MM-DD[T]HH:mm')
           }
         },
         baseQuery.selector

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -1,6 +1,11 @@
 import { Q } from 'cozy-client'
 import { GROUP_DOCTYPE, ACCOUNT_DOCTYPE, transactionsConn } from 'doctypes'
+import startOfMonth from 'date-fns/start_of_month'
 import endOfMonth from 'date-fns/end_of_month'
+import startOfYear from 'date-fns/start_of_year'
+import endOfYear from 'date-fns/end_of_year'
+import format from 'date-fns/format'
+import merge from 'lodash/merge'
 
 /**
  * Outputs a connection to fetch transactions
@@ -102,13 +107,52 @@ export const makeEarliestLatestQueries = baseQuery => {
   return [earliestQuery, latestQuery]
 }
 
-/** Add a month selector to a connection */
+/**
+ * Add a month selector to a connection, month is only a upper limit
+ * to allow for infinite scrolling through fetchMore
+ */
 export const addMonthToConn = (baseConn, month) => {
   const { query: baseQuery, as: baseAs, ...rest } = baseConn
   const thresholdDate = endOfMonth(new Date(month)).toISOString()
   const q = baseQuery()
   const query = q.where({ date: { $lt: thresholdDate }, ...q.selector })
   const as = `${baseAs}-${month}`
+  return {
+    query,
+    as,
+    ...rest
+  }
+}
+
+/**
+ * Makes a new conn, adding a date filter on the query selector
+ * so that only transactions for a given month are fetched.
+ */
+export const addPeriodToConn = (baseConn, period) => {
+  const { query: mkBaseQuery, as: baseAs, ...rest } = baseConn
+  const d = new Date(period)
+  const startDate = period.length === 7 ? startOfMonth(d) : startOfYear(d)
+  const endDate = period.length === 7 ? endOfMonth(d) : endOfYear(d)
+  const baseQuery = mkBaseQuery()
+  const query = Q(baseQuery.doctype)
+    .where(
+      merge(
+        {
+          date: {
+            $lte: format(endDate, 'YYYY-MM-DD'),
+            $gte: format(startDate, 'YYYY-MM-DD')
+          }
+        },
+        baseQuery.selector
+      )
+    )
+    .indexFields(['date', 'account'])
+    .sortBy([{ date: 'desc' }, { account: 'desc' }])
+    .limitBy(500)
+  const as = `${baseAs}-${format(startDate, 'YYYY-MM')}-${format(
+    endDate,
+    'YYYY-MM'
+  )}`
   return {
     query,
     as,

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -2,7 +2,8 @@ import { Q } from 'cozy-client'
 import {
   makeFilteredTransactionsConn,
   makeEarliestLatestQueries,
-  addMonthToConn
+  addMonthToConn,
+  addPeriodToConn
 } from './queries'
 
 describe('makeFilteredTransactionsConn', () => {
@@ -193,6 +194,43 @@ describe('addMonthToConn', () => {
             // Use stringContaining not to have difference of timezones
             // between CI and local development
             $lt: expect.stringContaining('2021-07-31T')
+          }
+        }
+      })
+    )
+  })
+})
+
+describe('addPeriodToConn', () => {
+  it('should keep the existing selector', () => {
+    const conn1 = makeFilteredTransactionsConn({
+      groups: {
+        lastUpdate: Date.now(),
+        data: [
+          {
+            _id: 'g1',
+            accounts: {
+              raw: ['a1', 'a2', 'a3']
+            }
+          }
+        ]
+      },
+      accounts: {
+        lastUpdate: Date.now()
+      },
+      filteringDoc: {
+        _id: 'g1',
+        _type: 'io.cozy.bank.groups'
+      }
+    })
+    const conn2 = addPeriodToConn(conn1, '2021-07')
+    expect(conn2.query).toEqual(
+      expect.objectContaining({
+        selector: {
+          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }],
+          date: {
+            $gte: '2021-07-01T00:00',
+            $lte: '2021-07-31T23:59'
           }
         }
       })


### PR DESCRIPTION
Delayed credit card transactions happen at the very end of the month. Here
the selector, having only day and not the hour, would not pick transactions
of the last day (because 2021-01-31 < 2021-01-31T12:00, the first date
being the upper bound of the query, and the second date the date of the
transaction), and thus no transaction were visible in the categories page.

- Extracted the code for it to be more testable
- Added the hours for the query to fetch correctly transactions for the
 last day