### PR TITLE
fix: Update Cozy UI with Sprite excluded from Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Error when removing a group on desktop and mobile
 * Correct minimum date is used to create recurrence
 * Fix warming queries with null applicationDate selector
+* Update cozy-ui to 52.0.0 to reduce the size of the bundle
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "cozy-realtime": "3.11.0",
     "cozy-scripts": "5.2.0",
     "cozy-stack-client": "24.0.0",
-    "cozy-ui": "51.4.0",
+    "cozy-ui": "52.0.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5213,10 +5213,10 @@ cozy-stack-client@^6.64.3:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@51.4.0:
-  version "51.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-51.4.0.tgz#a81917ab08c94f56eb0e9203d7b7bd58656018e4"
-  integrity sha512-er6/OaErU055j2Q4jLu0ROUnlPnvcK1R9sH4y2AcX6pLyoBtPu1jRjVNhhLDHQzlq/7CiG4QUB1FltL+ozNv2g==
+cozy-ui@52.0.0:
+  version "52.0.0"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-52.0.0.tgz#f35e44add520b07da05eca151aa836ae0bf53a05"
+  integrity sha512-GVV2UYElckfrbuhxG9oBAHXM4Z+tMVPA5XViXdZ0IC60o1+lVhSpWdOs5ZWj/rx8Iw1Nq7RVmcUoLCAgEQNKFw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
See [PR#1908](https://github.com/cozy/cozy-ui/pull/1908)

This update reduces the size of the bundle.

Before:
![before](https://user-images.githubusercontent.com/22611343/134376720-87fb1dd1-78fc-4259-8a24-67e50e3c4f32.png)

After:
<img width="324" alt="after" src="https://user-images.githubusercontent.com/22611343/134376715-bccfe648-ae3c-452b-bd9f-9e2fd566037c.png">