### PR TITLE
fix: Prevent loop refresh due to lack of fetch policy on query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * First transactions are no longer trimmed on the balance page on tablet
 * Missing colors for categories in the chart on the analysis page
 * The analysis page correctly retrieves information when viewing all accounts
+* Prevent render loop after login if a pin had been set
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 * Missing colors for categories in the chart on the analysis page
 * The analysis page correctly retrieves information when viewing all accounts
 * Prevent render loop after login if a pin had been set
-* Renderr pin setting row in configuration even when no pin has been set yet
+* Render pin setting row in configuration even when no pin has been set yet
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Missing colors for categories in the chart on the analysis page
 * The analysis page correctly retrieves information when viewing all accounts
 * Prevent render loop after login if a pin had been set
+* Renderr pin setting row in configuration even when no pin has been set yet
 
 ## 🔧 Tech
 

--- a/src/components/LogoutModal/LogoutModal.jsx
+++ b/src/components/LogoutModal/LogoutModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import Typography from 'cozy-ui/transpiled/react/Typography'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 function LogoutModal() {
@@ -10,10 +11,10 @@ function LogoutModal() {
     <Dialog
       open
       content={
-        <>
+        <div className="u-ta-center u-pt-3">
           <Spinner size="xxlarge" />
-          <p>{t('LogoutModal.message')}</p>
-        </>
+          <Typography variant="body1">{t('LogoutModal.message')}</Typography>
+        </div>
       }
     />
   )

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -224,6 +224,7 @@ export const makeBalanceTransactionsConn = () => {
   const fromDate = format(subYears(new Date(), 1), 'YYYY-MM-DD')
   return {
     as: 'home/transactions',
+    fetchPolicy: older30s,
     query: () =>
       Q(TRANSACTION_DOCTYPE)
         .limitBy(1000)

--- a/src/ducks/context/BanksContext.jsx
+++ b/src/ducks/context/BanksContext.jsx
@@ -7,7 +7,7 @@ import React, {
   useState
 } from 'react'
 import PropTypes from 'prop-types'
-import { Q } from 'cozy-client'
+import CozyClient, { Q } from 'cozy-client'
 import { KONNECTOR_DOCTYPE } from 'doctypes'
 import { useJobsContext } from 'ducks/context/JobsContext'
 import { isBankKonnector } from 'utils/triggers'
@@ -44,7 +44,10 @@ const BanksProvider = ({ children, client }) => {
           const slug = jobsInProgress.konnector
           return `${KONNECTOR_DOCTYPE}/${slug}`
         })
-        const resp = await client.query(Q(KONNECTOR_DOCTYPE).getByIds(ids))
+        const resp = await client.query(Q(KONNECTOR_DOCTYPE).getByIds(ids), {
+          as: 'io.cozy.konnectors/in-progress',
+          fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+        })
         const newJobInProgress = resp.data.map(konnector => {
           const slug = konnector.slug
           const jobInProgress = jobsInProgress.find(j => j.konnector === slug)

--- a/src/ducks/pin/queries.js
+++ b/src/ducks/pin/queries.js
@@ -1,13 +1,7 @@
 import { SETTINGS_DOCTYPE } from 'doctypes'
 import { connect } from 'react-redux'
 import mapValues from 'lodash/mapValues'
-import { Q, getDocumentFromState } from 'cozy-client'
-
-const getOne = (doctype, id) => () => {
-  const queryDef = Q(doctype)
-  queryDef.id = id
-  return queryDef
-}
+import CozyClient, { Q, getDocumentFromState } from 'cozy-client'
 
 export const pinIdentity = {
   doctype: SETTINGS_DOCTYPE,
@@ -15,7 +9,9 @@ export const pinIdentity = {
 }
 
 export const pinSetting = {
-  query: getOne(pinIdentity.doctype, pinIdentity.id)
+  query: Q(pinIdentity.doctype).getById(pinIdentity.id),
+  fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000),
+  as: 'io.cozy.bank.settings/pin'
 }
 
 /**

--- a/src/ducks/settings/PinSettings.jsx
+++ b/src/ducks/settings/PinSettings.jsx
@@ -61,16 +61,13 @@ class PinSettings extends React.Component {
   render() {
     const { pinSetting, t } = this.props
     const pinDoc = pinSetting.data
-    if (!pinDoc) {
-      return null
-    }
     return (
       <React.Fragment>
         <ToggleRow
           title={t('Pin.settings.toggle-title')}
           description={t('Pin.settings.toggle-description')}
           onToggle={this.handleToggle}
-          enabled={Boolean(pinDoc.pin)}
+          enabled={pinDoc ? Boolean(pinDoc.pin) : false}
           name="pin-doc"
         />
         {this.state.togglingOn ? (

--- a/src/ducks/settings/PinSettings.spec.jsx
+++ b/src/ducks/settings/PinSettings.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import CozyClient from 'cozy-client'
+import { render, act } from '@testing-library/react'
+import AppLike from 'test/AppLike'
+import PinSettings from './PinSettings'
+
+const getCheckbox = root => {
+  const container = root.getByLabelText(
+    'Lock my app with a pin code or a fingerprint. Unlocking will be required after 1 minute of inactivity.'
+  )
+  return container.querySelector('input')
+}
+
+describe('PinSettings', () => {
+  const setup = async ({ pinDoc }) => {
+    const client = new CozyClient()
+    client.stackClient.fetchJSON = async (method, route) => {
+      if (method === 'GET' && route === '/data/io.cozy.bank.settings/pin') {
+        if (pinDoc) {
+          return pinDoc
+        } else {
+          throw new Error('not_found')
+        }
+      } else {
+        throw new Error('Unsupported route for mocked fetchJSON')
+      }
+    }
+    const root = render(
+      <AppLike client={client}>
+        <PinSettings />
+      </AppLike>
+    )
+
+    // Wait for queries to be resolved
+    await act(async () => {})
+
+    return { root }
+  }
+
+  it('should render an unchecked switch by default', async () => {
+    const { root } = await setup({
+      pinDoc: null
+    })
+    expect(getCheckbox(root).checked).toBe(false)
+  })
+
+  it('should render a checked switch by default', async () => {
+    const { root } = await setup({
+      pinDoc: { _id: 'pin', pin: '1234' }
+    })
+    expect(getCheckbox(root).checked).toBe(true)
+  })
+
+  it('should render an unchecked switch if pin has been removed', async () => {
+    const { root } = await setup({
+      pinDoc: { _id: 'pin' }
+    })
+    expect(getCheckbox(root).checked).toBe(false)
+  })
+})

--- a/src/ducks/settings/ToggleRow.jsx
+++ b/src/ducks/settings/ToggleRow.jsx
@@ -38,6 +38,7 @@ const ToggleRow = ({ enabled, description, onToggle }) => {
         color="primary"
         onClick={e => e.stopPropagation()}
         onChange={() => onToggle(!enabled)}
+        aria-label={description}
       />
     </ToggleRowContent>
   )


### PR DESCRIPTION
A render loop was happening since the pin doc was fetched over and over
after login. If we set a fetch policy, we no longer have a problem since
the pin will not be refetched if it has been less 30s that it has been
fetched.

Also smaller fixes/features:

- Better logout page
- No pin setting rendered if pin had not yet been saved
- Add fetch policies for other queries