### PR TITLE
fix: Disables selection mode when leaving an account page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Remove balance from transaction header
 * Add checkbox icon button to activate selection mode in transactions page and search page
-* Improve improve ui for no result in search page
+* Improve ui for no result in search page
 * Update cozy-ui to 51.4.0
 * Update cozy-harvest-lib to 6.4.0
 * Recategorizing several transactions is faster
@@ -14,6 +14,7 @@
 
 * Checkbox horizontal position for selectionning rows in desktop
 * Hide owner field in account configuration when Contacts app is not installed
+* Deactivates selection mode when leaving an account page
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/Transactions.jsx
+++ b/src/ducks/transactions/Transactions.jsx
@@ -169,8 +169,8 @@ export class TransactionsDumb extends React.Component {
   }
 
   componentWillUnmount() {
-    const { emptySelection } = this.props
-    emptySelection()
+    const { emptyAndDeactivateSelection } = this.props
+    emptyAndDeactivateSelection()
   }
 
   updateTransactions(transactions) {
@@ -260,11 +260,12 @@ TransactionsDumb.defaultProps = {
 }
 
 export const TransactionList = props => {
-  const { emptySelection } = useSelectionContext()
+  const { emptyAndDeactivateSelection } = useSelectionContext()
   const breakpoints = useBreakpoints()
+
   return (
     <TransactionsDumb
-      emptySelection={emptySelection}
+      emptyAndDeactivateSelection={emptyAndDeactivateSelection}
       breakpoints={breakpoints}
       {...props}
     />

--- a/src/ducks/transactions/Transactions.spec.jsx
+++ b/src/ducks/transactions/Transactions.spec.jsx
@@ -131,7 +131,7 @@ describe('Interactions', () => {
           breakpoints={{ isDesktop: false }}
           transactions={transactions}
           showTriggerErrors={false}
-          emptySelection={() => null}
+          emptyAndDeactivateSelection={() => null}
         />
       </AppLike>
     )


### PR DESCRIPTION
A la première implémentation de la feature, on ne pouvait pas simplement activer le mode Selection sans avoir de transaction sélectionnées. Il fallait sélectionner une transaction pour activer le mode. Donc le fait de vider les sélections suffisait à désactiver le mode Sélection. Ce n'est plus le cas maintenant puisque nous avons un bouton sur mobile qui permet d'activer le mode Sélection, sans pour autant sélectionner de transaction.