### PR TITLE
fix: Mobile fixes

### DIFF
--- a/docs/data-fetching.md
+++ b/docs/data-fetching.md
@@ -91,7 +91,7 @@ fetchMore.
 - `transactions-<groupId>`
 
 When the user selects a group. Very similar to the `transactions-<accountId>`
-query but we fetch transactions for several accounts with a CouchDB `$or`
+query but we fetch transactions for several accounts with a CouchDB `$in`
 query on the `account` attribute.
 
 - `transactions-<groupId>-<endDate>`

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -233,7 +233,7 @@ export const makeBalanceTransactionsConn = () => {
         })
         .sortBy([{ date: 'desc' }])
         .indexFields(['date'])
-        .select(['date', 'amount', 'account', 'currency'])
+        .select(['_id', 'date', 'amount', 'account', 'currency'])
   }
 }
 

--- a/src/ducks/budgetAlerts/index.js
+++ b/src/ducks/budgetAlerts/index.js
@@ -30,6 +30,7 @@ const makeSelectorForAccountOrGroup = async (client, accountOrGroup) => {
   } else if (accountOrGroup._type === GROUP_DOCTYPE) {
     // TODO find the right way to make an $or selector that works with cozyClient.query
     // With an $or we have an error "no matching index found, create an index"
+    // Seems like a $in selector would be better, see ducks/transactions/queries.js
     return null
   } else if (accountOrGroup._type === ACCOUNT_DOCTYPE) {
     return {

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -41,7 +41,7 @@ export const makeFilteredTransactionsConn = options => {
         }
         indexFields = ['date', 'account']
         whereClause = {
-          $or: accounts.map(a => ({ account: a }))
+          account: { $in: accounts }
         }
         sortByClause = [{ date: 'desc' }, { account: 'desc' }]
       } else if (filteringDoc._type === ACCOUNT_DOCTYPE) {
@@ -51,7 +51,7 @@ export const makeFilteredTransactionsConn = options => {
       } else if (Array.isArray(filteringDoc)) {
         indexFields = ['date', 'account']
         whereClause = {
-          $or: filteringDoc.map(a => ({ account: a }))
+          account: { $in: filteringDoc }
         }
         sortByClause = [{ date: 'desc' }, { account: 'desc' }]
       } else {

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -46,7 +46,7 @@ describe('makeFilteredTransactionsConn', () => {
       expect.objectContaining({
         indexedFields: ['date', 'account'],
         selector: {
-          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }]
+          account: { $in: ['a1', 'a2', 'a3'] }
         },
         sort: [{ date: 'desc' }, { account: 'desc' }]
       })
@@ -77,7 +77,7 @@ describe('makeFilteredTransactionsConn', () => {
       expect.objectContaining({
         indexedFields: ['date', 'account'],
         selector: {
-          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }]
+          account: { $in: ['a1', 'a2', 'a3'] }
         },
         sort: [{ date: 'desc' }, { account: 'desc' }]
       })
@@ -101,7 +101,7 @@ describe('makeFilteredTransactionsConn', () => {
       expect.objectContaining({
         indexedFields: ['date', 'account'],
         selector: {
-          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }]
+          account: { $in: ['a1', 'a2', 'a3'] }
         },
         sort: [{ date: 'desc' }, { account: 'desc' }]
       })
@@ -138,12 +138,12 @@ describe('makeEarliestLatestQueries', () => {
 
   it('should make two queries that selects the earliest and latest transactions for multiple accounts', () => {
     const baseQuery = Q('io.cozy.bank.transactions').where({
-      $or: [{ account: 'comptelou1' }, { account: 'compteisa2' }]
+      account: { $in: ['comptelou1', 'compteisa2'] }
     })
     expect(makeEarliestLatestQueries(baseQuery)).toEqual([
       expect.objectContaining({
         selector: {
-          $or: [{ account: 'comptelou1' }, { account: 'compteisa2' }],
+          account: { $in: ['comptelou1', 'compteisa2'] },
           date: { $gt: null }
         },
         indexedFields: ['date'],
@@ -152,7 +152,7 @@ describe('makeEarliestLatestQueries', () => {
       }),
       expect.objectContaining({
         selector: {
-          $or: [{ account: 'comptelou1' }, { account: 'compteisa2' }],
+          account: { $in: ['comptelou1', 'compteisa2'] },
           date: { $gt: null }
         },
         indexedFields: ['date'],
@@ -189,7 +189,7 @@ describe('addMonthToConn', () => {
     expect(conn2.query).toEqual(
       expect.objectContaining({
         selector: {
-          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }],
+          account: { $in: ['a1', 'a2', 'a3'] },
           date: {
             // Use stringContaining not to have difference of timezones
             // between CI and local development
@@ -227,7 +227,7 @@ describe('addPeriodToConn', () => {
     expect(conn2.query).toEqual(
       expect.objectContaining({
         selector: {
-          $or: [{ account: 'a1' }, { account: 'a2' }, { account: 'a3' }],
+          account: { $in: ['a1', 'a2', 'a3'] },
           date: {
             $gte: '2021-07-01T00:00',
             $lte: '2021-07-31T23:59'


### PR DESCRIPTION
#### Home chart does not make the page crash on mobile

We need to add _id to the selected fields otherwise Pouch does
not send it back, and this is not supported by cozy-client

I have opened on issue on cozy-client to discuss about the difference of behavior between pouch and couch, and to see if we should solve this problem at the cozy-client level https://github.com/cozy/cozy-client/issues/985.


#### Fetching transactions for a group works on mobile

The $or query would fail with Pouchdb, with a "no index is usable for
this query". Seems like the $or query is not well supported by Pouch.
Fortunately, the $in operator can replace the the $or here
and seems more performant. It seems that we should avoid the $or
operator for our queries to be compatible between Couch and Pouch.