### PR TITLE
feat: Do not wrap transaction row content in Typography twice

### DIFF
--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -159,7 +159,7 @@ const TransactionRowDesktop = ({
               </IconButton>
             </Img>
             <Bd className="u-pl-1">
-              <ListItemText className="u-pv-half">
+              <ListItemText className="u-pv-half" disableTypography>
                 <Typography variant="body1">{getLabel(transaction)}</Typography>
                 {!filteringOnAccount && <AccountCaption account={account} />}
                 {applicationDate ? (

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -43,6 +43,8 @@ const RowCheckbox = ({ isSelected }) => {
   ) : null
 }
 
+const dividerStyle = { marginLeft: '3.5rem' }
+
 const TransactionRowMobile = ({
   transaction,
   filteringOnAccount,
@@ -144,9 +146,7 @@ const TransactionRowMobile = ({
             </Bd>
           </Media>
         </ListItem>
-        {hasDivider && (
-          <Divider style={{ marginLeft: '3.5rem' }} variant="inset" />
-        )}
+        {hasDivider && <Divider style={dividerStyle} variant="inset" />}
       </TransactionOpener>
       {transactionModal}
     </>

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -104,7 +104,7 @@ const TransactionRowMobile = ({
                   <CategoryIcon categoryId={getCategoryId(transaction)} />
                 </Img>
                 <Bd className="u-mr-half">
-                  <ListItemText>
+                  <ListItemText disableTypography>
                     <Typography className="u-ellipsis" variant="body1">
                       {getLabel(transaction)}
                     </Typography>


### PR DESCRIPTION
Since the Typography is done manually, we can use the disableTypography 
props otherwise the Typography wrapper twice.