### PR TITLE
Fix/add test case

### DIFF
--- a/src/ducks/recurrence/fixtures/fixtures6.json
+++ b/src/ducks/recurrence/fixtures/fixtures6.json
@@ -1,0 +1,58 @@
+{
+  "io.cozy.bank.operations": [
+    {
+      "_id": "february",
+      "account": "1d22740c6c510e5368d1b6b670deee05",
+      "amount": 30,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2021-02-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "EDF",
+      "localCategoryId": "0",
+      "localCategoryProba": 0.1,
+      "metadata": {
+        "dateImport": "2021-02-01T05:36:26.028Z",
+        "vendor": "budget-insight",
+        "version": 1
+      },
+      "originalBankLabel": "EDF",
+      "rawDate": "2021-02-01",
+      "realisationDate": "2021-02-01T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "61906",
+      "vendorId": 9475793
+    },
+    {
+      "_id": "may",
+      "account": "1d22740c6c510e5368d1b6b670deee05",
+      "amount": 30,
+      "automaticCategoryId": "401080",
+      "currency": "EUR",
+      "date": "2021-05-01T12:00:00.000Z",
+      "deleted": null,
+      "isActive": true,
+      "isComing": false,
+      "label": "EDF",
+      "localCategoryId": "0",
+      "localCategoryProba": 0.1,
+      "metadata": {
+        "dateImport": "2021-05-01T05:36:26.028Z",
+        "vendor": "budget-insight",
+        "version": 1
+      },
+      "originalBankLabel": "EDF",
+      "rawDate": "2021-05-01",
+      "realisationDate": "2021-05-01T12:00:00.000Z",
+      "sourceCategoryId": 9998,
+      "toCategorize": false,
+      "valueDate": null,
+      "vendorAccountId": "61906",
+      "vendorId": 9475793
+    }
+  ]
+}

--- a/src/ducks/recurrence/search.spec.js
+++ b/src/ducks/recurrence/search.spec.js
@@ -16,8 +16,7 @@ import fixtures3 from './fixtures/fixtures3.json'
 import fixtures4 from './fixtures/fixtures4.json'
 import fixtures5 from './fixtures/fixtures5.json'
 import fixtures6 from './fixtures/fixtures6.json'
-import Polyglot from 'node-polyglot'
-import enLocale from 'locales/en.json'
+import { getT, enLocaleOption } from 'utils/lang'
 
 const formatBundleExtent = bundle => {
   const oldestOp = minBy(bundle.ops, x => x.date)
@@ -377,13 +376,10 @@ describe('recurrence scenario with 01 feb, march and april are to categorize (0)
       [mayTransactionEDF]
     )
 
-    const polyglot = new Polyglot()
-    polyglot.extend(enLocale)
-    const t = polyglot.t.bind(polyglot)
-
     const bundle = bundleWithEDF[0]
     expect(bundle.ops.length).toBe(2)
 
+    const t = getT(enLocaleOption)
     expect(getFrequencyText(t, bundle)).toBe('every month')
     const [op1, op2] = bundle.ops
     expect(op1._id).toBe('february')

--- a/src/ducks/reimbursements/Reimbursements.spec.jsx
+++ b/src/ducks/reimbursements/Reimbursements.spec.jsx
@@ -2,12 +2,11 @@ import React from 'react'
 import { DumbReimbursements } from './Reimbursements'
 import fixtures from 'test/fixtures/unit-tests.json'
 import AppLike from 'test/AppLike'
-import Polyglot from 'node-polyglot'
-import en from 'locales/en'
 import format from 'date-fns/format'
 import { createMockClient } from 'cozy-client'
 import { render } from '@testing-library/react'
 import { getCategoryIdFromName } from 'ducks/categories/helpers'
+import { getT, enLocaleOption } from 'utils/lang'
 
 // Mock useVisible so that it considers all element as visible in the
 // viewport (IntersectionObserver not available during tests)
@@ -19,13 +18,10 @@ jest.mock('hooks/useRedirectionURL', () => {
   return () => ['https://cozy.tools:8080', () => {}]
 })
 
-const polyglot = new Polyglot()
-polyglot.extend(en)
-
 describe('Reimbursements', () => {
   const baseProps = {
     fetchStatus: 'loaded',
-    t: polyglot.t.bind(polyglot),
+    t: getT(enLocaleOption),
     f: format,
     triggers: { fetchStatus: 'loaded' },
     transactions: { fetchStatus: 'loaded' },

--- a/src/ducks/transactions/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal.spec.jsx
@@ -2,8 +2,6 @@ import React from 'react'
 import { render, fireEvent, within } from '@testing-library/react'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { format } from 'date-fns'
-import Polyglot from 'node-polyglot'
-import en from 'locales/en.json'
 
 import AppLike from 'test/AppLike'
 import { createClientWithData } from 'test/client'
@@ -15,6 +13,7 @@ import TransactionModal, {
   showAlertAfterApplicationDateUpdate
 } from './TransactionModal'
 import data from '../../../test/fixtures'
+import { getT, enLocaleOption } from 'utils/lang'
 
 jest.mock('ducks/tracking/tracker', () => {
   const tracker = {
@@ -137,9 +136,7 @@ describe('transaction modal', () => {
 })
 
 describe('change application date alert', () => {
-  const p = new Polyglot()
-  p.extend(en)
-  const t = p.t.bind(p)
+  const t = getT(enLocaleOption)
 
   beforeEach(() => {
     Alerter.success.mockReset()

--- a/src/ducks/transactions/TransactionRecurrenceEditor.spec.jsx
+++ b/src/ducks/transactions/TransactionRecurrenceEditor.spec.jsx
@@ -2,14 +2,12 @@ import keyBy from 'lodash/keyBy'
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { mount } from 'enzyme'
-import Polyglot from 'node-polyglot'
 
 import { createMockClient } from 'cozy-client/dist/mock'
 import { findOptions } from 'cozy-ui/transpiled/react/NestedSelect/testing'
 
 import AppLike from 'test/AppLike'
 import fixtures from 'test/fixtures/unit-tests.json'
-import enLocale from 'locales/en.json'
 import {
   schema,
   TRANSACTION_DOCTYPE,
@@ -20,13 +18,12 @@ import {
 import TransactionRecurrenceEditor, {
   makeOptionFromRecurrence
 } from './TransactionRecurrenceEditor'
+import { getT, enLocaleOption } from 'utils/lang'
 
 describe('makeOptionFromRecurrence', () => {
   it('should work', () => {
     const accountsById = keyBy(fixtures[ACCOUNT_DOCTYPE], x => x._id)
-    const polyglot = new Polyglot()
-    polyglot.extend(enLocale)
-    const t = polyglot.t.bind(polyglot)
+    const t = getT(enLocaleOption)
     const option = makeOptionFromRecurrence(
       fixtures[RECURRENCE_DOCTYPE][0],
       t,

--- a/src/utils/lang.jsx
+++ b/src/utils/lang.jsx
@@ -20,11 +20,15 @@ export const getLanguageFromDOM = rootOption => {
  * To be used when not in React context, in React
  * context, the t function comes from the context
  */
-export const getT = () => {
-  const lang = getLanguageFromDOM()
+export const getT = option => {
+  const lang = getLanguageFromDOM(option)
   const polyglot = new Polyglot({
     lang: lang,
     phrases: locales[lang]
   })
   return polyglot.t.bind(polyglot)
+}
+
+export const enLocaleOption = {
+  dataset: { cozy: JSON.stringify({ locale: 'en' }) }
 }


### PR DESCRIPTION
- Add test case to check frequency in this case
The objective is to check that the new operation (mayTransaction) has been 
attached to the bundle and that this frequency remains "each month" after the recurrency service is passed.

- refactor: use getT(option) instead of new Polyglot
Allows to facilitate the recovery of t during the
tests