### PR TITLE
Fix transaction select dates for accounts with only 1 transaction

### DIFF
--- a/src/components/SelectDates/SelectDates.spec.jsx
+++ b/src/components/SelectDates/SelectDates.spec.jsx
@@ -91,4 +91,24 @@ describe('SelectDates', () => {
     // Already at latest, since onChange does nothing
     expect(onChange).not.toHaveBeenCalled()
   })
+
+  it('should behave correctly with undefined value', async () => {
+    const onChange = jest.fn()
+    const root = render(
+      <AppLike>
+        <SelectDates
+          value={undefined}
+          options={[{ yearMonth: '2017-10' }]}
+          onChange={onChange}
+        />
+      </AppLike>
+    )
+
+    // When value is undefined, the first option is displayed
+    expect(
+      Array.from(root.container.querySelectorAll('.cz__single-value')).map(
+        n => n.textContent
+      )
+    ).toEqual(['2017', 'October'])
+  })
 })

--- a/src/components/SelectDates/utils.js
+++ b/src/components/SelectDates/utils.js
@@ -1,5 +1,6 @@
 import startOfMonth from 'date-fns/start_of_month'
 import addMonths from 'date-fns/add_months'
+import isSameDay from 'date-fns/is_same_day'
 
 const rangedSome = (arr, predicate, start, end) => {
   start = Math.max(start, 0)
@@ -19,6 +20,9 @@ const rangedSome = (arr, predicate, start, end) => {
 export const monthRange = (earliestDate, latestDate, step = 1) => {
   const res = []
   let cur = earliestDate
+  if (isSameDay(earliestDate, latestDate)) {
+    return [earliestDate]
+  }
   while (cur < latestDate) {
     res.push(cur)
     const sm = startOfMonth(cur)

--- a/src/components/SelectDates/utils.spec.js
+++ b/src/components/SelectDates/utils.spec.js
@@ -22,4 +22,8 @@ describe('monthRange', () => {
     expect(monthRange(new Date(2019, 6), new Date(2019, 7)).length).toBe(1)
     expect(monthRange(new Date(2019, 6), new Date(2020, 0)).length).toBe(6)
   })
+
+  it('should work if earliest date and latest date are the same ', () => {
+    expect(monthRange(new Date(2019, 6), new Date(2019, 6)).length).toBe(1)
+  })
 })

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -132,6 +132,16 @@ const CategoriesHeader = props => {
     [dispatch]
   )
 
+  // When date selector loads the latest and earliest transaction,
+  // sets the period to the latest month
+  const onExtentLoad = useCallback(
+    extent => {
+      const latestPeriod = extent[1]
+      dispatch(addFilterByPeriod(latestPeriod))
+    },
+    [dispatch]
+  )
+
   const incomeToggle = showIncomeToggle ? (
     <IncomeToggle withIncome={withIncome} onToggle={onWithIncomeToggle} />
   ) : null
@@ -158,8 +168,9 @@ const CategoriesHeader = props => {
 
   const dateSelector = (
     <TransactionSelectDates
-      value={period}
       onChange={onChangePeriod}
+      onExtentLoad={onExtentLoad}
+      value={period}
       showFullYear
       className={classes.selectDates}
     />

--- a/src/hooks/useFullyLoadedQuery.jsx
+++ b/src/hooks/useFullyLoadedQuery.jsx
@@ -1,32 +1,19 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect } from 'react'
 import { useQuery } from 'cozy-client'
-
-const useIsMounted = () => {
-  const mounted = useRef()
-  useEffect(() => {
-    mounted.current = true
-    return () => {
-      mounted.current = false
-    }
-  }, [])
-  return mounted
-}
+import useSafeState from './useSafeState'
 
 /**
  * Will run fetchMore on the query until the query is fully loaded
  */
 const useFullyLoadedQuery = (query, options) => {
   const res = useQuery(query, options)
-  const [fetching, setFetching] = useState(false)
-  const mounted = useIsMounted()
+  const [fetching, setFetching] = useSafeState(false)
   useEffect(() => {
     const checkToFetchMore = async () => {
       if (res.fetchStatus === 'loaded' && res.hasMore && !fetching) {
         setFetching(true)
         await res.fetchMore()
-        if (mounted.current) {
-          setFetching(false)
-        }
+        setFetching(false)
       }
     }
     checkToFetchMore()

--- a/src/hooks/useIsMounted.jsx
+++ b/src/hooks/useIsMounted.jsx
@@ -1,0 +1,14 @@
+import { useRef, useEffect } from 'react'
+
+const useIsMounted = () => {
+  const mounted = useRef()
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+  return mounted
+}
+
+export default useIsMounted

--- a/src/hooks/useSafeState.jsx
+++ b/src/hooks/useSafeState.jsx
@@ -1,0 +1,18 @@
+import { useState, useCallback } from 'react'
+import useIsMounted from './useIsMounted'
+
+const useSafeState = initialState => {
+  const mounted = useIsMounted()
+  const [state, setState] = useState(initialState)
+  const setSafeState = useCallback(
+    newState => {
+      if (mounted.current) {
+        setState(newState)
+      }
+    },
+    [] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+  return [state, setSafeState]
+}
+
+export default useSafeState


### PR DESCRIPTION
Symptom: On the categories page, if an account has only 1
transaction, the select date is broken, and the page does not
show anything.

2 problems are fixed here

1. Month range did not behave correctly and would not return any
  item if both min and max were the same. This meant that the
  select date did not have any option when an account had only
  1 transaction and was thus unusable

2. After loading the "extent" (meaning the earliest and latest
   transaction for the current filter), the transaction select
   date was not updated with the current period; the options
   are there so it is possible to wake up the select date by
   opening it and selecting another option, but before that,
   "All year" is shown in the month part of the select, and
   the categories page is on the current month (right now)
   which might not correspond to the latest month available
   for the particular account. To remedy the problem, the
   select dates pings its parent when it receives the extent
   so that the parent can set its current period to the
   latest month. This seems a bit far fetched and I do not
   like the children to parent communication that is happening
   here; I wonder if the extent should not be calculated by
   the parent of the select dates so that the flow of data
   remains in one direction, parent to child.

There are surely some tests to write, particularly when an account does not have any transaction.