### PR TITLE
feat: Add OCS Brand

### DIFF
--- a/src/ducks/brandDictionary/brands.json
+++ b/src/ducks/brandDictionary/brands.json
@@ -359,6 +359,10 @@
     "maintenance": true
   },
   {
+    "name": "OCS",
+    "regexp": "\\bocs\\b"
+  },
+  {
     "name": "Opngo",
     "regexp": "\\bopngo\\b",
     "konnectorSlug": "opngo"


### PR DESCRIPTION
Allows to match OCS operations by the brand dictionnary (especially in the recurrence service).