### PR TITLE
fix: Crash on mobile version

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -63,10 +63,6 @@ const initRender = () => {
 
 const setupApp = async persistedState => {
   const root = document.querySelector('[role=application]')
-  const {
-    app: { icon, name },
-    locale
-  } = parseCozyData(root)
   lang = getLanguageFromDOM(root)
 
   setupD3Locale(lang)
@@ -117,6 +113,10 @@ const setupApp = async persistedState => {
   persistState(store)
 
   if (__TARGET__ !== 'mobile') {
+    const {
+      app: { icon, name },
+      locale
+    } = parseCozyData(root)
     !flag('authentication') &&
       cozyBar.init({
         appName: name,

--- a/src/utils/lang.jsx
+++ b/src/utils/lang.jsx
@@ -7,11 +7,12 @@ import parseCozyData from 'utils/cozyData'
 const locales = { en, fr }
 
 export const getLanguageFromDOM = rootOption => {
+  if (__TARGET__ === 'mobile' && navigator && navigator.language) {
+    return navigator.language.slice(0, 2)
+  }
+
   const root = rootOption || document.querySelector('[role=application]')
-  const { locale } = parseCozyData(root)
-  return __TARGET__ === 'mobile' && navigator && navigator.language
-    ? navigator.language.slice(0, 2)
-    : locale || 'en'
+  return root?.dataset?.cozy ? parseCozyData(root).locale : 'en'
 }
 
 /**

--- a/src/utils/lang.spec.jsx
+++ b/src/utils/lang.spec.jsx
@@ -1,0 +1,16 @@
+import { getLanguageFromDOM } from './lang'
+
+describe('lang', () => {
+  it('should return "en" locale as a default', () => {
+    const lang = getLanguageFromDOM()
+    expect(lang).toEqual('en')
+  })
+
+  it('should rely on the data-cozy field if it exists', () => {
+    const cozyData = JSON.stringify({ locale: 'fr' })
+    document.body.innerHTML = `<div role="application" data-cozy=${cozyData}></div>`
+
+    const lang = getLanguageFromDOM()
+    expect(lang).toEqual('fr')
+  })
+})


### PR DESCRIPTION
Fix [issue #2181](https://github.com/cozy/cozy-banks/issues/2181)

In mobile version we don’t have dataset and so we
can’t parse this data.
Now we check root.data.cozy value before
to parse it.