### PR TITLE
refactor: Use deep import for lodash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Extract component from GroupSettings
 * Groups are not filtered anymore to exclude undefined one in AccountSwitch
 * Remove updateOrCreateGroup() to remove router from dependencies
+* Only deep import for lodash
 
 # 1.34.0
 

--- a/src/targets/services/stats.js
+++ b/src/targets/services/stats.js
@@ -1,6 +1,7 @@
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 import { BankAccountStats } from 'cozy-doctypes'
-import { groupBy, keyBy } from 'lodash'
+import keyBy from 'lodash/keyBy'
+import groupBy from 'lodash/groupBy'
 import logger from 'cozy-logger'
 import {
   getPeriod,

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -1,4 +1,4 @@
-import { merge } from 'lodash'
+import merge from 'lodash/merge'
 import dummyjson from 'dummy-json'
 import dataTpl from './unit-tests.json'
 import helpers from './helpers'


### PR DESCRIPTION
to avoid importing the whole lib