### PR TITLE
fix: Recurrence median function returns the correct number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Prevent render loop after login if a pin had been set
 * Render pin setting row in configuration even when no pin has been set yet
 * Autogroups and LinkMyselfToAccount services crashed if configuration settings had not been saved yet
+* Median function in Recurrence returns the correct median
 
 ## 🔧 Tech
 

--- a/src/ducks/recurrence/__snapshots__/search.spec.js.snap
+++ b/src/ducks/recurrence/__snapshots__/search.spec.js.snap
@@ -9,7 +9,7 @@ exports[`recurrence bundles should find new bundles 1`] = `
 "Cozy Cloud                                         |    3963.13 |      3 operations |  from 2018-06-01 to 2018-09-28 |    59.5
 Echeance Pret 03103 61893938                       |   -1281.82 |     11 operations |  from 2019-03-05 to 2020-01-06 |      31
 Edf Clients Particuliers                           |      -36.6 |     11 operations |  from 2018-08-24 to 2019-06-24 |      31
-Free Mobile                                        |     -17.99 |     15 operations |  from 2018-05-22 to 2020-01-20 |      30
+Free Mobile                                        |     -17.99 |     15 operations |  from 2018-05-22 to 2020-01-20 |    31.5
 Free Telecom                                       |     -31.98 |     20 operations |  from 2018-05-07 to 2020-02-06 |      30
 Navigo Annuel Gie Comutitres                       |      -75.2 |     20 operations |  from 2018-06-04 to 2020-03-03 |      31
 Paypal Europe S A R L Et Cie S C A Ech             |     -13.99 |      4 operations |  from 2018-05-29 to 2018-10-30 |      32

--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -18,8 +18,8 @@ import { findMatchingBrand } from 'ducks/brandDictionary'
 const ONE_DAY = 86400 * 1000
 
 const mean = iterable => sum(iterable) / iterable.length
-const median = iterable => {
-  const sorted = [...iterable].sort()
+export const median = iterable => {
+  const sorted = sortBy([...iterable])
   if (sorted.length % 2 == 0) {
     const mid = sorted.length / 2
     return (sorted[mid - 1] + sorted[mid]) / 2

--- a/src/ducks/recurrence/rules.spec.js
+++ b/src/ducks/recurrence/rules.spec.js
@@ -3,7 +3,8 @@ import {
   mergeCategoryIds,
   sameLabel,
   brandSplit,
-  addStats
+  addStats,
+  median
 } from './rules'
 import keyBy from 'lodash/keyBy'
 import fixtures4 from './fixtures/fixtures4.json'
@@ -171,5 +172,19 @@ describe('make stats', () => {
     expect(mean).toBe(NaN)
     expect(median).toBe(30)
     expect(mad).toBe(NaN)
+  })
+})
+
+describe('median', () => {
+  it('should return the correct median', () => {
+    // for an even number of elements
+    expect(median([64, 120, 27, 1])).toBe(45.5)
+    expect(median([1, 36, 8, 200, 72, 43])).toBe(39.5)
+    expect(median([12, 10, 8, 6])).toBe(9)
+    expect(median([900, 0])).toBe(450)
+    // for an odd number of elements
+    expect(median([100, 1, 10])).toBe(10)
+    expect(median([2, 22, 222])).toBe(22)
+    expect(median([0, 1, 1, 120, 2, 22, 27, 312, 3])).toBe(3)
   })
 })


### PR DESCRIPTION
Median used Array.sort() but this way [1, 2, 120] returns [1, 120, 2]. Lodash sortBy() sorts array correctly.

fix https://github.com/cozy/cozy-banks/issues/2206