### PR TITLE
Transaction list scroll stabilisation

### DIFF
--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -174,10 +174,19 @@ class TransactionsPage extends Component {
     )
   }
 
-  handleFetchMoreBecomeVisible() {
+  async handleFetchMoreBecomeVisible() {
     const { transactions } = this.props
-    if (transactions.hasMore && transactions.fetchStatus === 'loaded') {
-      transactions.fetchMore()
+    if (
+      transactions.hasMore &&
+      transactions.fetchStatus === 'loaded' &&
+      !this.fetchingMore
+    ) {
+      try {
+        this.fetchingMore = true
+        await transactions.fetchMore()
+      } finally {
+        this.fetchingMore = false
+      }
     }
   }
 
@@ -217,7 +226,9 @@ class TransactionsPage extends Component {
             showBalance={isMobile && !areAccountsLoading}
           />
         ) : null}
-        <HeaderLoadingProgress isFetching={isFetchingNewData} />
+        <HeaderLoadingProgress
+          isFetching={isFetchingNewData || this.fetchingMore}
+        />
         <div
           ref={this.handleListRef}
           style={{ opacity: 0 }}

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -2,7 +2,6 @@ import React, { Component, useState, useCallback, useMemo } from 'react'
 import ReactDOM from 'react-dom'
 import { withRouter } from 'react-router'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
 import cx from 'classnames'
 import debounce from 'lodash/debounce'
 import compose from 'lodash/flowRight'
@@ -289,10 +288,6 @@ export const UnpluggedTransactionsPage = compose(
   translate(),
   withBreakpoints()
 )(TransactionsPage)
-
-UnpluggedTransactionsPage.propTypes = {
-  filteredTransactions: PropTypes.array.isRequired
-}
 
 const ConnectedTransactionsPage = compose(
   withRouter,

--- a/src/ducks/transactions/scroll/TopMost.js
+++ b/src/ducks/transactions/scroll/TopMost.js
@@ -20,10 +20,10 @@ class TopMost {
     const topRoot =
       scrollEl === window ? 0 : scrollEl.getBoundingClientRect().top
     const offsets = sortBy(
-      Object.entries(this.nodes).map(([tId, node]) => [
-        tId,
-        node ? node.getBoundingClientRect().top : Infinity
-      ]),
+      Object.entries(this.nodes).map(([tId, node]) => {
+        const rect = node ? node.getBoundingClientRect() : null
+        return [tId, rect ? rect.top : Infinity]
+      }),
       x => x[1]
     )
     const topMost = find(offsets, o => {

--- a/src/hooks/useIntersectionObserver.jsx
+++ b/src/hooks/useIntersectionObserver.jsx
@@ -1,8 +1,10 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import 'intersection-observer'
 
 const useIntersectionObserver = (observerOptions, handleIntersection) => {
   const [ref, setRef] = useState(null)
+  const callbackRef = useRef()
+  callbackRef.current = handleIntersection
   const handleRef = useCallback(node => {
     setRef(node)
   }, [])
@@ -11,10 +13,13 @@ const useIntersectionObserver = (observerOptions, handleIntersection) => {
     if (!ref) {
       return
     }
-    const o = new IntersectionObserver(handleIntersection, observerOptions)
+    const handleIntersectionCb = options => {
+      callbackRef.current(options)
+    }
+    const o = new IntersectionObserver(handleIntersectionCb, observerOptions)
     o.observe(ref)
     return () => o.unobserve(ref)
-  }, [handleIntersection, observerOptions, ref])
+  }, [observerOptions, ref])
   return handleRef
 }
 export default useIntersectionObserver


### PR DESCRIPTION
- Fetch more was called in a loop because the component becuase the 
  compoentn would call fetchMore, the list would be re-renderred, then
  the list would see that it was at the end of the list, then would
  call fetchMore etc... Normally the collection inside cozy-client should
  have status="loaded" and the call to fetchMore would not happen, but
  apparently it can happen.

  Now the component keeps a ref on the promise returned by the fetchMore
  promise so that the component cannot launch 2 fetchMore calls.

- There could be a null node in the internals of TopMost and the getBoundingClientRect
  method call would crash. This is checked now.