### PR TITLE
UI fixes

### DIFF
--- a/src/ducks/balance/AccountRow.jsx
+++ b/src/ducks/balance/AccountRow.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import cx from 'classnames'
 import compose from 'lodash/flowRight'
 import { withStyles } from '@material-ui/core/styles'
+import flag from 'cozy-flags'
 
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import Switch from 'cozy-ui/transpiled/react/MuiCozyTheme/Switch'
@@ -117,7 +118,10 @@ const AccountRow = props => {
     id,
     initialVisible
   } = props
-  const [ref, visible] = useVisible(initialVisible, observerOptions)
+  const [ref, visible] = useVisible(
+    flag('banks.balance.account-row-skeleton') ? initialVisible : true,
+    observerOptions
+  )
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const owners = account.owners.data.filter(Boolean).filter(owner => !owner.me)

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -32,6 +32,7 @@ import {
   makeFilteredTransactionsConn,
   addPeriodToConn
 } from 'ducks/transactions/queries'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
 import BarTheme from 'ducks/bar/BarTheme'
 import { computeCategoriesData } from 'ducks/categories/selectors'
 import { getDate } from 'ducks/transactions/helpers'
@@ -67,7 +68,7 @@ const CategoryTransactions = ({ transactions, subcategoryName }) => {
       : []
   }, [subcategoryName, transactions])
   return (
-    <div className="js-scrolling-element">
+    <div className={DESKTOP_SCROLLING_ELEMENT_CLASSNAME}>
       <TransactionList
         showTriggerErrors={false}
         onChangeTopMostTransaction={null}

--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -23,6 +23,7 @@ import LegalMention from 'ducks/legal/LegalMention'
 import useEstimatedBudget from './useEstimatedBudget'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import { useTrackPage } from 'ducks/tracking/browser'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
 
 import styles from './styles.styl'
 
@@ -113,7 +114,7 @@ const PlannedTransactionsPage = ({ emptyIcon }) => {
       </Header>
       <div
         className={cx(
-          'js-scrolling-element',
+          DESKTOP_SCROLLING_ELEMENT_CLASSNAME,
           isMobile ? styles['List--mobile'] : null
         )}
       >

--- a/src/ducks/reimbursements/Reimbursements.jsx
+++ b/src/ducks/reimbursements/Reimbursements.jsx
@@ -24,6 +24,7 @@ import withBrands from 'ducks/brandDictionary/withBrands'
 import { getGroupedFilteredExpenses } from './selectors'
 import { getPeriod, parsePeriod, getFilteringDoc } from 'ducks/filters'
 import { getCategoryName } from 'ducks/categories/categoriesMap'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
 
 const Caption = props => {
   const { className, ...rest } = props
@@ -117,7 +118,9 @@ export class DumbReimbursements extends Component {
 
     return (
       <TransactionActionsProvider>
-        <div className={`${styles.Reimbursements} js-scrolling-element`}>
+        <div
+          className={`${styles.Reimbursements} ${DESKTOP_SCROLLING_ELEMENT_CLASSNAME}`}
+        >
           <Section>
             <SectionTitle>
               {t('Reimbursements.pending')}

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -36,6 +36,7 @@ import BackButton from 'components/BackButton'
 import { BarCenter, BarSearch } from 'components/Bar'
 import { useParams } from 'components/RouterContext'
 import BarSearchInput from 'components/BarSearchInput'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
 
 import searchIllu from 'assets/search-illu.svg'
 
@@ -260,7 +261,7 @@ const SearchPage = () => {
           </NarrowContent>
         </Padded>
       ) : null}
-      <div className={`js-scrolling-element`}>
+      <div className={DESKTOP_SCROLLING_ELEMENT_CLASSNAME}>
         {searchSufficient && lastUpdate ? (
           results.length > 0 ? (
             <TransactionsListContext.Provider value={transactionListOptions}>

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -173,19 +173,13 @@ const TransactionRowDesktop = ({
             </Bd>
           </Media>
         </td>
-        <TdSecondary
-          className={styles.ColumnSizeDate}
-          onClick={handleClickCategory}
-        >
+        <TdSecondary className={styles.ColumnSizeDate}>
           <TransactionDate
             isExtraLarge={isExtraLarge}
             transaction={transaction}
           />
         </TdSecondary>
-        <TdSecondary
-          className={styles.ColumnSizeAmount}
-          onClick={handleClickCategory}
-        >
+        <TdSecondary className={styles.ColumnSizeAmount}>
           <Figure
             total={transaction.amount || 0}
             symbol={getCurrencySymbol(transaction.currency)}

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.spec.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.spec.jsx
@@ -5,6 +5,8 @@ import AppLike from 'test/AppLike'
 import fixtures from 'test/fixtures'
 import TransactionRowDesktop from './TransactionRowDesktop'
 
+// TransactionRowDesktop is mainly tested via Transactions.spec.jsx
+// This is why this file is so short
 describe('TransactionRowDesktop', () => {
   const setup = () => {
     const transaction = fixtures['io.cozy.bank.operations'][0]

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -24,6 +24,7 @@ import { getDate } from 'ducks/transactions/helpers'
 import useVisible from 'hooks/useVisible'
 import SelectionBar from 'ducks/selection/SelectionBar'
 import { useSelectionContext } from 'ducks/context/SelectionContext'
+import getScrollingElement from './scroll/getScrollingElement'
 
 export const sortByDate = (transactions = []) =>
   sortBy(transactions, getDate).reverse()
@@ -207,7 +208,7 @@ export class TransactionsDumb extends React.Component {
     const {
       breakpoints: { isDesktop }
     } = this.props
-    return isDesktop ? document.querySelector('.js-scrolling-element') : window
+    return getScrollingElement(isDesktop)
   }
 
   render() {

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -138,17 +138,29 @@ describe('Interactions', () => {
   }
 
   describe('Transaction modal', () => {
-    it('should show transaction modal on click on label', async () => {
+    const checkClickOnTextOpensTransactionModal = text => {
       const { root } = setup({
         isDesktop: true,
         transactions: mockTransactions.slice(0, 1)
       })
-      const label = root.getByText('Remboursement Pret Lcl')
+      const node = root.getByText(text)
       expect(root.queryByRole('dialog')).toBeFalsy()
-      fireEvent.click(label)
+      fireEvent.click(node)
       const dialog = root.getByRole('dialog')
       expect(dialog).toBeTruthy()
       expect(within(dialog).getByText('Assigned to Aug 2017'))
+    }
+
+    it('should show transaction modal on click on label', () => {
+      checkClickOnTextOpensTransactionModal('Remboursement Pret Lcl')
+    })
+
+    it('should show transaction modal on click on date', () => {
+      checkClickOnTextOpensTransactionModal('25 Aug 2017')
+    })
+
+    it('should show transaction modal on click on amount', () => {
+      checkClickOnTextOpensTransactionModal('-1,231.00')
     })
   })
 

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -41,6 +41,7 @@ import {
   addMonthToConn,
   makeFilteredTransactionsConn
 } from 'ducks/transactions/queries'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from './scroll/getScrollingElement'
 
 const getMonth = date => date.slice(0, 7)
 
@@ -235,7 +236,7 @@ class TransactionsPage extends Component {
           className={cx(
             styles.TransactionPage__transactions,
             className,
-            'js-scrolling-element'
+            DESKTOP_SCROLLING_ELEMENT_CLASSNAME
           )}
         >
           {flag('banks.future-balance') && showFutureBalance ? (

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -41,7 +41,9 @@ import {
   addMonthToConn,
   makeFilteredTransactionsConn
 } from 'ducks/transactions/queries'
-import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from './scroll/getScrollingElement'
+import getScrollingElement, {
+  DESKTOP_SCROLLING_ELEMENT_CLASSNAME
+} from './scroll/getScrollingElement'
 
 const getMonth = date => date.slice(0, 7)
 
@@ -137,6 +139,12 @@ class TransactionsPage extends Component {
       currentMonth: month
     })
     this.props.onChangeMonth(month)
+
+    const {
+      breakpoints: { isDesktop }
+    } = this.props
+    const scrollingElement = getScrollingElement(isDesktop)
+    scrollingElement.scrollTo({ top: 0 })
   }
 
   renderTransactions() {

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -173,7 +173,6 @@ class TransactionsPage extends Component {
       <TransactionList
         showTriggerErrors={showTriggerErrors}
         onChangeTopMostTransaction={this.handleChangeTopmostTransaction}
-        onScroll={this.checkToActivateTopInfiniteScroll}
         transactions={transactions.data}
         canFetchMore={transactions.hasMore}
         filteringOnAccount={isFilteringOnAccount}

--- a/src/ducks/transactions/scroll/getScrollingElement.jsx
+++ b/src/ducks/transactions/scroll/getScrollingElement.jsx
@@ -1,0 +1,9 @@
+export const DESKTOP_SCROLLING_ELEMENT_CLASSNAME = 'js-scrolling-element'
+
+const getScrollingElement = isDesktop => {
+  return isDesktop
+    ? document.querySelector(`.${DESKTOP_SCROLLING_ELEMENT_CLASSNAME}`)
+    : window
+}
+
+export default getScrollingElement


### PR DESCRIPTION
- Click on transaction row amount/date opens transaction modal

Previously, the categorisation modal was opened. The categorisation
modal should only be opened when the user clicks on the category
icon.


-  When changing month on the transaction list, scroll to the top

Otherwise, if the user has scrolled in the transactions list, she stays at
the current scroll instead of being transported to the latest transaction
of the selected month.

Since when selecting a month, the latest transaction of the selected month
is at the top of the transaction list, we can go the top of the list.

- Put skeleton behavior for balance account rows behind a flag

This had been to improve performance but the behavior is weird. Until
we fix it, deactivate the behavior via a flag.