### PR TITLE
Migrate PouchDB adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## ✨ Features
 
+* Optimization of the database on mobile (addition of the indexeddb adapter). For old users, a modal appears and allows to launch the data migration.
+* Update cozy-pouch-link to 24.3.2 to be able to migrates database on mobile to indexeddb
+
 ## 🐛 Bug Fixes
 
 ## 🔧 Tech
+
+* Add pouchdb-adapter-idb and pouchdb-adapter-indexeddb v7.2.2
 
 # 1.34.0
 

--- a/package.json
+++ b/package.json
@@ -198,6 +198,8 @@
     "number-to-locale-string": "1.2.0",
     "piwik-react-router": "0.12.1",
     "pouchdb-adapter-cordova-sqlite": "2.0.5",
+    "pouchdb-adapter-idb": "7.2.2",
+    "pouchdb-adapter-indexeddb": "7.2.2",
     "raven-js": "3.27.2",
     "react": "16.9.0",
     "react-chartjs-2": "2.7.6",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cozy-konnector-libs": "4.30.3-beta.1",
     "cozy-logger": "1.7.0",
     "cozy-notifications": "0.12.0",
-    "cozy-pouch-link": "24.1.0",
+    "cozy-pouch-link": "24.3.2",
     "cozy-realtime": "3.11.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "24.0.0",

--- a/src/components/MigrateAdapterDialog/MigrateAdapterDialog.jsx
+++ b/src/components/MigrateAdapterDialog/MigrateAdapterDialog.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { Button } from 'cozy-ui/transpiled/react/Button'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+
+const MigrateAdapterDialog = ({ handleMigrateModaleAnswer }) => {
+  const { t } = useI18n()
+
+  const onClose = () => {
+    handleMigrateModaleAnswer(false)
+  }
+
+  const onConfirm = async () => {
+    handleMigrateModaleAnswer(true)
+  }
+
+  return (
+    <ConfirmDialog
+      open={true}
+      onClose={onClose}
+      title={t('Migration.title')}
+      content={t('Migration.content')}
+      actions={
+        <>
+          <Button
+            theme="primary"
+            label={t('Migration.confirm')}
+            onClick={onConfirm}
+          />
+          <Button
+            theme="secondary"
+            label={t('Migration.cancel')}
+            onClick={onClose}
+          />
+        </>
+      }
+    />
+  )
+}
+
+export default React.memo(MigrateAdapterDialog)

--- a/src/components/MigrateAdapterDialog/index.js
+++ b/src/components/MigrateAdapterDialog/index.js
@@ -1,0 +1,1 @@
+export { default } from './MigrateAdapterDialog'

--- a/src/ducks/client/index.js
+++ b/src/ducks/client/index.js
@@ -7,12 +7,12 @@ let client
 const lib =
   __TARGET__ === 'mobile' ? require('./mobile/mobile') : require('./web')
 
-export const getClient = () => {
+export const getClient = async () => {
   if (client) {
     return client
   }
 
-  client = lib.getClient()
+  client = await lib.getClient()
 
   const intents = new Intents({ client })
   client.intents = intents

--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -1,17 +1,15 @@
 /* global __POUCH__ */
-
 import fromPairs from 'lodash/fromPairs'
+
 import { StackLink, Q } from 'cozy-client'
-import { offlineDoctypes } from 'doctypes'
 import { isMobileApp, isIOSApp } from 'cozy-device-helper'
 import flag from 'cozy-flags'
-import { TRANSACTION_DOCTYPE } from 'doctypes'
 
+import { offlineDoctypes, TRANSACTION_DOCTYPE } from 'doctypes'
 import { APPLICATION_DATE } from 'ducks/transactions/constants'
 
 const activatePouch = __POUCH__ && !flag('banks.pouch.disabled')
-
-let PouchLink
+let links = null
 
 const makeWarmupQueryOptions = (doctype, indexedFields) => {
   return {
@@ -29,53 +27,52 @@ const makeWarmupQueryOptions = (doctype, indexedFields) => {
   }
 }
 
-const pouchLinkOptions = {
-  doctypes: offlineDoctypes,
-  doctypesReplicationOptions: {
-    [TRANSACTION_DOCTYPE]: {
-      warmupQueries: [
-        makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['date']),
-        makeWarmupQueryOptions(TRANSACTION_DOCTYPE, [APPLICATION_DATE]),
-        makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['account']),
-        makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['date', 'account']),
-        makeWarmupQueryOptions(TRANSACTION_DOCTYPE, [
-          APPLICATION_DATE,
-          'account'
-        ])
-      ]
-    }
-  },
-  initialSync: true
-}
-
-if (activatePouch) {
-  PouchLink = require('cozy-pouch-link').default
-
-  if (isMobileApp() && isIOSApp()) {
-    pouchLinkOptions.pouch = {
-      plugins: [require('pouchdb-adapter-cordova-sqlite')],
-      options: {
-        adapter: 'cordova-sqlite',
-        location: 'default'
-      }
-    }
-  }
-}
-
-let links = null
 export const getLinks = (options = {}) => {
   if (links) {
     return links
   }
 
   const stackLink = new StackLink()
+
   links = [stackLink]
 
   if (activatePouch) {
+    const pouchLinkOptions = {
+      doctypes: offlineDoctypes,
+      doctypesReplicationOptions: {
+        [TRANSACTION_DOCTYPE]: {
+          warmupQueries: [
+            makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['date']),
+            makeWarmupQueryOptions(TRANSACTION_DOCTYPE, [APPLICATION_DATE]),
+            makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['account']),
+            makeWarmupQueryOptions(TRANSACTION_DOCTYPE, ['date', 'account']),
+            makeWarmupQueryOptions(TRANSACTION_DOCTYPE, [
+              APPLICATION_DATE,
+              'account'
+            ])
+          ]
+        }
+      },
+      initialSync: true
+    }
+
+    if (isMobileApp() && isIOSApp()) {
+      pouchLinkOptions.pouch = {
+        plugins: [require('pouchdb-adapter-cordova-sqlite')],
+        options: {
+          adapter: 'cordova-sqlite',
+          location: 'default'
+        }
+      }
+    }
+
+    const PouchLink = require('cozy-pouch-link').default
+
     const pouchLink = new PouchLink({
       ...pouchLinkOptions,
       ...options.pouchLink
     })
+
     links = [pouchLink, ...links]
   }
 

--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -1,31 +1,15 @@
 /* global __POUCH__ */
-import fromPairs from 'lodash/fromPairs'
 
-import { StackLink, Q } from 'cozy-client'
+import { StackLink } from 'cozy-client'
 import { isMobileApp, isIOSApp } from 'cozy-device-helper'
 import flag from 'cozy-flags'
 
 import { offlineDoctypes, TRANSACTION_DOCTYPE } from 'doctypes'
 import { APPLICATION_DATE } from 'ducks/transactions/constants'
+import { makeWarmupQueryOptions } from 'ducks/client/linksHelpers'
 
 const activatePouch = __POUCH__ && !flag('banks.pouch.disabled')
 let links = null
-
-const makeWarmupQueryOptions = (doctype, indexedFields) => {
-  return {
-    definition: () => {
-      const qdef = Q(doctype)
-        .where(
-          fromPairs(indexedFields.map(fieldName => [fieldName, { $gt: null }]))
-        )
-        .indexFields(indexedFields)
-      return qdef
-    },
-    options: {
-      as: `${doctype}-by-${indexedFields.join('-')}`
-    }
-  }
-}
 
 export const getLinks = async (options = {}) => {
   if (links) {

--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -6,7 +6,11 @@ import flag from 'cozy-flags'
 
 import { offlineDoctypes, TRANSACTION_DOCTYPE } from 'doctypes'
 import { APPLICATION_DATE } from 'ducks/transactions/constants'
-import { makeWarmupQueryOptions } from 'ducks/client/linksHelpers'
+import {
+  makeWarmupQueryOptions,
+  pickAdapter,
+  getAdapterPlugin
+} from 'ducks/client/linksHelpers'
 
 const activatePouch = __POUCH__ && !flag('banks.pouch.disabled')
 let links = null
@@ -17,6 +21,7 @@ export const getLinks = async (options = {}) => {
   }
 
   const stackLink = new StackLink()
+  const adapter = await pickAdapter()
 
   links = [stackLink]
 
@@ -42,9 +47,9 @@ export const getLinks = async (options = {}) => {
 
     if (isMobileApp() && isIOSApp()) {
       pouchLinkOptions.pouch = {
-        plugins: [require('pouchdb-adapter-cordova-sqlite')],
+        plugins: [getAdapterPlugin(adapter)],
         options: {
-          adapter: 'cordova-sqlite',
+          adapter,
           location: 'default'
         }
       }

--- a/src/ducks/client/links.js
+++ b/src/ducks/client/links.js
@@ -27,7 +27,7 @@ const makeWarmupQueryOptions = (doctype, indexedFields) => {
   }
 }
 
-export const getLinks = (options = {}) => {
+export const getLinks = async (options = {}) => {
   if (links) {
     return links
   }

--- a/src/ducks/client/linksHelpers.js
+++ b/src/ducks/client/linksHelpers.js
@@ -1,0 +1,19 @@
+import fromPairs from 'lodash/fromPairs'
+
+import { Q } from 'cozy-client'
+
+export const makeWarmupQueryOptions = (doctype, indexedFields) => {
+  return {
+    definition: () => {
+      const qdef = Q(doctype)
+        .where(
+          fromPairs(indexedFields.map(fieldName => [fieldName, { $gt: null }]))
+        )
+        .indexFields(indexedFields)
+      return qdef
+    },
+    options: {
+      as: `${doctype}-by-${indexedFields.join('-')}`
+    }
+  }
+}

--- a/src/ducks/client/linksHelpers.js
+++ b/src/ducks/client/linksHelpers.js
@@ -1,6 +1,9 @@
 import fromPairs from 'lodash/fromPairs'
+import localforage from 'localforage'
 
+import PouchLink from 'cozy-pouch-link'
 import { Q } from 'cozy-client'
+import { isMobileApp, isIOSApp } from 'cozy-device-helper'
 
 export const makeWarmupQueryOptions = (doctype, indexedFields) => {
   return {
@@ -16,4 +19,41 @@ export const makeWarmupQueryOptions = (doctype, indexedFields) => {
       as: `${doctype}-by-${indexedFields.join('-')}`
     }
   }
+}
+
+export const getAdapterPlugin = adapterName => {
+  if (adapterName === 'cordova-sqlite') {
+    return require('pouchdb-adapter-cordova-sqlite')
+  }
+  if (adapterName === 'idb') {
+    return require('pouchdb-adapter-idb')
+  }
+  return require('pouchdb-adapter-indexeddb').default
+}
+
+export const getOldAdapterName = () => {
+  return isMobileApp() && isIOSApp() ? 'cordova-sqlite' : 'idb'
+}
+
+export const fetchCredentials = async () => {
+  return await localforage.getItem('credentials')
+}
+
+export const isAuthenticated = async () => {
+  const credentials = await fetchCredentials()
+  return Boolean(credentials)
+}
+
+export const shouldMigrateAdapter = async () => {
+  const isAuthentified = await isAuthenticated()
+  return isAuthentified && PouchLink.getPouchAdapterName() !== 'indexeddb'
+}
+
+export const pickAdapter = async () => {
+  const isAuthentified = await isAuthenticated()
+  if (!isAuthentified) return 'indexeddb' // user not authentified, so no data to migrate
+
+  return PouchLink.getPouchAdapterName() === 'indexeddb'
+    ? PouchLink.getPouchAdapterName()
+    : getOldAdapterName()
 }

--- a/src/ducks/client/mobile/helpers.js
+++ b/src/ducks/client/mobile/helpers.js
@@ -1,0 +1,43 @@
+import { getDeviceName } from 'cozy-device-helper'
+
+import { SentryCozyClientPlugin as SentryPlugin } from 'lib/sentry'
+import PushPlugin from 'ducks/mobile/push'
+
+const getSoftwareName = m => {
+  if (m.name === undefined) {
+    throw new Error(`Your manifest must have a 'name' key.`)
+  }
+
+  return m.name_prefix ? `${m.name_prefix} ${m.name}` : m.name
+}
+
+const getClientName = m => `${getSoftwareName(m)} (${getDeviceName()})`
+
+const getScope = m => {
+  if (m.permissions === undefined) {
+    throw new Error(`Your manifest must have a 'permissions' key.`)
+  }
+
+  return Object.keys(m.permissions).map(permission => {
+    const { type /*, verbs, selector, values*/ } = m.permissions[permission]
+
+    return type
+  })
+}
+
+export const registerPluginsAndHandlers = client => {
+  client.registerPlugin(PushPlugin)
+  client.registerPlugin(SentryPlugin)
+}
+
+export const getManifestOptions = manifest => {
+  const cozyPolicyURI = 'https://files.cozycloud.cc/cgu.pdf'
+
+  return {
+    oauth: {
+      clientName: getClientName(manifest),
+      policyURI: manifest.name_prefix === 'Cozy' ? cozyPolicyURI : '',
+      scope: getScope(manifest)
+    }
+  }
+}

--- a/src/ducks/client/mobile/mobile.js
+++ b/src/ducks/client/mobile/mobile.js
@@ -15,7 +15,7 @@ import {
   getManifestOptions
 } from 'ducks/client/mobile/helpers'
 
-export const getClient = () => {
+export const getClient = async () => {
   const manifestOptions = getManifestOptions(manifest)
   const appSlug = manifest.slug
 
@@ -33,7 +33,7 @@ export const getClient = () => {
         'https://downcloud.cozycloud.cc/upload/cozy-banks/email-assets/logo-bank.png',
       notificationPlatform: 'firebase'
     },
-    links: getLinks({
+    links: await getLinks({
       pouchLink: {
         // TODO: the revocation check via cozy-pouch-link should not be
         // done in the app. We should find a way to have this in a shared

--- a/src/ducks/client/mobile/mobile.js
+++ b/src/ducks/client/mobile/mobile.js
@@ -1,58 +1,19 @@
 /* global __APP_VERSION__ */
+import merge from 'lodash/merge'
 
 import CozyClient from 'cozy-client'
-import { getDeviceName } from 'cozy-device-helper'
 
-import merge from 'lodash/merge'
-import { getLinks } from '../links'
 import { schema } from 'doctypes'
-import manifest from 'ducks/client/manifest'
-import PushPlugin from 'ducks/mobile/push'
-import { checkForRevocation } from 'ducks/client/utils'
-import { SentryCozyClientPlugin as SentryPlugin } from 'lib/sentry'
-
 import { SOFTWARE_ID } from 'ducks/mobile/constants'
-import { getRedirectUri } from 'ducks/client/mobile/redirect'
+import { getLinks } from 'ducks/client/links'
+import manifest from 'ducks/client/manifest'
+import { checkForRevocation } from 'ducks/client/utils'
 import appMetadata from 'ducks/client/appMetadata'
-
-export const getScope = m => {
-  if (m.permissions === undefined) {
-    throw new Error(`Your manifest must have a 'permissions' key.`)
-  }
-
-  return Object.keys(m.permissions).map(permission => {
-    const { type /*, verbs, selector, values*/ } = m.permissions[permission]
-
-    return type
-  })
-}
-
-export const getSoftwareName = m => {
-  if (m.name === undefined) {
-    throw new Error(`Your manifest must have a 'name' key.`)
-  }
-
-  return m.name_prefix ? `${m.name_prefix} ${m.name}` : m.name
-}
-
-export const getClientName = m => `${getSoftwareName(m)} (${getDeviceName()})`
-
-export const getManifestOptions = manifest => {
-  const cozyPolicyURI = 'https://files.cozycloud.cc/cgu.pdf'
-
-  return {
-    oauth: {
-      clientName: getClientName(manifest),
-      policyURI: manifest.name_prefix === 'Cozy' ? cozyPolicyURI : '',
-      scope: getScope(manifest)
-    }
-  }
-}
-
-const registerPluginsAndHandlers = client => {
-  client.registerPlugin(PushPlugin)
-  client.registerPlugin(SentryPlugin)
-}
+import { getRedirectUri } from 'ducks/client/mobile/redirect'
+import {
+  registerPluginsAndHandlers,
+  getManifestOptions
+} from 'ducks/client/mobile/helpers'
 
 export const getClient = () => {
   const manifestOptions = getManifestOptions(manifest)
@@ -88,5 +49,6 @@ export const getClient = () => {
     merge(manifestOptions, banksOptions, { store: false })
   )
   registerPluginsAndHandlers(client)
+
   return client
 }

--- a/src/ducks/client/mobile/mobile.spec.js
+++ b/src/ducks/client/mobile/mobile.spec.js
@@ -1,5 +1,10 @@
 import { getClient } from './mobile'
 
+// Mock otherwise we have a 'fetch is not defined' error
+// due to pouchdb-browser. Here we are not concerned with this
+// component
+jest.mock('cozy-pouch-link', () => () => null)
+
 describe('get mobile client', () => {
   it('should have plugins correctly instantiated', async () => {
     global.__APP_VERSION__ = '1.5.0'

--- a/src/ducks/client/mobile/mobile.spec.js
+++ b/src/ducks/client/mobile/mobile.spec.js
@@ -1,9 +1,9 @@
 import { getClient } from './mobile'
 
 describe('get mobile client', () => {
-  it('should have plugins correctly instantiated', () => {
+  it('should have plugins correctly instantiated', async () => {
     global.__APP_VERSION__ = '1.5.0'
-    const client = getClient()
+    const client = await getClient()
     expect(client.plugins.push).not.toBeUndefined()
     expect(client.plugins.sentry).not.toBeUndefined()
   })

--- a/src/ducks/client/web.js
+++ b/src/ducks/client/web.js
@@ -28,7 +28,7 @@ const getCozyURI = () => {
   return `${protocol}//${domain}`
 }
 
-export const getClient = () => {
+export const getClient = async () => {
   const uri = flag('cozyURL') || getCozyURI()
   const token = flag('cozyToken') || getToken()
 
@@ -37,7 +37,7 @@ export const getClient = () => {
     uri,
     token,
     schema,
-    links: getLinks(),
+    links: await getLinks(),
     store: false
   })
 }

--- a/src/ducks/mobile/MobileRouter.jsx
+++ b/src/ducks/mobile/MobileRouter.jsx
@@ -1,34 +1,87 @@
 import React from 'react'
-import { withClient } from 'cozy-client'
-import appIcon from 'targets/favicons/icon-banks.jpg'
-import { MobileRouter as AuthMobileRouter } from 'cozy-authentication'
 import { hashHistory } from 'react-router'
-import { protocol, appTitle } from 'ducks/mobile/constants'
-import LogoutModal from 'components/LogoutModal'
 
-import manifest from 'ducks/client/manifest'
-import initBar from 'ducks/mobile/bar'
+import { withClient } from 'cozy-client'
+import { MobileRouter as AuthMobileRouter } from 'cozy-authentication'
+import PouchLink from 'cozy-pouch-link'
 import { getUniversalLinkDomain } from 'cozy-ui/transpiled/react/AppLinker'
 
+import LogoutModal from 'components/LogoutModal'
+import MigrateAdapterDialog from 'components/MigrateAdapterDialog'
+import { protocol, appTitle } from 'ducks/mobile/constants'
+import manifest from 'ducks/client/manifest'
+import initBar from 'ducks/mobile/bar'
+import {
+  getOldAdapterName,
+  getAdapterPlugin,
+  shouldMigrateAdapter,
+  fetchCredentials
+} from 'ducks/client/linksHelpers'
+import appIcon from 'targets/favicons/icon-banks.jpg'
+
 export class MobileRouter extends React.Component {
+  state = {
+    shouldDisplayMigrateDialog: false
+  }
+
+  async componentDidMount() {
+    const shouldMigrate = await shouldMigrateAdapter()
+    this.setState({
+      shouldDisplayMigrateDialog: shouldMigrate
+    })
+  }
+
+  handleMigrateModaleAnswer = async shouldMigrate => {
+    this.setState({ shouldDisplayMigrateDialog: false })
+    if (shouldMigrate) {
+      const { client } = this.props
+      const pouchLink = client.links.find(link => {
+        return link instanceof PouchLink
+      })
+      const creds = await fetchCredentials()
+      const url = creds.uri
+      const oldAdapter = getOldAdapterName()
+      const oldAdapterPlugin = getAdapterPlugin(oldAdapter)
+      const newAdapterPlugin = getAdapterPlugin('indexeddb')
+      const plugins = [oldAdapterPlugin, newAdapterPlugin]
+      await pouchLink.migrateAdapter({
+        fromAdapter: oldAdapter,
+        toAdapter: 'indexeddb',
+        url,
+        plugins
+      })
+      // Reload page to benefit from new adapter
+      window.location.reload()
+    }
+  }
+
   render() {
     const { routes, client } = this.props
+    const { shouldDisplayMigrateDialog } = this.state
+
     return (
-      <AuthMobileRouter
-        protocol={protocol}
-        history={hashHistory}
-        appIcon={appIcon}
-        appTitle={appTitle}
-        appSlug={manifest.slug}
-        universalLinkDomain={getUniversalLinkDomain()}
-        onAuthenticated={async () => {
-          hashHistory.replace('/balances')
-          await initBar(client)
-        }}
-        LogoutComponent={LogoutModal}
-      >
-        {routes}
-      </AuthMobileRouter>
+      <>
+        {shouldDisplayMigrateDialog && (
+          <MigrateAdapterDialog
+            handleMigrateModaleAnswer={this.handleMigrateModaleAnswer}
+          />
+        )}
+        <AuthMobileRouter
+          protocol={protocol}
+          history={hashHistory}
+          appIcon={appIcon}
+          appTitle={appTitle}
+          appSlug={manifest.slug}
+          universalLinkDomain={getUniversalLinkDomain()}
+          onAuthenticated={async () => {
+            hashHistory.replace('/balances')
+            await initBar(client)
+          }}
+          LogoutComponent={LogoutModal}
+        >
+          {routes}
+        </AuthMobileRouter>
+      </>
     )
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -929,5 +929,12 @@
     "categorize": "Categorize",
     "selectAll": "Select all",
     "unselectAll": "Unselect all"
+  },
+
+  "Migration": {
+    "title": "Update Cozy Banks",
+    "content": "Cozy Banks needs to update in order to improve its performances. This might take up to several minutes during which you cannot use your app. Do you want to do it now? If you refuse, we will ask you again next time",
+    "confirm": "Ok, let's do it!",
+    "cancel": "No, not now"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -931,5 +931,12 @@
     "categorize": "Catégorisation",
     "selectAll": "Tout sélectionner",
     "unselectAll": "Tout désélectionner"
+  },
+
+  "Migration": {
+    "title": "Mise à jour de Cozy Banks",
+    "content": "Cozy Banks doit être mis à jour afin d'améliorer ses performances. Cela peut prendre plusieurs minutes pendant lesquelles vous ne pouvez pas utiliser votre application. Voulez-vous le faire maintenant ? Si vous refusez, nous vous le demanderons à nouveau la prochaine fois",
+    "confirm" : "Ok, c'est parti !",
+    "cancel": "Non, pas maintenant"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4851,7 +4851,7 @@ cozy-client@13.8.3:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-client@24.1.0, cozy-client@^24.1.0:
+cozy-client@24.1.0:
   version "24.1.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-24.1.0.tgz#9cb3f794ff42cc7d1e09bea718bc35615fb0433d"
   integrity sha512-QtFKqb8VWdZL3jv/Zc7Pqb+dUi0CeJ1VKeeMV1I+pHBpzb0yCt15nHlXXIiC136GUuqBI2IK2mItWlofu4SpYQ==
@@ -4890,6 +4890,32 @@ cozy-client@6.64.5, cozy-client@^6.58.0, cozy-client@^6.58.1:
     react-redux "^5.0.7"
     redux "^3.7.2"
     redux-thunk "^2.3.0"
+    sift "^6.0.0"
+    url-search-params-polyfill "^7.0.0"
+
+cozy-client@^24.2.0:
+  version "24.2.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-24.2.0.tgz#eb9e8c0748a338d90b55d763ba219a9d28c7b71c"
+  integrity sha512-Cr4Ve1K+qBVV4JwfqLtxBCHzsg1TnEqsYM+yj6Rmd9uN47g7rqcJrOt8obgsbb74zggqJkObrMKOGG/jbgZAAA==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-device-helper "^1.12.0"
+    cozy-flags "2.7.1"
+    cozy-logger "^1.6.0"
+    cozy-stack-client "^24.0.0"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    open "^7.0.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
@@ -5123,13 +5149,13 @@ cozy-notifications@0.12.0:
     mjml "4.3.1"
     word-wrap "^1.2.3"
 
-cozy-pouch-link@24.1.0:
-  version "24.1.0"
-  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-24.1.0.tgz#fbfcb83cde162b6901bc32aabd98910572da4dc8"
-  integrity sha512-WBIYKOgaJQs/+GgJSPgXNA+z3AgX6n99FaGQwNcZxly5YbT1Rcew5d0UCGJBC7yTq95De+G3Jmj1N7Ev0Z11VQ==
+cozy-pouch-link@24.3.2:
+  version "24.3.2"
+  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-24.3.2.tgz#d894d71196995975803abdfb15c9cabd42281e1f"
+  integrity sha512-CT1GRgdoQ5rAmvXN8jD0wphy91eVfUEIJb9sxI4pJm9iSYL7c4z6ofJHyljy3+lT6V16DH5zUvus9JPvt8IOgw==
   dependencies:
     "@cozy/minilog" "1.0.0"
-    cozy-client "^24.1.0"
+    cozy-client "^24.2.0"
     cozy-device-helper "^1.12.0"
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14664,6 +14664,31 @@ pouchdb-adapter-cordova-sqlite@2.0.5:
   dependencies:
     pouchdb-adapter-websql-core "^6.4.3"
 
+pouchdb-adapter-idb@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-idb/-/pouchdb-adapter-idb-7.2.2.tgz#0a4b6c6f6639f93e2e50cb20d50b5fb6eaf1e80e"
+  integrity sha512-swSVQFm/p5CPKP0zyOmtv/hFpTyjtDlPAKTpxH4gEm9V+K30kDZ8ciAHaCkGEBSfWfZFYUI8/VOnAL2L0WIIeA==
+  dependencies:
+    pouchdb-adapter-utils "7.2.2"
+    pouchdb-binary-utils "7.2.2"
+    pouchdb-collections "7.2.2"
+    pouchdb-errors "7.2.2"
+    pouchdb-json "7.2.2"
+    pouchdb-merge "7.2.2"
+    pouchdb-utils "7.2.2"
+
+pouchdb-adapter-indexeddb@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-indexeddb/-/pouchdb-adapter-indexeddb-7.2.2.tgz#ffcee0435bb5a9599c8d45de09a5758103e31c61"
+  integrity sha512-OK/a0MAMEALySy4bIDOQy/qLnBDwPARW7yQKA25CmMObdOdCrca7EUSySZD5gjMDY0u4DUANgb0USlD6Hk9Feg==
+  dependencies:
+    pouchdb-adapter-utils "7.2.2"
+    pouchdb-binary-utils "7.2.2"
+    pouchdb-errors "7.2.2"
+    pouchdb-md5 "7.2.2"
+    pouchdb-merge "7.2.2"
+    pouchdb-utils "7.2.2"
+
 pouchdb-adapter-utils@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-6.4.3.tgz#384bb1bcd37dc7d473016eb450cec53d665bcae4"
@@ -14676,6 +14701,18 @@ pouchdb-adapter-utils@6.4.3:
     pouchdb-merge "6.4.3"
     pouchdb-promise "6.4.3"
     pouchdb-utils "6.4.3"
+
+pouchdb-adapter-utils@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.2.2.tgz#c64426447d9044ba31517a18500d6d2d28abd47d"
+  integrity sha512-2CzZkTyTyHZkr3ePiWFMTiD5+56lnembMjaTl8ohwegM0+hYhRyJux0biAZafVxgIL4gnCUC4w2xf6WVztzKdg==
+  dependencies:
+    pouchdb-binary-utils "7.2.2"
+    pouchdb-collections "7.2.2"
+    pouchdb-errors "7.2.2"
+    pouchdb-md5 "7.2.2"
+    pouchdb-merge "7.2.2"
+    pouchdb-utils "7.2.2"
 
 pouchdb-adapter-websql-core@^6.4.3:
   version "6.4.3"
@@ -14831,6 +14868,13 @@ pouchdb-json@6.4.3:
   dependencies:
     vuvuzela "1.0.3"
 
+pouchdb-json@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-json/-/pouchdb-json-7.2.2.tgz#b939be24b91a7322e9a24b8880a6e21514ec5e1f"
+  integrity sha512-3b2S2ynN+aoB7aCNyDZc/4c0IAdx/ir3nsHB+/RrKE9cM3QkQYbnnE3r/RvOD1Xvr6ji/KOCBie+Pz/6sxoaug==
+  dependencies:
+    vuvuzela "1.0.3"
+
 pouchdb-mapreduce-utils@7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-7.0.0.tgz#ff342e9d515d4c9cf0b19ad85c78f10f2568493b"
@@ -14879,6 +14923,11 @@ pouchdb-merge@6.4.3:
   version "6.4.3"
   resolved "https://registry.yarnpkg.com/pouchdb-merge/-/pouchdb-merge-6.4.3.tgz#4ef901f4aaa27be6aec0108998a127fe55bb0628"
   integrity sha512-UuSpex/V1kNr1aXcmg+TQlOdjzMWc08AX/Ja6jrPq9J42M97UFF+7Ijx3JllxDK0j6QJZrvhpvjFzsRhFC4+zw==
+
+pouchdb-merge@7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-merge/-/pouchdb-merge-7.2.2.tgz#940d85a2b532d6a93a6cab4b250f5648511bcc16"
+  integrity sha512-6yzKJfjIchBaS7Tusuk8280WJdESzFfQ0sb4jeMUNnrqs4Cx3b0DIEOYTRRD9EJDM+je7D3AZZ4AT0tFw8gb4A==
 
 pouchdb-promise@6.4.3:
   version "6.4.3"


### PR DESCRIPTION
This asks the user having an old Pouch adapter (e.g. idb, cordova-sqlite)
if he wants to migrate it. We detect such need by an entry in the
localstorage set by cozy-pouch-link

Same work as we did on Drive : https://github.com/cozy/cozy-drive/pull/2399

![image](https://user-images.githubusercontent.com/67680939/132193524-3f318ed5-1915-4938-a10a-845d8f76731a.png)
