### PR TITLE
fix: Analysis page retrieves information when viewing all accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Deactivates selection mode when leaving an account page
 * First transactions are no longer trimmed on the balance page on tablet
 * Missing colors for categories in the chart on the analysis page
+* The analysis page correctly retrieves information when viewing all accounts
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -146,8 +146,8 @@ export const addPeriodToConn = (baseConn, period) => {
         baseQuery.selector
       )
     )
-    .indexFields(['date', 'account'])
-    .sortBy([{ date: 'desc' }, { account: 'desc' }])
+    .indexFields(baseQuery.indexedFields || ['date', 'account'])
+    .sortBy(baseQuery.sort || [{ date: 'desc' }, { account: 'desc' }])
     .limitBy(500)
   const as = `${baseAs}-${format(startDate, 'YYYY-MM')}-${format(
     endDate,

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -236,4 +236,38 @@ describe('addPeriodToConn', () => {
       })
     )
   })
+
+  it('should use _id selector instead of account for null filteringDoc', () => {
+    const conn1 = makeFilteredTransactionsConn({
+      groups: {
+        lastUpdate: Date.now(),
+        data: [
+          {
+            _id: 'g1',
+            accounts: {
+              raw: ['a1', 'a2', 'a3']
+            }
+          }
+        ]
+      },
+      accounts: {
+        lastUpdate: Date.now()
+      },
+      filteringDoc: null
+    })
+    const conn2 = addPeriodToConn(conn1, '2021-07')
+
+    expect(conn2.query).toEqual(
+      expect.objectContaining({
+        selector: {
+          _id: { $gt: null },
+          date: {
+            $gte: '2021-07-01T00:00',
+            $lte: '2021-07-31T23:59'
+          }
+        },
+        indexedFields: ['date', '_id']
+      })
+    )
+  })
 })


### PR DESCRIPTION
Sur la page d'analyse pour tous les comptes, `filteringDoc` est null et dans ce cas on devrait indexer les doc selon la date et l'id puisque c'est la requête que retourne le "constructeur de requête" `makeFilteredTransactionsConn`. Sauf que les selector sont forcés en dur sur la date et l'account dans la fonction d'ajout de période `addPeriodToConn`.

Ce qui déclenche une erreur sur mobile au niveau des selecteurs.

Je ne sais pas pourquoi il n'y a pas le souci sur browser, mais à la lecture du code (d'ailleurs pour les autres fonction qui ajout des infos à la définition de la requête on récupère bien les selectors de la requête initiale) et de l'erreur ce fix reste pertinent.