### PR TITLE
feat: Add logs and jsdoc for recurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ## 🔧 Tech
 
-*
+* Add logs to better debugging recurrence
 
 # 1.35.0
 

--- a/src/ducks/recurrence/rules.js
+++ b/src/ducks/recurrence/rules.js
@@ -37,13 +37,25 @@ export const median = iterable => {
  */
 const makeStats = operations => {
   const dates = sortBy(operations, x => x.date).map(x => +new Date(x.date))
+
+  // Days between a transaction and the next one.
+  // First result is between first and second transactions
+  // Second result is between second and third transactions etc.
   const deltas = dates
     .map((d, i) => (i === 0 ? null : (d - dates[i - 1]) / ONE_DAY))
     .slice(1)
+
+  // Mean interval in days between operations
   const m = mean(deltas)
+
+  // Median number of days between transactions
   const med = operations.length < 3 ? 30 : median(deltas)
   const sqDistToAverage = deltas.map(d => Math.pow(d, 2) - Math.pow(m, 2))
+
+  // Standard deviation of bundle's date intervals
   const sigma = Math.sqrt(sum(sqDistToAverage) / deltas.length)
+
+  // Median absolute deviation of bundle's date intervals
   const mad = median(deltas.map(d => Math.abs(d - med)))
 
   return {
@@ -54,25 +66,6 @@ const makeStats = operations => {
       mad
     }
   }
-}
-
-/**
- * Will return a predicate that returns true only if all
- * predicates return true
- *
- * Lodash as the same function but it is convenient to have
- * it here to be able to add logging easily
- *
- * @param  {Array[Function]} predicates
- * @return {Function}
- */
-export const overEvery = predicates => item => {
-  for (const predicate of predicates) {
-    if (!predicate(item)) {
-      return false
-    }
-  }
-  return true
 }
 
 const getTransactionDate = x => x.date
@@ -201,7 +194,7 @@ export const rulesPerName = {
   },
   amountShouldBeMoreThan: {
     rule: amountShouldBeMoreThan,
-    description: 'Amount of bundle is more than',
+    description: 'Amount of bundle should be more than',
     stage: 0,
     type: 'filter'
   },

--- a/src/ducks/recurrence/search.js
+++ b/src/ducks/recurrence/search.js
@@ -13,11 +13,14 @@ import { getLabel } from 'ducks/transactions/helpers'
 import {
   addStats,
   getRulesFromConfig,
-  groupBundles,
-  overEvery
+  groupBundles
 } from 'ducks/recurrence/rules'
 import { addTransactionToBundles } from 'ducks/recurrence/utils'
-import { NB_DAYS_LOOKBACK } from 'ducks/recurrence/service'
+import {
+  NB_DAYS_LOOKBACK,
+  logRecurrencesLabelAndTransactionsNumber
+} from 'ducks/recurrence/service'
+import { log } from './logger'
 
 const ONE_DAY = 86400 * 1000
 
@@ -41,6 +44,7 @@ const assert = (pred, msg) => {
  * @return {array} recurrence groups
  */
 export const findRecurrences = (operations, rules) => {
+  log('info', 'Creating new bundle...')
   const groups = groupBy(operations, x => getCategoryId(x))
 
   let bundles = flatMap(Object.entries(groups), ([categoryId, ops]) => {
@@ -53,20 +57,36 @@ export const findRecurrences = (operations, rules) => {
     }))
   })
 
-  const groupedByStage = groupBy(rules, rule => rule.stage)
-  const stageKeys = Object.keys(groupedByStage).sort()
+  logRecurrencesLabelAndTransactionsNumber({
+    prefix: `Create ${bundles.length} bundles before filtering them:`,
+    recurrences: bundles
+  })
 
-  for (let stageKey of stageKeys) {
-    const ruleInfos = groupedByStage[stageKey]
+  const rulesGroupedByStage = groupBy(rules, rule => rule.stage)
+  const rulesStageKeys = Object.keys(rulesGroupedByStage).sort()
+
+  for (let rulesStageKey of rulesStageKeys) {
+    const rulesInfos = rulesGroupedByStage[rulesStageKey]
     assert(
-      unique(ruleInfos.map(r => r.type)).length === 1,
+      unique(rulesInfos.map(r => r.type)).length === 1,
       'Cannot have multiple types per stage'
     )
-    const type = ruleInfos[0].type
-    const rules = ruleInfos.map(ruleInfo => ruleInfo.rule)
+    const type = rulesInfos[0].type
+    const rules = rulesInfos.map(ruleInfo => ruleInfo.rule)
 
     if (type === 'filter') {
-      bundles = bundles.filter(overEvery(rules))
+      bundles = bundles.filter(bundle => {
+        for (const ruleInfos of rulesInfos) {
+          if (!ruleInfos.rule(bundle)) {
+            logRecurrencesLabelAndTransactionsNumber({
+              prefix: `Excluding bundle from creation. Reason: ${ruleInfos.description}. Excluded bundle:`,
+              recurrences: [bundle]
+            })
+            return false
+          }
+        }
+        return true
+      })
     } else if (type === 'map') {
       bundles = bundles.map(compose(rules))
     } else if (type === 'group') {
@@ -91,6 +111,8 @@ export const updateRecurrences = (bundles, newTransactions, rules) => {
   const minDate = new Date(minBy(newTransactions, 'date').date)
   const dateSpan = (maxDate - minDate) / ONE_DAY
 
+  log('info', `Update recurrences process dateSpan: ${dateSpan}`)
+
   let newBundles = []
   let updatedBundles = []
 
@@ -108,9 +130,22 @@ export const updateRecurrences = (bundles, newTransactions, rules) => {
       transactionsForUpdatedBundles
     )
 
+    logRecurrencesLabelAndTransactionsNumber({
+      prefix: `Found ${updatedBundles.length} bundles to update:`,
+      recurrences: updatedBundles
+    })
+    log(
+      'info',
+      `${remainingTransactions.length} remaining transactions to consider for creating new bundles`
+    )
+
     if (remainingTransactions.length > 0) {
       newBundles = findRecurrences(remainingTransactions, rules)
     }
+    logRecurrencesLabelAndTransactionsNumber({
+      prefix: `Finally create ${newBundles.length} new bundles:`,
+      recurrences: newBundles
+    })
   }
 
   const allBundles = [...updatedBundles, ...newBundles].map(addStats)
@@ -119,6 +154,8 @@ export const updateRecurrences = (bundles, newTransactions, rules) => {
 }
 
 export const findAndUpdateRecurrences = (recurrences, operations) => {
+  log('info', 'Find and update recurrences...')
+
   const rules = getRulesFromConfig(defaultRulesConfig)
 
   let updatedRecurrences

--- a/src/ducks/recurrence/search.spec.js
+++ b/src/ducks/recurrence/search.spec.js
@@ -1228,8 +1228,6 @@ describe('with existing recurrences', () => {
 
     const bundles = findAndUpdateRecurrences(recurrences, transactions)
 
-    // console.info(JSON.stringify(bundles))
-
     expect(bundles).toMatchObject(expectedBundles)
   })
 })

--- a/src/ducks/recurrence/service.js
+++ b/src/ducks/recurrence/service.js
@@ -40,30 +40,69 @@ const makeQueryForTransactions = recurrences => {
 
 const getRecurrenceId = recurrence => recurrence._id
 
-const logDifferences = (oldRecurrences, updatedRecurrences) => {
+export const logDifferences = (oldRecurrences, updatedRecurrences) => {
   const {
     true: existingRecurrences = [],
     false: newRecurrences = []
   } = groupBy(updatedRecurrences, rec => Boolean(getRecurrenceId(rec)))
   const oldById = keyBy(oldRecurrences, getRecurrenceId)
   const existingById = keyBy(existingRecurrences, getRecurrenceId)
-  log('info', `${newRecurrences.length} new recurrences`)
+
+  let logForNewRecurrences = []
+  let logForExistingRecurrences = []
+
   for (const [id, existing] of Object.entries(existingById)) {
-    log(
-      'info',
+    logForExistingRecurrences.push(
       `${getLabel(existing)}: ${existing.ops.length} operations (+${existing.ops
         .length - oldById[id].ops.length})`
     )
   }
+
   for (const rec of newRecurrences) {
-    log(
-      'info',
+    logForNewRecurrences.push(
       `${getLabel(rec)}: ${rec.ops.length} operations (+${
         rec.ops.length
       }), category: ${tree[rec.categoryIds[0]]}`
     )
   }
+
+  if (logForNewRecurrences.length > 0) {
+    log(
+      'info',
+      `${
+        newRecurrences.length
+      } modifications on recurrences:\n${logForNewRecurrences.join('\n')}`
+    )
+  }
+
+  if (logForExistingRecurrences.length > 0) {
+    log(
+      'info',
+      `${
+        existingRecurrences.length
+      } existing recurrences :\n${logForExistingRecurrences.join('\n')}`
+    )
+  }
 }
+
+export const logRecurrencesLabelAndTransactionsNumber = ({
+  prefix,
+  recurrences,
+  suffix
+}) => {
+  const recurrencesLogs = recurrences.map(recurrence => {
+    if (!recurrence.ops) {
+      return
+    }
+    return `${getLabel(recurrence)}: ${recurrence.ops.length} operations`
+  })
+
+  log(
+    'info',
+    [prefix, recurrencesLogs.join('\n'), suffix].filter(Boolean).join('\n')
+  )
+}
+
 /**
  * Fetches
  *   - transactions in the last 3 months
@@ -77,18 +116,16 @@ const main = async ({ client }) => {
   try {
     const recurrences = await fetchHydratedBundles(client)
 
-    log('info', `Found ${recurrences.length} existing recurrences`)
-    recurrences.forEach(recurrence => {
-      if (!recurrence.ops) {
-        return
-      }
-      log(
-        'info',
-        `${getLabel(recurrence)}: ${recurrence.ops.length} operations`
-      )
+    logRecurrencesLabelAndTransactionsNumber({
+      prefix: `Found ${recurrences.length} existing recurrences:`,
+      recurrences
     })
 
     const transactionQuery = makeQueryForTransactions(recurrences)
+    log(
+      'info',
+      `Transactions selector is ${JSON.stringify(transactionQuery.selector)}`
+    )
     const transactions = await client.queryAll(transactionQuery)
 
     if (recurrences.length > 0) {
@@ -112,11 +149,14 @@ const main = async ({ client }) => {
       transactions
     ).map(x => omit(x, '_type'))
 
+    logRecurrencesLabelAndTransactionsNumber({
+      prefix: `Created/updated ${updatedRecurrences.length} recurrences:`,
+      recurrences: updatedRecurrences
+    })
     log(
       'info',
       `Added ${updatedRecurrences.length - recurrences.length} new recurrences`
     )
-
     logDifferences(recurrences, updatedRecurrences)
 
     const {


### PR DESCRIPTION
pour le cas `should update existing bundle and create a new one` : 
![image](https://user-images.githubusercontent.com/67680939/134019048-b0450265-2897-4363-a2cf-fd7168f020e6.png)

même cas sauf qu'on ne passe que 2 transactions à la place de 3 pour le nouveau bundle potentiel. On log alors l'erreur `Filter out bundles where the size is below`
![image](https://user-images.githubusercontent.com/67680939/134019387-56e75965-6674-47c6-8bb0-80ed0253eecf.png)

