### PR TITLE
fix group delete on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
 
 ## 🐛 Bug Fixes
 
-* Error when removing a group
+* Error when removing a group on desktop and mobile
 * Correct minimum date is used to create recurrence
+* Fix warming queries with null applicationDate selector
 
 ## 🔧 Tech
 

--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -14,14 +14,15 @@ import { destroyRecurrenceIfEmpty } from 'ducks/recurrence/api'
 import { disableOutdatedNotifications } from 'ducks/settings/helpers'
 import { getT } from 'utils/lang'
 
+export const DESTROY_ACCOUNT = 'DESTROY_ACCOUNT'
+const STACK_FIND_LIMIT = 100
+
 const removeAccountFromGroup = (group, account) => {
   return {
     ...group,
     accounts: group.accounts.filter(accountId => accountId !== account.id)
   }
 }
-
-const STACK_FIND_LIMIT = 100
 
 export const deleteOrphanOperations = async (client, account) => {
   // We use a collection here instead of using the client because
@@ -79,7 +80,6 @@ export const updateRecurrences = async (client, account, deletedOps) => {
   }
 }
 
-export const DESTROY_ACCOUNT = 'DESTROY_ACCOUNT'
 export const onAccountDelete = async (client, account) => {
   const t = getT()
   const notif = Alerter.info(t('DeletingAccount.related-data.deleting'), {
@@ -94,8 +94,6 @@ export const onAccountDelete = async (client, account) => {
   Alerter.success(t('DeletingAccount.related-data.successfully-deleted'))
 }
 
-window.onAccountDelete = onAccountDelete
-
 export const onGroupDelete = async (client, account) => {
   await deleteOrphanOperations(client, account)
   await removeAccountFromGroups(client, account)
@@ -103,5 +101,6 @@ export const onGroupDelete = async (client, account) => {
   await disableOutdatedNotifications(client)
 }
 
+window.onAccountDelete = onAccountDelete
 CozyClient.registerHook(ACCOUNT_DOCTYPE, 'before:destroy', onAccountDelete)
 CozyClient.registerHook(GROUP_DOCTYPE, 'before:destroy', onGroupDelete)

--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -96,7 +96,6 @@ export const onAccountDelete = async (client, account) => {
 
 export const onGroupDelete = async (client, account) => {
   await deleteOrphanOperations(client, account)
-  await removeAccountFromGroups(client, account)
   await removeStats(client, account)
   await disableOutdatedNotifications(client)
 }

--- a/src/ducks/settings/GroupSettings/RemoveGroupButton.jsx
+++ b/src/ducks/settings/GroupSettings/RemoveGroupButton.jsx
@@ -9,11 +9,10 @@ import { logException } from 'lib/sentry'
 import { useRouter } from 'components/RouterContext'
 import { trackEvent } from 'ducks/tracking/browser'
 
-const RemoveGroupButton = props => {
+const RemoveGroupButton = ({ group }) => {
   const { t } = useI18n()
   const client = useClient()
   const router = useRouter()
-  const { group } = props
 
   const handleRemove = useCallback(async () => {
     try {

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -280,7 +280,7 @@ export const updateApplicationDate = async (
 ) => {
   const date = getDisplayDate(transaction)
   if (isSameMonth(date, applicationDate)) {
-    applicationDate = null // reset the application date
+    applicationDate = '' // reset the application date
   }
   const { data } = await client.save({
     ...transaction,

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -432,7 +432,7 @@ describe('updateApplicationDate', () => {
     )
     expect(client.save).toHaveBeenCalledWith({
       date: '2019-09-07T12:00',
-      applicationDate: null
+      applicationDate: ''
     })
   })
 })


### PR DESCRIPTION
Lorsqu'on supprimait un groupe sur mobile, il réapparaissait suite à la synchro pouch<->couch, à cause du fait qu'avant la suppression on envoyait une autre requête qui modifiait le groupe en question.

J'en ai profité pour corriger un bug lié à https://github.com/pouchdb/pouchdb/issues/7290