### PR TITLE
feat: Put skeleton behavior for balance account rows behind a flag

### DIFF
--- a/src/ducks/balance/AccountRow.jsx
+++ b/src/ducks/balance/AccountRow.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import compose from 'lodash/flowRight'
 import { withStyles } from '@material-ui/core/styles'
+import flag from 'cozy-flags'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
@@ -117,7 +118,10 @@ const AccountRow = props => {
     id,
     initialVisible
   } = props
-  const [ref, visible] = useVisible(initialVisible, observerOptions)
+  const [ref, visible] = useVisible(
+    flag('banks.balance.account-row-skeleton') ? initialVisible : true,
+    observerOptions
+  )
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const owners = account.owners.data.filter(Boolean).filter(owner => !owner.me)


### PR DESCRIPTION
We are not sure if we want to keep the account row skeleton behavior
(account rows on home page are displayed with "loading" if they 
are "below the fold"). This was done to improve performance on mount
of the home page, but it seems that it can be a bit janky and
the loading state disappears too much time after the user has
scrolled to the element.

Here, this behavior is disabled: all account rows are "visible" by
default. If we want to reput this behavior or improve on it, it
will be easy to remove the flag.