### PR TITLE
Planned transactions page shows transactions correctly on tablet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,4 @@ refactoring was necessary:
   * Move `lang` and `dictRequire` to utils/lang
 * Ability to run the push notifications debug server from the CLI
 * Add some documentation to develop for android
+* Extract HeaderInfoCard from PlannedTransactionsPage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * On mobile, account settings page doesn't loop after removing an account
 * Checkbox in transaction row are no longer trimmed
 * Transactions are no longer selectable in the projected expenses page
+* Planned transactions page shows transactions correctly on tablet
 
 ## 🔧 Tech
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ refactoring was necessary:
 * Ability to run the push notifications debug server from the CLI
 * Add some documentation to develop for android
 * Extract HeaderInfoCard from PlannedTransactionsPage
+* Extract PlannedTransactionsPage header in its own component

--- a/src/ducks/future/HeaderInfoCard.jsx
+++ b/src/ducks/future/HeaderInfoCard.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { withStyles } from '@material-ui/core/styles'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Figure from 'cozy-ui/transpiled/react/Figure'
+import Card from 'cozy-ui/transpiled/react/Card'
+import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import { getCurrencySymbol } from 'utils/currencySymbol'
+import useEstimatedBudget from './useEstimatedBudget'
+
+const HeaderCard = withStyles({
+  card: {
+    backgroundColor: 'var(--headerInvertedBackgroundColorLight)',
+    border: 0
+  }
+})(({ classes, children }) => {
+  return <Card className={classes.card}>{children}</Card>
+})
+
+const HeaderInfoCard = () => {
+  const { t } = useI18n()
+  const { estimatedBalance, currency, transactions } = useEstimatedBudget()
+
+  if (estimatedBalance === null) {
+    return null
+  }
+
+  return (
+    <HeaderCard>
+      <Media>
+        <Bd>
+          <Typography variant="h6" color="primary">
+            {t('EstimatedBudget.30-day-balance')}
+          </Typography>
+          <Typography variant="caption" color="textSecondary">
+            {t('EstimatedBudget.numberEstimatedTransactions', {
+              smart_count: transactions.length
+            })}
+          </Typography>
+        </Bd>
+        <Img>
+          <Figure
+            className="u-ml-2"
+            total={estimatedBalance}
+            symbol={getCurrencySymbol(currency)}
+          />
+        </Img>
+      </Media>
+    </HeaderCard>
+  )
+}
+
+export default React.memo(HeaderInfoCard)

--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -19,17 +19,17 @@ import styles from './styles.styl'
 const PlannedTransactionsPage = ({ emptyIcon }) => {
   const budget = useEstimatedBudget()
   const { t } = useI18n()
-  const { isMobile } = useBreakpoints()
+  const { isMobile, isTablet } = useBreakpoints()
   useTrackPage('previsionnel')
 
   return (
     <>
       <PlannedTransactionsPageHeader />
       <div
-        className={cx(
-          DESKTOP_SCROLLING_ELEMENT_CLASSNAME,
-          isMobile ? styles['List--mobile'] : null
-        )}
+        className={cx(DESKTOP_SCROLLING_ELEMENT_CLASSNAME, {
+          [styles['List--mobile']]: isMobile,
+          [styles['List--tablet']]: isTablet
+        })}
       >
         {/* Necessary to offset vertically the content in the scrolling area when the LegalMention is displayed */}
         {LegalMention.active && <div className="u-mt-2"> </div>}

--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -1,74 +1,30 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import cx from 'classnames'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Typography from 'cozy-ui/transpiled/react/Typography'
-import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
-import BarTheme from 'ducks/bar/BarTheme'
-import AccountSwitch from 'ducks/account/AccountSwitch'
 import Padded from 'components/Padded'
-import Header from 'components/Header'
-import BackButton from 'components/BackButton'
 import Loading from 'components/Loading'
-import { useRouter } from 'components/RouterContext'
-
 import { TransactionList } from 'ducks/transactions/Transactions'
 import LegalMention from 'ducks/legal/LegalMention'
 import { useTrackPage } from 'ducks/tracking/browser'
 import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
 import useEstimatedBudget from 'ducks/future/useEstimatedBudget'
-import HeaderInfoCard from 'ducks/future/HeaderInfoCard'
+import PlannedTransactionsPageHeader from 'ducks/future/PlannedTransactionsPageHeader'
 
 import styles from './styles.styl'
 
 const PlannedTransactionsPage = ({ emptyIcon }) => {
   const budget = useEstimatedBudget()
-  const router = useRouter()
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   useTrackPage('previsionnel')
 
-  const handleBack = useCallback(() => {
-    router.push('/balances/details')
-  }, [router])
-
   return (
     <>
-      <Header theme="inverted" fixed className={styles.Header}>
-        <BarTheme theme="primary" />
-        <Padded>
-          {isMobile ? (
-            <>
-              <BackButton theme="primary" onClick={handleBack} />
-              <div className={cx(styles['Title--mobile'])}>
-                <AccountSwitch insideBar={false} />
-              </div>
-              <HeaderInfoCard />
-            </>
-          ) : (
-            <Media>
-              <Img>
-                <BackButton arrow onClick={handleBack} theme="primary" />
-              </Img>
-              <Bd className="u-stack-xs">
-                <AccountSwitch size="normal" />
-                <div>
-                  <Typography color="primary" variant="h3">
-                    {t('EstimatedBudget.page-title')}
-                  </Typography>
-                </div>
-              </Bd>
-              <Img>
-                <HeaderInfoCard />
-              </Img>
-            </Media>
-          )}
-          <LegalMention className="u-mt-1" />
-        </Padded>
-      </Header>
+      <PlannedTransactionsPageHeader />
       <div
         className={cx(
           DESKTOP_SCROLLING_ELEMENT_CLASSNAME,

--- a/src/ducks/future/PlannedTransactionsPage.jsx
+++ b/src/ducks/future/PlannedTransactionsPage.jsx
@@ -1,12 +1,9 @@
 import React, { useCallback } from 'react'
 import cx from 'classnames'
-import { withStyles } from '@material-ui/core/styles'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
-import Figure from 'cozy-ui/transpiled/react/Figure'
-import Card from 'cozy-ui/transpiled/react/Card'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -20,54 +17,12 @@ import { useRouter } from 'components/RouterContext'
 
 import { TransactionList } from 'ducks/transactions/Transactions'
 import LegalMention from 'ducks/legal/LegalMention'
-import useEstimatedBudget from './useEstimatedBudget'
-import { getCurrencySymbol } from 'utils/currencySymbol'
 import { useTrackPage } from 'ducks/tracking/browser'
 import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
+import useEstimatedBudget from 'ducks/future/useEstimatedBudget'
+import HeaderInfoCard from 'ducks/future/HeaderInfoCard'
 
 import styles from './styles.styl'
-
-const HeaderCard = withStyles({
-  card: {
-    backgroundColor: 'var(--headerInvertedBackgroundColorLight)',
-    border: 0
-  }
-})(({ classes, children }) => {
-  return <Card className={classes.card}>{children}</Card>
-})
-
-const HeaderInfoCard = () => {
-  const { t } = useI18n()
-  const { estimatedBalance, currency, transactions } = useEstimatedBudget()
-
-  if (estimatedBalance === null) {
-    return null
-  }
-
-  return (
-    <HeaderCard>
-      <Media>
-        <Bd>
-          <Typography variant="h6" color="primary">
-            {t('EstimatedBudget.30-day-balance')}
-          </Typography>
-          <Typography variant="caption" color="textSecondary">
-            {t('EstimatedBudget.numberEstimatedTransactions', {
-              smart_count: transactions.length
-            })}
-          </Typography>
-        </Bd>
-        <Img>
-          <Figure
-            className="u-ml-2"
-            total={estimatedBalance}
-            symbol={getCurrencySymbol(currency)}
-          />
-        </Img>
-      </Media>
-    </HeaderCard>
-  )
-}
 
 const PlannedTransactionsPage = ({ emptyIcon }) => {
   const budget = useEstimatedBudget()
@@ -75,9 +30,11 @@ const PlannedTransactionsPage = ({ emptyIcon }) => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
   useTrackPage('previsionnel')
+
   const handleBack = useCallback(() => {
     router.push('/balances/details')
   }, [router])
+
   return (
     <>
       <Header theme="inverted" fixed className={styles.Header}>
@@ -119,20 +76,20 @@ const PlannedTransactionsPage = ({ emptyIcon }) => {
         )}
       >
         {/* Necessary to offset vertically the content in the scrolling area when the LegalMention is displayed */}
-        {LegalMention.active ? <div className="u-mt-2"> </div> : null}
+        {LegalMention.active && <div className="u-mt-2"> </div>}
         {budget.isLoading ? (
           <Padded>
             <Loading />
           </Padded>
         ) : (
           <>
-            {budget.transactions && budget.transactions.length > 0 ? (
+            {budget.transactions && budget.transactions.length > 0 && (
               <TransactionList
                 transactions={budget.transactions}
                 showTriggerErrors={false}
               />
-            ) : null}
-            {budget.transactions && budget.transactions.length === 0 ? (
+            )}
+            {budget.transactions && budget.transactions.length === 0 && (
               <div className={isMobile ? 'u-mh-half' : ''}>
                 <Empty
                   icon={emptyIcon}
@@ -142,7 +99,7 @@ const PlannedTransactionsPage = ({ emptyIcon }) => {
                   }
                 />
               </div>
-            ) : null}
+            )}
           </>
         )}
       </div>

--- a/src/ducks/future/PlannedTransactionsPageHeader.jsx
+++ b/src/ducks/future/PlannedTransactionsPageHeader.jsx
@@ -1,0 +1,65 @@
+import React, { useCallback } from 'react'
+import cx from 'classnames'
+
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import { Media, Bd, Img } from 'cozy-ui/transpiled/react/Media'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+import Padded from 'components/Padded'
+import { useRouter } from 'components/RouterContext'
+import Header from 'components/Header'
+import BackButton from 'components/BackButton'
+import BarTheme from 'ducks/bar/BarTheme'
+import AccountSwitch from 'ducks/account/AccountSwitch'
+import LegalMention from 'ducks/legal/LegalMention'
+import HeaderInfoCard from 'ducks/future/HeaderInfoCard'
+
+import styles from './styles.styl'
+
+const PlannedTransactionsPageHeader = () => {
+  const { isMobile } = useBreakpoints()
+  const router = useRouter()
+  const { t } = useI18n()
+
+  const handleBack = useCallback(() => {
+    router.push('/balances/details')
+  }, [router])
+
+  return (
+    <Header theme="inverted" fixed className={styles.Header}>
+      <BarTheme theme="primary" />
+      <Padded>
+        {isMobile ? (
+          <>
+            <BackButton theme="primary" onClick={handleBack} />
+            <div className={cx(styles['Title--mobile'])}>
+              <AccountSwitch insideBar={false} />
+            </div>
+            <HeaderInfoCard />
+          </>
+        ) : (
+          <Media>
+            <Img>
+              <BackButton arrow onClick={handleBack} theme="primary" />
+            </Img>
+            <Bd className="u-stack-xs">
+              <AccountSwitch size="normal" />
+              <div>
+                <Typography color="primary" variant="h3">
+                  {t('EstimatedBudget.page-title')}
+                </Typography>
+              </div>
+            </Bd>
+            <Img>
+              <HeaderInfoCard />
+            </Img>
+          </Media>
+        )}
+        <LegalMention className="u-mt-1" />
+      </Padded>
+    </Header>
+  )
+}
+
+export default React.memo(PlannedTransactionsPageHeader)

--- a/src/ducks/future/styles.styl
+++ b/src/ducks/future/styles.styl
@@ -4,6 +4,9 @@
 .List--mobile
     margin-top 6.5rem
 
+.List--tablet
+    margin-top 8.5rem
+
 .Title--mobile
   margin-top -3.25rem
   position relative


### PR DESCRIPTION
Les block des transactions commençait sous l'en-tête

**Avant**
![image](https://user-images.githubusercontent.com/67680939/130603470-a695a113-3816-4b4b-a26f-c1dbdb9679ec.png)

**Après**
![image](https://user-images.githubusercontent.com/67680939/130603407-1731d1d3-36bf-4d11-bebf-cae2e5494436.png)

⚠️ cette PR est un fix sur la branche `release/1.34.0`. Une fois mergé, commit à récupérer pour master.