### PR TITLE
Transactions are no longer selectable in the projected expenses page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * Reassigned transactions are displayed in the correct period according to the selected period
 * On mobile, account settings page doesn't loop after removing an account
 * Checkbox in transaction row are no longer trimmed
+* Transactions are no longer selectable in the projected expenses page
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * Median function in Recurrence returns the correct median
 * Reassigned transactions are displayed in the correct period according to the selected period
 * On mobile, account settings page doesn't loop after removing an account
+* Checkbox in transaction row are no longer trimmed
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionOpener.jsx
@@ -22,6 +22,7 @@ const TransactionOpener = ({
   children
 }) => {
   const rowRef = useRef()
+  const canEditTransaction = transaction._id
 
   const handleClick = useCallback(ev => ev.preventDefault(), [])
 
@@ -29,9 +30,10 @@ const TransactionOpener = ({
     if (isSelectionModeActive) {
       toggleSelection(transaction)
     } else {
-      transaction._id && showTransactionModal()
+      canEditTransaction && showTransactionModal()
     }
   }, [
+    canEditTransaction,
     isSelectionModeActive,
     showTransactionModal,
     toggleSelection,
@@ -39,8 +41,8 @@ const TransactionOpener = ({
   ])
 
   const handlePress = useCallback(() => {
-    toggleSelection(transaction)
-  }, [toggleSelection, transaction])
+    canEditTransaction && toggleSelection(transaction)
+  }, [canEditTransaction, toggleSelection, transaction])
 
   useEffect(() => {
     if (!rowRef || !rowRef.current) return

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -127,7 +127,7 @@ const TransactionRowDesktop = ({
         )}
         onClick={canEditTransaction && handleClickRow}
       >
-        {isSelectionModeEnabled && (
+        {isSelectionModeEnabled && canEditTransaction && (
           <TdSecondary
             className={cx(styles.ColumnSizeCheckbox, 'u-pl-0 u-ta-center')}
             onClick={handleClickCheckbox}
@@ -143,7 +143,7 @@ const TransactionRowDesktop = ({
           className={cx(
             styles.ColumnSizeDesc,
             'u-pv-half',
-            isSelectionModeEnabled ? 'u-pl-0' : 'u-pl-1'
+            isSelectionModeEnabled && canEditTransaction ? 'u-pl-0' : 'u-pl-1'
           )}
         >
           <Media>

--- a/src/ducks/transactions/Transactions.styl
+++ b/src/ducks/transactions/Transactions.styl
@@ -4,6 +4,7 @@
 
 .ColumnSizeCheckbox
     maxed-flex-basis 4%
+    min-width 3rem
 
 .ColumnSizeDesc
     maxed-flex-basis 40%


### PR DESCRIPTION
correction également sur les checkbox de sélection sur le ligne de transaction : elles ne sont plus rognées sur tablette

⚠️ cette PR est un fix sur la branche `release/1.34.0`. Une fois mergé, commit à récupérer pour master.