### PR TITLE
fix: Missing colors for categories in the chart on the analysis page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Hide owner field in account configuration when Contacts app is not installed
 * Deactivates selection mode when leaving an account page
 * First transactions are no longer trimmed on the balance page on tablet
+* Missing colors for categories in the chart on the analysis page
 
 ## 🔧 Tech
 

--- a/src/ducks/categories/colors.js
+++ b/src/ducks/categories/colors.js
@@ -2,7 +2,8 @@ import isNode from 'detect-node'
 import palette from 'cozy-ui/transpiled/react/palette'
 import { getCssVariableValue } from 'cozy-ui/transpiled/react/utils/color'
 
-const getColor = color => (isNode ? palette[color] : getCssVariableValue(color))
+const getColor = color =>
+  isNode ? palette[color] : getCssVariableValue(color) || palette[color]
 
 export default {
   kids: getColor('azure'),


### PR DESCRIPTION
Since v49.0.0 of cozy-ui we removed some css variable colors so in that case we fallback to the palette