### PR TITLE
fix: Konnector update infos UI update

### DIFF
--- a/src/components/KonnectorUpdateInfo/index.jsx
+++ b/src/components/KonnectorUpdateInfo/index.jsx
@@ -4,6 +4,9 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import OpenWithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
+import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 
 import CozyClient, { Q, isQueryLoading } from 'cozy-client'
 
@@ -55,31 +58,38 @@ const KonnectorUpdateInfo = () => {
   }
 
   return (
-    <Padded className={styles.KonnectorUpdateInfo}>
-      <Infos
-        className="u-maw-none u-p-1-half"
-        actionButton={
-          <ButtonLink
-            theme="secondary"
-            extension={isMobile ? 'full' : 'narrow'}
-            className="u-mh-0"
-            label={t('KonnectorUpdateInfo.cta')}
-            icon="openwith"
-            href={url}
-          />
-        }
-        title={t('KonnectorUpdateInfo.title')}
-        text={
-          <span
-            dangerouslySetInnerHTML={{
-              __html: t('KonnectorUpdateInfo.content')
-            }}
-          />
-        }
-        icon="warning"
-        isImportant
-      />
-    </Padded>
+    <CozyTheme variant="normal">
+      <Padded className={styles.KonnectorUpdateInfo}>
+        <Infos
+          className="u-ta-left"
+          action={
+            <ButtonLink
+              theme="secondary"
+              extension={isMobile ? 'full' : 'narrow'}
+              className="u-mh-0"
+              label={t('KonnectorUpdateInfo.cta')}
+              icon={OpenWithIcon}
+              href={url}
+            />
+          }
+          description={
+            <>
+              <Typography variant="h5" className="u-error" gutterBottom>
+                {t('KonnectorUpdateInfo.title')}
+              </Typography>
+              <Typography variant="body1">
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: t('KonnectorUpdateInfo.content')
+                  }}
+                />
+              </Typography>
+            </>
+          }
+          isImportant
+        />
+      </Padded>
+    </CozyTheme>
   )
 }
 

--- a/src/components/KonnectorUpdateInfo/index.jsx
+++ b/src/components/KonnectorUpdateInfo/index.jsx
@@ -5,9 +5,10 @@ import Infos from 'cozy-ui/transpiled/react/Infos'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 
-import CozyClient, { useQuery, Q, isQueryLoading } from 'cozy-client'
-import { KONNECTOR_DOCTYPE } from 'doctypes'
+import CozyClient, { Q, isQueryLoading } from 'cozy-client'
 
+import { KONNECTOR_DOCTYPE } from 'doctypes'
+import useFullyLoadedQuery from 'hooks/useFullyLoadedQuery'
 import styles from 'components/KonnectorUpdateInfo/styles.styl'
 import Padded from 'components/Padded'
 import useRedirectionURL from 'hooks/useRedirectionURL'
@@ -37,17 +38,13 @@ const KonnectorUpdateInfo = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const [url] = useRedirectionURL(APP_DOCTYPE, redirectionOptions)
-  const outdatedKonnectors = useQuery(
+  const outdatedKonnectors = useFullyLoadedQuery(
     outdatedKonnectorsConn.query,
     outdatedKonnectorsConn
   )
 
   if (!url || isQueryLoading(outdatedKonnectors)) {
     return null
-  }
-
-  if (outdatedKonnectors.hasMore) {
-    outdatedKonnectors.fetchMore()
   }
 
   const bankingKonnectors = outdatedKonnectors.data.filter(

--- a/src/components/KonnectorUpdateInfo/index.jsx
+++ b/src/components/KonnectorUpdateInfo/index.jsx
@@ -1,12 +1,11 @@
 import React from 'react'
-import compose from 'lodash/flowRight'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Infos from 'cozy-ui/transpiled/react/Infos'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 
-import CozyClient, { queryConnect, Q, isQueryLoading } from 'cozy-client'
+import CozyClient, { useQuery, Q, isQueryLoading } from 'cozy-client'
 import { KONNECTOR_DOCTYPE } from 'doctypes'
 
 import styles from 'components/KonnectorUpdateInfo/styles.styl'
@@ -27,10 +26,21 @@ const redirectionOptions = {
   pendingUpdate: true
 }
 
-const KonnectorUpdateInfo = ({ outdatedKonnectors }) => {
+const outdatedKonnectorsConn = {
+  query: () =>
+    Q(KONNECTOR_DOCTYPE).where({ available_version: { $exists: true } }),
+  fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
+  as: 'outdatedKonnectors'
+}
+
+const KonnectorUpdateInfo = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   const [url] = useRedirectionURL(APP_DOCTYPE, redirectionOptions)
+  const outdatedKonnectors = useQuery(
+    outdatedKonnectorsConn.query,
+    outdatedKonnectorsConn
+  )
 
   if (!url || isQueryLoading(outdatedKonnectors)) {
     return null
@@ -76,16 +86,4 @@ const KonnectorUpdateInfo = ({ outdatedKonnectors }) => {
   )
 }
 
-const outdatedKonnectors = {
-  query: () =>
-    Q(KONNECTOR_DOCTYPE).where({ available_version: { $exists: true } }),
-  fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
-  as: 'outdatedKonnectors'
-}
-
-export default compose(
-  queryConnect({
-    outdatedKonnectors
-  }),
-  React.memo
-)(KonnectorUpdateInfo)
+export default React.memo(KonnectorUpdateInfo)

--- a/src/components/KonnectorUpdateInfo/index.spec.jsx
+++ b/src/components/KonnectorUpdateInfo/index.spec.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import AppLike from 'test/AppLike'
-import KonnectorUpdateInfo from './index'
+import { createMockClient } from 'cozy-client/dist/mock'
 import useRedirectionURL from 'hooks/useRedirectionURL'
+import { KONNECTOR_DOCTYPE, schema } from 'doctypes'
+import KonnectorUpdateInfo from './index'
 
 jest.mock('hooks/useRedirectionURL')
 
@@ -12,9 +14,22 @@ describe('KonnectorUpdateInfo', () => {
   })
 
   const setup = ({ outdatedKonnectors }) => {
+    const client = createMockClient({
+      queries: {
+        outdatedKonnectors: {
+          lastUpdate: new Date(),
+          data: outdatedKonnectors,
+          doctype: KONNECTOR_DOCTYPE,
+          hasMore: false
+        }
+      },
+      clientOptions: {
+        schema
+      }
+    })
     const root = render(
-      <AppLike>
-        <KonnectorUpdateInfo outdatedKonnectors={outdatedKonnectors} />
+      <AppLike client={client}>
+        <KonnectorUpdateInfo />
       </AppLike>
     )
     return { root }
@@ -25,7 +40,13 @@ describe('KonnectorUpdateInfo', () => {
       'http://store.cozy.tools:8080/#/discover/?type=konnector&category=banking&pendingUpdate=true'
     ])
     const { root } = setup({
-      outdatedKonnectors: { data: [{ categories: 'banking' }] }
+      outdatedKonnectors: [
+        {
+          _id: 'io.cozy.konnectors/caissedepargne1',
+          categories: 'banking',
+          slug: 'caissedepargne1'
+        }
+      ]
     })
 
     const link = root.getByText('Update my banks').closest('a')


### PR DESCRIPTION
- Use normal theme
- Reactivate icons that used the string api to load icons
- Use the new API from infos

![konnectorupdate](https://user-images.githubusercontent.com/465582/125762658-f8c84418-1067-47a2-b687-b49cb596c6db.jpg)
