### PR TITLE
Fixes on categories page

### DIFF
--- a/src/components/SelectDates/SelectDates.jsx
+++ b/src/components/SelectDates/SelectDates.jsx
@@ -22,7 +22,7 @@ import Select from 'components/Select'
 import { rangedSome } from 'components/SelectDates/utils'
 import { themed } from 'components/useTheme'
 
-const isAllYear = value => value.includes('allyear')
+const isAllYear = value => value && value.includes('allyear')
 
 const getOptionValue = option => option.value
 const capitalizeFirstLetter = string => {
@@ -160,6 +160,14 @@ class SelectDates extends PureComponent {
     })
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.options !== prevProps.options) {
+      if (this.props.value) {
+        this.onChange(this.props.value)
+      }
+    }
+  }
+
   handleChooseNext = () => {
     this.chooseOption(-1)
   }
@@ -202,12 +210,17 @@ class SelectDates extends PureComponent {
       if (!nearest) {
         nearest = findValue(!searchInPast)
       }
-      value = nearest.value
+      if (nearest) {
+        value = nearest.value
+      }
     }
-    if (value.includes('allyear')) {
+    if (value && value.includes('allyear')) {
       value = value.substr(0, 4)
     }
-    this.props.onChange(value)
+
+    if (value && this.props.value !== value) {
+      this.props.onChange(value)
+    }
   }
 
   getAvailableYears() {

--- a/src/ducks/categories/CategoriesHeader.jsx
+++ b/src/ducks/categories/CategoriesHeader.jsx
@@ -111,7 +111,11 @@ const CategoriesHeader = props => {
     classes
   } = props
 
-  const hasData = categories.length > 0 && categories[0].transactionsNumber > 0
+  const hasData =
+    categories.length > 0 &&
+    (selectedCategory
+      ? selectedCategory.transactionsNumber > 0
+      : categories[0].transactionsNumber > 0)
   const showIncomeToggle = hasData && selectedCategory === undefined
   const globalCurrency = getGlobalCurrency(categories)
   const transactionsTotal = getTransactionsTotal(categories)


### PR DESCRIPTION
#### When changing account on "Categories", date selector takes an
available value

When the date selector receives new options, it will call its onChange prop
if the value is not available in the new options. It calls the onChange
callback with the available option that is nearest to the current value.
This algorithm was already coded but was not called when new options were
received.

#### When going in an empty category, empty text was not shown

When we have selected a category, we need to look if the number of 
transactions within this category is 0. Previously we would look at the
first category instead of the selected category (the first category might
have transactions)