### PR TITLE
Selection and mass categorisation update

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,6 @@
     "react-router": "3.2.4",
     "react-side-effect": "2.1.0",
     "react-swipeable-views": "0.13.9",
-    "react-tappable": "1.0.4",
     "redux": "4",
     "redux-logger": "3.0.6",
     "redux-raven-middleware": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "cozy-realtime": "3.11.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "23.13.1",
-    "cozy-ui": "51.0.2",
+    "cozy-ui": "51.1.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -31,6 +31,11 @@ const SelectionProvider = ({ children }) => {
 
   const emptySelection = useCallback(() => setSelected([]), [setSelected])
 
+  const emptyAndDeactivateSelection = useCallback(() => {
+    emptySelection()
+    setIsSelectionModeActive(false)
+  }, [emptySelection])
+
   const fillSelectionWith = useCallback(arr => setSelected(arr), [setSelected])
 
   const toggleSelection = useCallback(
@@ -65,6 +70,7 @@ const SelectionProvider = ({ children }) => {
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
+      emptyAndDeactivateSelection,
       toggleSelection,
       fillSelectionWith
     }),
@@ -74,6 +80,7 @@ const SelectionProvider = ({ children }) => {
       isSelectionModeEnabled,
       isSelected,
       emptySelection,
+      emptyAndDeactivateSelection,
       toggleSelection,
       fillSelectionWith
     ]

--- a/src/ducks/context/SelectionContext.jsx
+++ b/src/ducks/context/SelectionContext.jsx
@@ -6,6 +6,8 @@ import React, {
   useMemo
 } from 'react'
 
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
 import flag from 'cozy-flags'
 
 export const SelectionContext = createContext()
@@ -19,6 +21,7 @@ export const useSelectionContext = () => {
 // imagine that there are quite few elements.
 // But an improvement would be to store only the ids.
 const SelectionProvider = ({ children }) => {
+  const { isDesktop } = useBreakpoints()
   const [selected, setSelected] = useState([])
   const [isSelectionModeActive, setIsSelectionModeActive] = useState(false)
 
@@ -44,14 +47,14 @@ const SelectionProvider = ({ children }) => {
           ? selected.filter(elem => elem !== item)
           : [...selected, item]
 
-        if (found && selected.length === 1) {
+        if (isDesktop && found && selected.length === 1) {
           setIsSelectionModeActive(false)
         }
 
         return nextSelected
       })
     },
-    [isSelectionModeActive, isSelectionModeEnabled]
+    [isDesktop, isSelectionModeActive, isSelectionModeEnabled]
   )
 
   const value = useMemo(

--- a/src/ducks/selection/SelectionBar.jsx
+++ b/src/ducks/selection/SelectionBar.jsx
@@ -14,15 +14,15 @@ const SelectionBar = ({ transactions }) => {
     isSelectionModeEnabled,
     isSelectionModeActive,
     selected,
-    emptySelection,
+    emptyAndDeactivateSelection,
     fillSelectionWith
   } = useSelectionContext()
 
   const { t } = useI18n()
 
   const beforeUpdate = useCallback(() => {
-    emptySelection()
-  }, [emptySelection])
+    emptyAndDeactivateSelection()
+  }, [emptyAndDeactivateSelection])
 
   const afterUpdates = () => {
     Alerter.success(
@@ -63,7 +63,7 @@ const SelectionBar = ({ transactions }) => {
         <UISelectionBar
           actions={actions}
           selected={selected}
-          hideSelectionBar={emptySelection}
+          hideSelectionBar={emptyAndDeactivateSelection}
         />
       )}
       {transactionCategoryModal}

--- a/src/ducks/selection/SelectionBar.jsx
+++ b/src/ducks/selection/SelectionBar.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 
 import UISelectionBar from 'cozy-ui/transpiled/react/SelectionBar'
@@ -6,7 +6,7 @@ import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import { useSelectionContext } from 'ducks/context/SelectionContext'
-import { makeSelectionBarActions } from 'ducks/selection/helpers'
+import { useSelectionBarActions } from 'ducks/selection/helpers'
 import { useTransactionCategoryModal } from 'ducks/transactions/TransactionRow'
 
 const SelectionBar = ({ transactions }) => {
@@ -14,8 +14,7 @@ const SelectionBar = ({ transactions }) => {
     isSelectionModeEnabled,
     isSelectionModeActive,
     selected,
-    emptyAndDeactivateSelection,
-    fillSelectionWith
+    emptyAndDeactivateSelection
   } = useSelectionContext()
 
   const { t } = useI18n()
@@ -42,19 +41,10 @@ const SelectionBar = ({ transactions }) => {
     afterUpdates
   })
 
-  const fillSelection = useCallback(() => fillSelectionWith(transactions), [
-    fillSelectionWith,
-    transactions
-  ])
-
-  const actions = useMemo(
-    () =>
-      makeSelectionBarActions({
-        showTransactionCategoryModal,
-        fillSelection
-      }),
-    [fillSelection, showTransactionCategoryModal]
-  )
+  const actions = useSelectionBarActions({
+    items: transactions,
+    showTransactionCategoryModal
+  })
 
   if (!isSelectionModeEnabled) return null
   return (

--- a/src/ducks/selection/helpers.js
+++ b/src/ducks/selection/helpers.js
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import GraphCircleIcon from 'cozy-ui/transpiled/react/Icons/GraphCircle'
 import SelectAllIcon from 'cozy-ui/transpiled/react/Icons/SelectAll'
 
@@ -9,12 +10,21 @@ export const useSelectionBarActions = ({
   items,
   showTransactionCategoryModal
 }) => {
-  const { fillSelectionWith } = useSelectionContext()
+  const { isDesktop } = useBreakpoints()
+  const {
+    emptySelection,
+    emptyAndDeactivateSelection,
+    fillSelectionWith
+  } = useSelectionContext()
 
   const fillSelection = useCallback(() => fillSelectionWith(items), [
     fillSelectionWith,
     items
   ])
+
+  const unSelectAllAction = useCallback(() => {
+    isDesktop ? emptyAndDeactivateSelection() : emptySelection()
+  }, [emptyAndDeactivateSelection, emptySelection, isDesktop])
 
   const actions = useMemo(
     () => ({
@@ -25,11 +35,21 @@ export const useSelectionBarActions = ({
       },
       selectAll: {
         action: () => fillSelection(),
-        displayCondition: selected => selected.length > 0,
+        displayCondition: selected => selected.length !== items.length,
+        icon: SelectAllIcon
+      },
+      unselectAll: {
+        action: () => unSelectAllAction(),
+        displayCondition: selected => selected.length === items.length,
         icon: SelectAllIcon
       }
     }),
-    [fillSelection, showTransactionCategoryModal]
+    [
+      fillSelection,
+      items.length,
+      showTransactionCategoryModal,
+      unSelectAllAction
+    ]
   )
 
   return actions

--- a/src/ducks/selection/helpers.js
+++ b/src/ducks/selection/helpers.js
@@ -1,20 +1,36 @@
+import { useCallback, useMemo } from 'react'
+
 import GraphCircleIcon from 'cozy-ui/transpiled/react/Icons/GraphCircle'
 import SelectAllIcon from 'cozy-ui/transpiled/react/Icons/SelectAll'
 
-export const makeSelectionBarActions = ({
-  showTransactionCategoryModal,
-  fillSelection
+import { useSelectionContext } from 'ducks/context/SelectionContext'
+
+export const useSelectionBarActions = ({
+  items,
+  showTransactionCategoryModal
 }) => {
-  return {
-    categorize: {
-      action: () => showTransactionCategoryModal(),
-      displayCondition: selected => selected.length > 0,
-      icon: GraphCircleIcon
-    },
-    selectAll: {
-      action: () => fillSelection(),
-      displayCondition: selected => selected.length > 0,
-      icon: SelectAllIcon
-    }
-  }
+  const { fillSelectionWith } = useSelectionContext()
+
+  const fillSelection = useCallback(() => fillSelectionWith(items), [
+    fillSelectionWith,
+    items
+  ])
+
+  const actions = useMemo(
+    () => ({
+      categorize: {
+        action: () => showTransactionCategoryModal(),
+        displayCondition: selected => selected.length > 0,
+        icon: GraphCircleIcon
+      },
+      selectAll: {
+        action: () => fillSelection(),
+        displayCondition: selected => selected.length > 0,
+        icon: SelectAllIcon
+      }
+    }),
+    [fillSelection, showTransactionCategoryModal]
+  )
+
+  return actions
 }

--- a/src/ducks/selection/helpers.js
+++ b/src/ducks/selection/helpers.js
@@ -36,7 +36,8 @@ export const useSelectionBarActions = ({
       selectAll: {
         action: () => fillSelection(),
         displayCondition: selected => selected.length !== items.length,
-        icon: SelectAllIcon
+        icon: SelectAllIcon,
+        disabled: () => false
       },
       unselectAll: {
         action: () => unSelectAllAction(),

--- a/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
@@ -1,0 +1,91 @@
+import React, { useCallback, useRef, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import Hammer from 'hammerjs'
+
+import { hasParentWithClass } from 'ducks/transactions/TransactionRow/helpers'
+
+import styles from 'ducks/transactions/Transactions.styl'
+
+const isTouchEventsCatched = ev => {
+  // exclude actions from being catched by touch
+  if (hasParentWithClass(ev.target, styles.TransactionRowMobile__actions)) {
+    return false
+  }
+  return true
+}
+
+const TransactionOpener = ({
+  transaction,
+  toggleSelection,
+  isSelectionModeActiveFn,
+  showTransactionModal,
+  children
+}) => {
+  const rowRef = useRef()
+
+  const handleClick = useCallback(ev => ev.preventDefault(), [])
+
+  const handleTap = useCallback(() => {
+    if (isSelectionModeActiveFn()) {
+      toggleSelection(transaction)
+    } else {
+      transaction._id && showTransactionModal()
+    }
+  }, [
+    isSelectionModeActiveFn,
+    showTransactionModal,
+    toggleSelection,
+    transaction
+  ])
+
+  const handlePress = useCallback(() => {
+    toggleSelection(transaction)
+  }, [toggleSelection, transaction])
+
+  useEffect(() => {
+    if (!rowRef || !rowRef.current) return
+
+    const hammer = new Hammer(rowRef.current)
+
+    hammer.on('tap', ev => {
+      if (isTouchEventsCatched(ev)) {
+        // setTimeout needed to trigger onClick event first, and so make preventDefault() work
+        setTimeout(() => {
+          handleTap()
+        }, 10)
+      }
+    })
+
+    hammer.on('press', ev => {
+      if (isTouchEventsCatched(ev)) {
+        handlePress()
+      }
+    })
+
+    return () => {
+      hammer && hammer.destroy()
+    }
+  }, [
+    handlePress,
+    handleTap,
+    showTransactionModal,
+    toggleSelection,
+    transaction,
+    transaction._id
+  ])
+
+  return (
+    <span ref={rowRef} onClick={handleClick}>
+      {children}
+    </span>
+  )
+}
+
+TransactionOpener.propTypes = {
+  transaction: PropTypes.object,
+  toggleSelection: PropTypes.func,
+  isSelectionModeActiveFn: PropTypes.func,
+  showTransactionModal: PropTypes.func
+}
+
+export default React.memo(TransactionOpener)

--- a/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
@@ -17,7 +17,7 @@ const isTouchEventsCatched = ev => {
 const TransactionOpener = ({
   transaction,
   toggleSelection,
-  isSelectionModeActiveFn,
+  isSelectionModeActive,
   showTransactionModal,
   children
 }) => {
@@ -26,13 +26,13 @@ const TransactionOpener = ({
   const handleClick = useCallback(ev => ev.preventDefault(), [])
 
   const handleTap = useCallback(() => {
-    if (isSelectionModeActiveFn()) {
+    if (isSelectionModeActive) {
       toggleSelection(transaction)
     } else {
       transaction._id && showTransactionModal()
     }
   }, [
-    isSelectionModeActiveFn,
+    isSelectionModeActive,
     showTransactionModal,
     toggleSelection,
     transaction
@@ -84,7 +84,7 @@ const TransactionOpener = ({
 TransactionOpener.propTypes = {
   transaction: PropTypes.object,
   toggleSelection: PropTypes.func,
-  isSelectionModeActiveFn: PropTypes.func,
+  isSelectionModeActive: PropTypes.func,
   showTransactionModal: PropTypes.func
 }
 

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -38,7 +38,7 @@ const TransactionRowDesktop = ({
   onRef,
   showRecurrence,
   isSelected,
-  isSelectionModeActiveFn,
+  isSelectionModeActive,
   isSelectionModeEnabled,
   toggleSelection
 }) => {
@@ -71,14 +71,14 @@ const TransactionRowDesktop = ({
   const handleClickCategory = useCallback(
     ev => {
       ev.preventDefault()
-      if (isSelectionModeActiveFn()) {
+      if (isSelectionModeActive) {
         toggleSelection(transaction)
       } else {
         showTransactionCategoryModal()
       }
     },
     [
-      isSelectionModeActiveFn,
+      isSelectionModeActive,
       showTransactionCategoryModal,
       toggleSelection,
       transaction
@@ -101,18 +101,13 @@ const TransactionRowDesktop = ({
       if (!ev.currentTarget.contains(ev.target)) {
         return
       }
-      if (isSelectionModeActiveFn()) {
+      if (isSelectionModeActive) {
         toggleSelection(transaction)
       } else {
         showTransactionModal()
       }
     },
-    [
-      isSelectionModeActiveFn,
-      showTransactionModal,
-      toggleSelection,
-      transaction
-    ]
+    [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
   )
 
   // Virtual transactions, like those generated from recurrences, cannot be edited

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -49,7 +49,7 @@ const TransactionRowMobile = ({
   onRef,
   showRecurrence,
   isSelected,
-  isSelectionModeActiveFn,
+  isSelectionModeActive,
   toggleSelection,
   hasDivider
 }) => {
@@ -78,7 +78,7 @@ const TransactionRowMobile = ({
       <TransactionOpener
         transaction={transaction}
         toggleSelection={toggleSelection}
-        isSelectionModeActiveFn={isSelectionModeActiveFn}
+        isSelectionModeActive={isSelectionModeActive}
         showTransactionModal={showTransactionModal}
       >
         <ListItem

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -1,7 +1,6 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useMemo } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
-import Tappable from 'react-tappable/lib/Tappable'
 
 import flag from 'cozy-flags'
 import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
@@ -32,15 +31,14 @@ import ApplicationDateCaption from 'ducks/transactions/TransactionRow/Applicatio
 import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
 import { useSelectionContext } from 'ducks/context/SelectionContext'
+import TransactionOpener from 'ducks/transactions/TransactionRow/TransactionOpener'
 
-const RowCheckbox = ({ isSelected, onTap, onPress }) => {
+const RowCheckbox = ({ isSelected }) => {
   const { isSelectionModeActive } = useSelectionContext()
 
   return isSelectionModeActive ? (
     <Img style={{ marginLeft: '-1rem' }}>
-      <Tappable onTap={onTap} onPress={onPress} pressDelay={250}>
-        <Checkbox checked={isSelected} readOnly />
-      </Tappable>
+      <Checkbox checked={isSelected} readOnly />
     </Img>
   ) : null
 }
@@ -58,26 +56,13 @@ const TransactionRowMobile = ({
   const { t } = useI18n()
   const account = transaction.account.data
   const rowRest = {}
-  const [rawShowTransactionModal, , transactionModal] = useTransactionModal(
+  const [showTransactionModal, , transactionModal] = useTransactionModal(
     transaction
-  )
-
-  const toggleTransactionSelection = useCallback(
-    () => toggleSelection(transaction),
-    [toggleSelection, transaction]
   )
 
   const boundOnRef = useMemo(() => {
     return onRef ? onRef.bind(null, transaction._id) : null
   }, [onRef, transaction])
-
-  const showTransactionModal = useCallback(
-    ev => {
-      ev.preventDefault()
-      rawShowTransactionModal()
-    },
-    [rawShowTransactionModal]
-  )
 
   if (flag('show-transactions-ids')) {
     rowRest.id = transaction._id
@@ -88,62 +73,37 @@ const TransactionRowMobile = ({
   const applicationDate = getApplicationDate(transaction)
   const recurrence = transaction.recurrence ? transaction.recurrence.data : null
 
-  const handleTap = useCallback(
-    ev => {
-      if (isSelectionModeActiveFn()) {
-        toggleSelection(transaction)
-      } else {
-        transaction._id && showTransactionModal(ev)
-      }
-    },
-    [
-      isSelectionModeActiveFn,
-      showTransactionModal,
-      toggleSelection,
-      transaction
-    ]
-  )
-
   return (
     <>
-      <ListItem
-        ref={boundOnRef}
-        {...rowRest}
-        className={cx({
-          [styles['TransactionRow--selected']]: isSelected
-        })}
-        button={!!transaction._id}
+      <TransactionOpener
+        transaction={transaction}
+        toggleSelection={toggleSelection}
+        isSelectionModeActiveFn={isSelectionModeActiveFn}
+        showTransactionModal={showTransactionModal}
       >
-        <Media className="u-w-100">
-          <RowCheckbox
-            isSelected={isSelected}
-            onTap={handleTap}
-            onPress={toggleTransactionSelection}
-          />
-          <Bd>
-            <Media className="u-w-100">
-              <Img
-                className="u-mr-half"
-                title={t(
-                  `Data.subcategories.${getCategoryName(
-                    getCategoryId(transaction)
-                  )}`
-                )}
-              >
-                <Tappable
-                  onTap={handleTap}
-                  onPress={toggleTransactionSelection}
-                  pressDelay={250}
+        <ListItem
+          ref={boundOnRef}
+          {...rowRest}
+          className={cx({
+            [styles['TransactionRow--selected']]: isSelected
+          })}
+          button={!!transaction._id}
+        >
+          <Media className="u-w-100">
+            <RowCheckbox isSelected={isSelected} />
+            <Bd>
+              <Media className="u-w-100">
+                <Img
+                  className="u-mr-half"
+                  title={t(
+                    `Data.subcategories.${getCategoryName(
+                      getCategoryId(transaction)
+                    )}`
+                  )}
                 >
                   <CategoryIcon categoryId={getCategoryId(transaction)} />
-                </Tappable>
-              </Img>
-              <Bd className="u-mr-half">
-                <Tappable
-                  onTap={handleTap}
-                  onPress={toggleTransactionSelection}
-                  pressDelay={250}
-                >
+                </Img>
+                <Bd className="u-mr-half">
                   <ListItemText>
                     <Typography className="u-ellipsis" variant="body1">
                       {getLabel(transaction)}
@@ -155,14 +115,8 @@ const TransactionRowMobile = ({
                       <ApplicationDateCaption transaction={transaction} />
                     ) : null}
                   </ListItemText>
-                </Tappable>
-              </Bd>
-              <Img className={styles.TransactionRowMobileImg}>
-                <Tappable
-                  onTap={handleTap}
-                  onPress={toggleTransactionSelection}
-                  pressDelay={250}
-                >
+                </Bd>
+                <Img className={styles.TransactionRowMobileImg}>
                   <Figure
                     total={transaction.amount}
                     symbol={getCurrencySymbol(transaction.currency)}
@@ -172,28 +126,28 @@ const TransactionRowMobile = ({
                   {recurrence && showRecurrence ? (
                     <RecurrenceCaption recurrence={recurrence} />
                   ) : null}
-                </Tappable>
-              </Img>
-            </Media>
+                </Img>
+              </Media>
 
-            {showTransactionActions && (
-              <TransactionActions
-                transaction={transaction}
-                onlyDefault
-                compact
-                menuPosition="right"
-                className={cx(
-                  'u-mb-half',
-                  styles.TransactionRowMobile__actions
-                )}
-              />
-            )}
-          </Bd>
-        </Media>
-      </ListItem>
-      {hasDivider && (
-        <Divider style={{ marginLeft: '3.5rem' }} variant="inset" />
-      )}
+              {showTransactionActions && (
+                <TransactionActions
+                  transaction={transaction}
+                  onlyDefault
+                  compact
+                  menuPosition="right"
+                  className={cx(
+                    'u-mb-half',
+                    styles.TransactionRowMobile__actions
+                  )}
+                />
+              )}
+            </Bd>
+          </Media>
+        </ListItem>
+        {hasDivider && (
+          <Divider style={{ marginLeft: '3.5rem' }} variant="inset" />
+        )}
+      </TransactionOpener>
       {transactionModal}
     </>
   )

--- a/src/ducks/transactions/TransactionRow/helpers.js
+++ b/src/ducks/transactions/TransactionRow/helpers.js
@@ -1,0 +1,7 @@
+export const hasParentWithClass = (el, cl) => {
+  while (el.parentNode) {
+    el = el.parentNode
+    if (el.classList && el.classList.contains(cl)) return true
+  }
+  return false
+}

--- a/src/ducks/transactions/TransactionRow/helpers.spec.js
+++ b/src/ducks/transactions/TransactionRow/helpers.spec.js
@@ -1,0 +1,27 @@
+import { hasParentWithClass } from './helpers'
+
+import styles from 'ducks/transactions/Transactions.styl'
+
+describe('hasParentWithClass', () => {
+  it('should return true if a none direct parent has the specific class', () => {
+    const grandParent = document.createElement('div')
+    grandParent.classList.add(styles.TransactionRowMobile__actions)
+    const parent = document.createElement('div')
+    grandParent.appendChild(parent)
+    const child = document.createElement('div')
+    parent.appendChild(child)
+
+    expect(
+      hasParentWithClass(child, styles.TransactionRowMobile__actions)
+    ).toBeTruthy()
+  })
+
+  it('should return false if a node without parent has the specific class', () => {
+    const node = document.createElement('div')
+    node.classList.add(styles.TransactionRowMobile__actions)
+
+    expect(
+      hasParentWithClass(node, styles.TransactionRowMobile__actions)
+    ).toBeFalsy()
+  })
+})

--- a/src/ducks/transactions/TransactionRow/index.spec.jsx
+++ b/src/ducks/transactions/TransactionRow/index.spec.jsx
@@ -12,8 +12,6 @@ import TransactionRowDesktop from './TransactionRowDesktop'
 
 const allTransactions = data['io.cozy.bank.operations']
 
-jest.mock('react-tappable/lib/Tappable', () => ({ children }) => children)
-
 describe('TransactionRowMobile', () => {
   const setup = ({ transactionAttributes } = {}) => {
     const SNACK_AND_WORK_MEALS = '400160'

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -96,7 +96,7 @@ const TransactionSections = ({
   const { isDesktop, isExtraLarge } = useBreakpoints()
   const {
     isSelected,
-    isSelectionModeActiveFn,
+    isSelectionModeActive,
     isSelectionModeEnabled,
     toggleSelection
   } = useSelectionContext()
@@ -124,7 +124,7 @@ const TransactionSections = ({
                   isExtraLarge={isExtraLarge}
                   filteringOnAccount={filteringOnAccount}
                   isSelected={isSelected(transaction)}
-                  isSelectionModeActiveFn={isSelectionModeActiveFn}
+                  isSelectionModeActive={isSelectionModeActive}
                   isSelectionModeEnabled={isSelectionModeEnabled}
                   toggleSelection={toggleSelection}
                   hasDivider={

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -1,7 +1,6 @@
 /* global mount */
 
 import React from 'react'
-import Tappable from 'react-tappable/lib/Tappable'
 import { render, fireEvent, wait } from '@testing-library/react'
 import { within } from '@testing-library/dom'
 
@@ -18,11 +17,6 @@ import { TransactionsDumb, sortByDate } from './Transactions'
 
 // No need to test this here
 jest.mock('ducks/transactions/TransactionPageErrors', () => () => null)
-
-jest.mock('react-tappable/lib/Tappable', () => ({
-  default: jest.fn(),
-  __esModule: true
-}))
 
 jest.mock('cozy-ui/transpiled/react/hooks/useBreakpoints', () => ({
   __esModule: true,
@@ -110,15 +104,6 @@ describe('Interactions', () => {
     Alerter.success.mockReset()
   })
 
-  // Mock tappable so that key down fires its onPress event
-  Tappable.mockImplementation(({ children, onPress, onTap }) => {
-    return (
-      <div onClick={onTap} onKeyDown={onPress}>
-        {children}
-      </div>
-    )
-  })
-
   const setup = ({
     isDesktop = false,
     transactions = mockTransactions
@@ -166,51 +151,6 @@ describe('Interactions', () => {
   })
 
   describe('SelectionBar', () => {
-    it('should show selection bar and open category modal', async () => {
-      const { root, client } = setup({ isDesktop: false })
-      const { getByText, getByTestId, queryByTestId } = root
-
-      fireEvent.keyDown(getByText('Maintenance'))
-      expect(queryByTestId('selectionBar')).toBeTruthy()
-      expect(queryByTestId('selectionBar-count').textContent).toBe(
-        '1 item selected'
-      )
-
-      // should remove the selection bar
-      fireEvent.click(getByText('Maintenance'))
-      expect(queryByTestId('selectionBar')).toBeFalsy()
-
-      // should show 2 transactions selected
-      fireEvent.keyDown(getByText('Maintenance'))
-      expect(queryByTestId('selectionBar')).toBeTruthy()
-      fireEvent.click(getByText('Franprix St Lazare Pr'))
-      expect(queryByTestId('selectionBar-count').textContent).toBe(
-        '2 items selected'
-      )
-
-      // should unselected transaction
-      fireEvent.click(getByText('Franprix St Lazare Pr'))
-      expect(queryByTestId('selectionBar-count').textContent).toBe(
-        '1 item selected'
-      )
-      fireEvent.click(getByText('Franprix St Lazare Pr'))
-      expect(queryByTestId('selectionBar-count').textContent).toBe(
-        '2 items selected'
-      )
-
-      // selecting a category
-      fireEvent.click(getByTestId('selectionBar-action-categorize'))
-      fireEvent.click(getByText('Everyday life'))
-      fireEvent.click(getByText('Supermarket'))
-
-      // should remove the selection bar and show a success alert
-      expect(queryByTestId('selectionBar')).toBeFalsy()
-      await wait(() => expect(client.save).toHaveBeenCalledTimes(2))
-      expect(Alerter.success).toHaveBeenCalledWith(
-        '2 operations have been recategorized'
-      )
-    })
-
     it('should show selection bar and open category modal on desktop', async () => {
       const { root, client } = setup({ isDesktop: true })
       const { getByText, getByTestId, queryByTestId } = root

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -43,6 +43,8 @@ const mockTransactions = data['io.cozy.bank.operations'].map((x, i) => ({
 
 describe('Transactions', () => {
   const setup = ({ showTriggerErrors, renderFn }) => {
+    useBreakpoints.mockReturnValue({ isDesktop: false })
+
     const Wrapper = ({ transactions = mockTransactions }) => {
       return (
         <AppLike>

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -104,7 +104,6 @@ for category in categories
     justify-content center
 
 .TransactionRowMobile__actions
-    margin-top -0.5rem
     margin-left 0
     display block
     padding-left 2.5rem

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -926,6 +926,7 @@
     "selected_count": "item selected |||| items selected",
     "close": "Close",
     "categorize": "Categorize",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "unselectAll": "Unselect all"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -928,6 +928,7 @@
     "selected_count": "élément sélectionné |||| éléments sélectionnés",
     "close": "Fermer",
     "categorize": "Catégorisation",
-    "selectAll": "Tout sélectionner"
+    "selectAll": "Tout sélectionner",
+    "unselectAll": "Tout désélectionner"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5258,10 +5258,10 @@ cozy-ui@40.1.0:
     react-select "2.2.0"
     react-swipeable-views "0.13.3"
 
-cozy-ui@51.0.2:
-  version "51.0.2"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.0.2.tgz#92e092a2c1a3437d45ec1515e19cff796f519b37"
-  integrity sha512-FfsemCsrXra4lUTuM6Qp48W0L485tiLvsGdrlJD/b2xsa/c/KCTnP2bgH6wyBtqQ3EzhQmOEOxNkwcrUXOTG7g==
+cozy-ui@51.1.0:
+  version "51.1.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.1.0.tgz#a0252ff8600f91f2b233466ae6af1be6e025c4db"
+  integrity sha512-fklO3mOHgAO5nKiDuo2xhtGWrjDKEyN0glnDFp5Xr4N81NP1Octg//XoybfauUFMxgcgMRTE7WL3oVGE8g047Q==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15842,11 +15842,6 @@ react-swipeable-views@0.13.9, react-swipeable-views@^0.13.3:
     react-swipeable-views-utils "^0.13.9"
     warning "^4.0.1"
 
-react-tappable@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/react-tappable/-/react-tappable-1.0.4.tgz#282b7b3dc25e6170b55d1ea33d986b7624a19fb9"
-  integrity sha512-thWt8b11Hy1BmWDPuqbj+Qom5MmnMZDjfzgSE2L2Yh0Hoc9+I6DKNmWrOJGaZtH6fL4FWtRk4HwyMfUJ10M67g==
-
 react-test-renderer@16.9.0, react-test-renderer@^16.0.0-0:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.9.0.tgz#7ed657a374af47af88f66f33a3ef99c9610c8ae9"


### PR DESCRIPTION
- correction : avec la lib Tappable lorsque l'on swipait vers le bas sur mobile, en prenant une ligne de transaction comme point de départ, cela avait aussi pour effet de cliquer sur la ligne et donc d'ouvrir la modale de transaction. C'est n'est plus le cas avec Hammerjs. En revanche on avait réussi à mocker Tappable pour faire un vrai test fonctionnel sur mobile, je n'ai pas réussi à faire de même avec Hammer. J'ai donc supprimé le test. On a encore le test fonctionnel sur desktop en revanche :+1:
- modification : l'activation de la SelectionBar n'est plus lié à son contenu. Elle peut donc être active sans avoir aucun élément sélectionné. C'est d'ailleurs ce qu'on souhaite faire sur mobile (pas sur desktop).
- ajout : un bouton pour déselectionner tout