### PR TITLE
fix: Updating settings now create or update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * The analysis page correctly retrieves information when viewing all accounts
 * Prevent render loop after login if a pin had been set
 * Render pin setting row in configuration even when no pin has been set yet
+* Autogroups and LinkMyselfToAccount services crashed if configuration settings had not been saved yet
 
 ## 🔧 Tech
 

--- a/src/ducks/account/services.js
+++ b/src/ducks/account/services.js
@@ -1,5 +1,5 @@
 import logger from 'cozy-logger'
-import { updateSettings, fetchSettings } from 'ducks/settings/helpers'
+import { fetchSettings } from 'ducks/settings/helpers'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 import get from 'lodash/get'
 import set from 'lodash/set'
@@ -63,7 +63,7 @@ export const linkMyselfToAccounts = async ({ client }) => {
   settings.linkMyselfToAccounts.processedAccounts = Array.from(
     mergeSets(alreadyProcessed, processedAccounts)
   )
-  await updateSettings(client, settings)
+  await client.save(settings)
 
   log('info', `Linked ${accountsToProcess.length} accounts to myself`)
 }
@@ -94,7 +94,7 @@ export const unlinkMyselfFromAccounts = async ({ client }) => {
 
   const settings = await fetchSettings(client)
   settings.linkMyselfToAccounts.processedAccounts = []
-  await updateSettings(client, settings)
+  await client.save(settings)
 
   log('info', 'Unlinked all accounts from myself')
 }

--- a/src/ducks/groups/services.js
+++ b/src/ducks/groups/services.js
@@ -2,7 +2,7 @@ import logger from 'cozy-logger'
 import omit from 'lodash/omit'
 import keyBy from 'lodash/keyBy'
 import difference from 'lodash/difference'
-import { updateSettings, fetchSettings } from 'ducks/settings/helpers'
+import { fetchSettings } from 'ducks/settings/helpers'
 import mergeSets from 'utils/mergeSets'
 
 import { GROUP_DOCTYPE, ACCOUNT_DOCTYPE } from 'doctypes'
@@ -105,7 +105,7 @@ export const createAutoGroups = async ({ client }) => {
   settings.autogroups.processedAccounts = Array.from(
     mergeSets(alreadyProcessed, processedAccounts)
   )
-  await updateSettings(client, settings)
+  await client.save(settings)
 }
 
 export const listAutoGroups = async ({ client }) => {

--- a/src/ducks/groups/services.spec.js
+++ b/src/ducks/groups/services.spec.js
@@ -78,7 +78,7 @@ describe('createAutoGroups', () => {
       expect(settings.autogroups.processedAccounts).toEqual(['a1', 'a2'])
 
       // Due to account deduplication
-      expect(client.save).toHaveBeenCalledTimes(2)
+      expect(client.save).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/src/ducks/settings/helpers.js
+++ b/src/ducks/settings/helpers.js
@@ -48,11 +48,6 @@ export const fetchSettings = async client => {
   return getDefaultedSettingsFromCollection(settingsCol)
 }
 
-export const updateSettings = async (client, newSettings) => {
-  const col = client.collection(DOCTYPE)
-  await col.update(newSettings)
-}
-
 export const reverseIndex = (items, getKeys) => {
   const ri = {}
   for (const item of items) {
@@ -143,7 +138,7 @@ export const fetchCategoryAlerts = async client => {
 export const updateCategoryAlerts = async (client, updatedAlerts) => {
   const settings = await fetchSettings(client)
   settings.categoryBudgetAlerts = updatedAlerts
-  return updateSettings(client, settings)
+  return client.save(settings)
 }
 
 export const getAccountOrGroupLabel = (accountOrGroup, t) => {


### PR DESCRIPTION
Update or create settings depend if settings has _rev prop or not
should fix autogroups and linkMyselfToAccounts services

Avant on faisait `client.collection(doctype).update(newSettings)` un qui retournait `Bad Request(400): You must either provide an _id and _rev in document (update) or neither (create with fixed id).' }` lorsque le doc `io.cozy.bank.settings.configuration` était `undefined` (donc pas encore créé). Dans ce cas là il ne faut donc pas faire une `update` mais un `create`. `client.save()` s'occupe de ça pour nous.