### PR TITLE
fix: Remove key field (not used)

### DIFF
--- a/src/ducks/recurrence/rules.spec.js
+++ b/src/ducks/recurrence/rules.spec.js
@@ -147,7 +147,6 @@ describe('make stats', () => {
   const makeBundle = ops => ({
     categoryIds: ['200110'],
     amounts: [2000, 2150],
-    key: '200110/2000',
     ops,
     automaticLabel: 'Mon Salaire'
   })

--- a/src/ducks/recurrence/search.js
+++ b/src/ducks/recurrence/search.js
@@ -47,7 +47,6 @@ export const findRecurrences = (operations, rules) => {
     return Object.entries(perAmount).map(([amount, ops]) => ({
       categoryIds: [categoryId],
       amounts: [parseInt(amount, 10)],
-      key: `${categoryId}/${amount}`,
       ops,
       automaticLabel: getLabel(ops[0])
     }))

--- a/src/ducks/recurrence/search.spec.js
+++ b/src/ducks/recurrence/search.spec.js
@@ -139,7 +139,6 @@ describe('recurrence scenario with all operations which have a subcategory', () 
     categoryIds: ['200110'],
     amounts: [2000, 2150],
     accounts: ['1d22740c6c510e5368d1b6b670deee05'],
-    key: '200110/2000',
     ops: [...transactions, mayTransaction],
     automaticLabel: 'Mon Salaire'
   }
@@ -238,7 +237,6 @@ describe('recurrence scenario with all operations which have a subcategory', () 
       categoryIds: ['400100'],
       amounts: [10],
       accounts: ['1d22740c6c510e5368d1b6b670deee05'],
-      key: '400100/10',
       ops: [juneSpot],
       automaticLabel: 'Spotify Abonnement'
     }
@@ -292,7 +290,6 @@ describe('recurrence scenario with 01 feb, march and april are to categorize (0)
     categoryIds: ['0', '200110'],
     amounts: [2000, 2150],
     accounts: ['1d22740c6c510e5368d1b6b670deee05'],
-    key: '200110/2000',
     ops: [...transactions, mayTransaction],
     automaticLabel: 'Mon Salaire'
   }
@@ -366,7 +363,6 @@ describe('recurrence scenario with 01 feb, march and april are to categorize (0)
       categoryIds: ['401080'],
       amounts: [30],
       accounts: ['1d22740c6c510e5368d1b6b670deee05'],
-      key: '401080/30',
       ops: [febTransactionEDF],
       automaticLabel: 'EDF'
     }


### PR DESCRIPTION
After looking in the app and in the services. We notice that the key field is not used.

The field is now deleted