### PR TITLE
fix: TransactionSelectDates crashed if the account had no transaction

### DIFF
--- a/src/components/BarSearchInput/index.jsx
+++ b/src/components/BarSearchInput/index.jsx
@@ -20,6 +20,7 @@ const BarSearchInput = ({
   onClick,
   placeholder,
   value,
+  defaultValue,
   autofocus,
   onReset
 }) => {
@@ -41,6 +42,9 @@ const BarSearchInput = ({
         onChange={onChange}
         placeholder={placeholder}
         value={value}
+        defaultValue={
+          value === undefined && defaultValue ? defaultValue : undefined
+        }
         autoFocus={autofocus}
       />
       <BarSearchIcon onClick={handleReset} className={styles.ResetIcon}>
@@ -51,7 +55,7 @@ const BarSearchInput = ({
 }
 
 BarSearchInput.defaultProps = {
-  value: ''
+  defaultValue: ''
 }
 
 export default BarSearchInput

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -137,7 +137,9 @@ const CategoriesHeader = props => {
   const onExtentLoad = useCallback(
     extent => {
       const latestPeriod = extent[1]
-      dispatch(addFilterByPeriod(latestPeriod))
+      if (latestPeriod) {
+        dispatch(addFilterByPeriod(latestPeriod))
+      }
     },
     [dispatch]
   )

--- a/src/ducks/transactions/TransactionSelectDates.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.jsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import PropTypes from 'prop-types'
-import { useSelector } from 'react-redux'
-import CozyClient from 'cozy-client'
+
 import SelectDates, { monthRange } from 'components/SelectDates'
 import last from 'lodash/last'
 import uniq from 'lodash/uniq'
@@ -12,15 +11,9 @@ import {
   differenceInCalendarMonths,
   isAfter
 } from 'date-fns'
-import { useQuery, useClient } from 'cozy-client'
 import { getDate } from 'ducks/transactions/helpers'
-import { getFilteringDoc } from 'ducks/filters'
-import { groupsConn, accountsConn } from 'doctypes'
-import {
-  makeFilteredTransactionsConn,
-  makeEarliestLatestQueries
-} from './queries'
-import useSafeState from 'hooks/useSafeState'
+
+import useTransactionExtent from 'hooks/useTransactionExtent'
 
 const rangeMonth = (startDate, endDate) => {
   const options = []
@@ -51,60 +44,6 @@ export const getOptions = transactions => {
       disabled: !mAvailableMonths.has(fmted)
     }
   })
-}
-
-const useConn = conn => {
-  return useQuery(conn.query, conn)
-}
-
-// We do not want queries with the minimal and maximal transaction to receive
-// transactions from other queries
-const extentAutoUpdateOptions = { update: true, add: false, remove: false }
-
-const useTransactionExtent = () => {
-  const client = useClient()
-  const accounts = useConn(accountsConn)
-  const groups = useConn(groupsConn)
-  const [loading, setLoading] = useSafeState(true)
-  const filteringDoc = useSelector(getFilteringDoc)
-  const transactionsConn = makeFilteredTransactionsConn({
-    filteringDoc,
-    accounts,
-    groups
-  })
-  const [data, setData] = useState([])
-
-  useEffect(() => {
-    const fetch = async () => {
-      const baseQuery = transactionsConn.query()
-      const [earliestQuery, latestQuery] = makeEarliestLatestQueries(baseQuery)
-      setLoading(true)
-      try {
-        const [earliest, latest] = await Promise.all(
-          [earliestQuery, latestQuery].map(async (q, i) => {
-            const queryName = `${transactionsConn.as}-${
-              i === 0 ? 'earliest' : 'latest'
-            }`
-            await client.query(q, {
-              fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
-              as: queryName,
-              autoUpdate: extentAutoUpdateOptions
-            })
-            return client.getQueryFromState(queryName)
-          })
-        )
-        setData([earliest.data[0], latest.data[0]])
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    if (transactionsConn.enabled) {
-      fetch()
-    }
-  }, [transactionsConn.enabled, transactionsConn.as]) // eslint-disable-line
-
-  return [data[0], data[1], loading]
 }
 
 const getMonthFromTransaction = transaction => {

--- a/src/ducks/transactions/TransactionSelectDates.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.jsx
@@ -62,7 +62,9 @@ const TransactionSelectDates = ({ onExtentLoad, ...props }) => {
       return
     }
     onExtentLoad(
-      [earliestTransaction, latestTransaction].map(getMonthFromTransaction)
+      earliestTransaction && latestTransaction
+        ? [earliestTransaction, latestTransaction].map(getMonthFromTransaction)
+        : []
     )
   }, [earliestTransaction, latestTransaction, loading, onExtentLoad])
 

--- a/src/ducks/transactions/TransactionSelectDates.spec.jsx
+++ b/src/ducks/transactions/TransactionSelectDates.spec.jsx
@@ -1,4 +1,5 @@
-import { getOptions } from './TransactionSelectDates'
+import React from 'react'
+import { render } from '@testing-library/react'
 import fixtures from 'test/fixtures'
 import addMonths from 'date-fns/add_months'
 import isBefore from 'date-fns/is_before'
@@ -6,6 +7,16 @@ import isEqual from 'date-fns/is_equal'
 import format from 'date-fns/format'
 import includes from 'lodash/includes'
 import MockDate from 'mockdate'
+
+import TransactionSelectDates, { getOptions } from './TransactionSelectDates'
+import { createMockClient } from 'cozy-client'
+import { TRANSACTION_DOCTYPE } from 'doctypes'
+import AppLike from 'test/AppLike'
+import getClient from 'selectors/getClient'
+import useTransactionExtent from 'hooks/useTransactionExtent'
+
+jest.mock('hooks/useTransactionExtent', () => jest.fn())
+jest.mock('selectors/getClient', () => jest.fn())
 
 const transactions = fixtures['io.cozy.bank.operations']
 
@@ -57,5 +68,81 @@ describe('options from select dates', () => {
         new Date(transactionInFuture.date)
       )
     )
+  })
+})
+
+describe('TransactionSelectDates', () => {
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  it('should render if earliest/latest transaction do not exist', () => {
+    MockDate.set(new Date('2019-06-01'))
+
+    const client = createMockClient({
+      queries: {
+        transactions: {
+          doctype: TRANSACTION_DOCTYPE,
+          data: []
+        }
+      }
+    })
+
+    useTransactionExtent.mockReturnValue([undefined, undefined, false])
+    getClient.mockReturnValue(client)
+    const onExtentLoad = jest.fn()
+    const root = render(
+      <AppLike client={client}>
+        <TransactionSelectDates
+          onExtentLoad={onExtentLoad}
+          options={getOptions(transactions)}
+          onChange={jest.fn()}
+        />
+      </AppLike>
+    )
+
+    expect(
+      Array.from(root.container.querySelectorAll('.cz__single-value')).map(
+        n => n.textContent
+      )
+    ).toEqual(['2019', 'June'])
+    expect(onExtentLoad).toHaveBeenCalledWith([])
+  })
+
+  it('should render if earliest/latest transaction do exist', () => {
+    MockDate.set(new Date('2019-06-01'))
+
+    const client = createMockClient({
+      queries: {
+        transactions: {
+          doctype: TRANSACTION_DOCTYPE,
+          data: []
+        }
+      }
+    })
+
+    useTransactionExtent.mockReturnValue([
+      transactions[0],
+      transactions[transactions.length - 1],
+      false
+    ])
+    getClient.mockReturnValue(client)
+    const onExtentLoad = jest.fn()
+    const root = render(
+      <AppLike client={client}>
+        <TransactionSelectDates
+          onExtentLoad={onExtentLoad}
+          options={getOptions(transactions)}
+          onChange={jest.fn()}
+        />
+      </AppLike>
+    )
+
+    expect(
+      Array.from(root.container.querySelectorAll('.cz__single-value')).map(
+        n => n.textContent
+      )
+    ).toEqual(['2019', 'June'])
+    expect(onExtentLoad).toHaveBeenCalledWith(['2017-08', '2018-06'])
   })
 })

--- a/src/hooks/useTransactionExtent.jsx
+++ b/src/hooks/useTransactionExtent.jsx
@@ -1,0 +1,73 @@
+import { useState, useEffect } from 'react'
+
+import { useSelector } from 'react-redux'
+import CozyClient, { useClient, useQuery } from 'cozy-client'
+import { groupsConn, accountsConn } from 'doctypes'
+import {
+  makeFilteredTransactionsConn,
+  makeEarliestLatestQueries
+} from 'ducks/transactions/queries'
+import useSafeState from 'hooks/useSafeState'
+import { getFilteringDoc } from 'ducks/filters'
+
+// We do not want queries with the minimal and maximal transaction to receive
+// transactions from other queries
+const extentAutoUpdateOptions = { update: true, add: false, remove: false }
+
+const useConn = conn => {
+  return useQuery(conn.query, conn)
+}
+
+/**
+ * Fetches earliest an latest transactions according to current
+ * account/group filter
+ *
+ * @returns {[Transaction, Transaction, boolean]} = [earliestTransaction, latestTransaction, isLoading]
+ */
+const useTransactionExtent = () => {
+  const client = useClient()
+  const accounts = useConn(accountsConn)
+  const groups = useConn(groupsConn)
+  const [loading, setLoading] = useSafeState(true)
+  const filteringDoc = useSelector(getFilteringDoc)
+  const transactionsConn = makeFilteredTransactionsConn({
+    filteringDoc,
+    accounts,
+    groups
+  })
+  const [data, setData] = useState([])
+
+  useEffect(() => {
+    const fetch = async () => {
+      const baseQuery = transactionsConn.query()
+      const [earliestQuery, latestQuery] = makeEarliestLatestQueries(baseQuery)
+      setLoading(true)
+      try {
+        const [earliest, latest] = await Promise.all(
+          [earliestQuery, latestQuery].map(async (q, i) => {
+            const queryName = `${transactionsConn.as}-${
+              i === 0 ? 'earliest' : 'latest'
+            }`
+            await client.query(q, {
+              fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
+              as: queryName,
+              autoUpdate: extentAutoUpdateOptions
+            })
+            return client.getQueryFromState(queryName)
+          })
+        )
+        setData([earliest.data[0], latest.data[0]])
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    if (transactionsConn.enabled) {
+      fetch()
+    }
+  }, [transactionsConn.enabled, transactionsConn.as]) // eslint-disable-line
+
+  return [data[0], data[1], loading]
+}
+
+export default useTransactionExtent


### PR DESCRIPTION
onExtentLoad would be called even if there was no transactions