### PR TITLE
feat: Replace cozy-data-* by cozy-data

### DIFF
--- a/src/actions/accounts.spec.js
+++ b/src/actions/accounts.spec.js
@@ -103,8 +103,8 @@ describe('onAccountDelete', () => {
     client.query.mockResolvedValue({
       data: []
     })
-    document.body.innerHTML =
-      '<div role="application" data-cozy-locale="en"></div>'
+    const cozyData = JSON.stringify({ locale: 'en' })
+    document.body.innerHTML = `<div role="application" data-cozy=${cozyData}></div>`
 
     await onAccountDelete(client, 'account-id')
     expect(Alerter.info).toHaveBeenCalled()

--- a/src/ducks/client/web.js
+++ b/src/ducks/client/web.js
@@ -4,6 +4,7 @@ import flag from 'cozy-flags'
 import { schema } from 'doctypes'
 import { getLinks } from 'ducks/client/links'
 import appMetadata from 'ducks/client/appMetadata'
+import parseRootDataset from 'utils/cozyData'
 
 const DEFAULT_URL = 'http://cozy.tools:8080'
 
@@ -12,9 +13,8 @@ const getToken = () => {
   if (!root) {
     return ''
   }
-  const data = root.dataset
-
-  return data.cozyToken
+  const { token } = parseRootDataset(root)
+  return token
 }
 
 const getCozyURI = () => {
@@ -22,10 +22,10 @@ const getCozyURI = () => {
   if (!root) {
     return DEFAULT_URL
   }
-  const data = root.dataset
+  const { domain } = parseRootDataset(root)
   const protocol = window.location.protocol
 
-  return `${protocol}//${data.cozyDomain}`
+  return `${protocol}//${domain}`
 }
 
 export const getClient = () => {

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -57,17 +57,7 @@
 <div
   role="application"
   <% if (__TARGET__ !== 'mobile') { %>
-  data-cozy-token="{{.Token}}"
-  data-cozy-domain="{{.Domain}}"
-  data-cozy-locale="{{.Locale}}"
-  data-cozy-app-name="{{.AppName}}"
-  data-cozy-app-name-prefix="{{.AppNamePrefix}}"
-  data-cozy-app-editor="{{.AppEditor}}"
-  data-cozy-icon-path="{{.IconPath}}"
-  data-cozy-tracking="{{.Tracking}}"
-  data-cozy-app-slug="{{.AppSlug}}"
-  data-cozy-subdomain-type="{{.SubDomain}}"
-  data-cozy-flags="{{.Flags}}"
+  data-cozy="{{.CozyData}}"
   <% } %>
 ></div>
 <% if (__TARGET__ === 'mobile') { %>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -39,6 +39,7 @@ import cozyBar from 'utils/cozyBar'
 import { getLanguageFromDOM } from 'utils/lang'
 
 import './logger'
+import parseCozyData from 'utils/cozyData'
 
 if (__TARGET__ === 'mobile') {
   require('styles/mobile.styl')
@@ -62,7 +63,10 @@ const initRender = () => {
 
 const setupApp = async persistedState => {
   const root = document.querySelector('[role=application]')
-  const data = root.dataset
+  const {
+    app: { icon, name },
+    locale
+  } = parseCozyData(root)
   lang = getLanguageFromDOM(root)
 
   setupD3Locale(lang)
@@ -115,10 +119,10 @@ const setupApp = async persistedState => {
   if (__TARGET__ !== 'mobile') {
     !flag('authentication') &&
       cozyBar.init({
-        appName: data.cozyAppName,
+        appName: name,
         cozyClient: client,
-        iconPath: data.cozyIconPath,
-        lang: data.cozyLocale,
+        iconPath: icon,
+        lang: locale,
         replaceTitleOnMobile: true
       })
   } else {

--- a/src/utils/cozyData.js
+++ b/src/utils/cozyData.js
@@ -1,0 +1,2 @@
+const parseCozyData = root => JSON.parse(root.dataset.cozy)
+export default parseCozyData

--- a/src/utils/lang.jsx
+++ b/src/utils/lang.jsx
@@ -3,14 +3,15 @@
 import en from 'locales/en.json'
 import fr from 'locales/fr.json'
 import Polyglot from 'node-polyglot'
+import parseCozyData from 'utils/cozyData'
 const locales = { en, fr }
 
 export const getLanguageFromDOM = rootOption => {
   const root = rootOption || document.querySelector('[role=application]')
-  const data = root.dataset
+  const { locale } = parseCozyData(root)
   return __TARGET__ === 'mobile' && navigator && navigator.language
     ? navigator.language.slice(0, 2)
-    : data.cozyLocale || 'en'
+    : locale || 'en'
 }
 
 /**


### PR DESCRIPTION
Utiliser `data-cozy="{{.CozyData}}"` dans le template plutôt que de lister chaque attribut manuellement :

```
data-cozy-token="{{.Token}}"
data-cozy-domain="{{.Domain}}"
data-cozy-xxx="{{.XXX}}"
...
```

Ceci afin de permettre l'utilisation des nouvelles variables injectées par la stack, sans avoir besoin de mettre l'app à jour.