### PR TITLE
fix: First transactions are no longer trimmed on the balance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Checkbox horizontal position for selectionning rows in desktop
 * Hide owner field in account configuration when Contacts app is not installed
 * Deactivates selection mode when leaving an account page
+* First transactions are no longer trimmed on the balance page on tablet
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -59,7 +59,7 @@ const updateListStyle = (listRef, headerRef) => {
   // eslint-disable-next-line
   const listNode = ReactDOM.findDOMNode(listRef)
 
-  if (document.body.getBoundingClientRect().width < 768) {
+  if (document.body.getBoundingClientRect().width < 1024) {
     listNode.style.paddingTop = headerNode.getBoundingClientRect().height + 'px'
   } else {
     listNode.style.paddingTop = 0


### PR DESCRIPTION
on tablet

**Before**
![image](https://user-images.githubusercontent.com/67680939/128364481-ea416896-4ea0-4174-8bca-97399a097758.png)

**After**
![image](https://user-images.githubusercontent.com/67680939/128364583-65db77c0-5c7f-459d-bfa5-70d7a4b46725.png)
