### PR TITLE
fix: Use correct css var color for warning and success

### DIFF
--- a/src/ducks/balance/AccountRow.styl
+++ b/src/ducks/balance/AccountRow.styl
@@ -8,7 +8,7 @@
 
 .AccountRow--hasWarning
     .AccountRow__figure
-        color var(--warnColor)
+        color var(--warningColor)
 
 .AccountRow--hasAlert
     .AccountRow__figure

--- a/src/ducks/categories/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader.styl
@@ -74,7 +74,7 @@
             background-color var(--categoriesHeaderTogglePrimaryBackgroundColor)
 
         input:checked + label
-            background-color var(--validColor)
+            background-color var(--successColor)
 
     +small-screen()
         &.normal, &.inverted

--- a/src/ducks/loan/LoanProgress.jsx
+++ b/src/ducks/loan/LoanProgress.jsx
@@ -22,7 +22,7 @@ const LoanProgress = props => {
 
   return (
     <>
-      <PercentageBar value={percentage} color="var(--validColor)" />
+      <PercentageBar value={percentage} color="var(--successColor)" />
       <div className="u-flex u-mt-half">
         <div className="u-flex-grow-1">
           <Figure total={reimbursedAmount} symbol="€" coloredPositive />

--- a/src/ducks/pin/styles.styl
+++ b/src/ducks/pin/styles.styl
@@ -105,7 +105,7 @@
     margin 1rem 0
 
 .PinWrapper--success
-    background var(--validColor)
+    background var(--successColor)
 
 .Pin__dots
     font-size 2rem

--- a/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
+++ b/src/ducks/transactions/actions/AttachedDocsAction/BillChip.jsx
@@ -67,7 +67,7 @@ const BillChip = props => {
     <Wrapper fileId={invoiceId} key={invoiceId} transaction={transaction}>
       <Chip component="button" size="small" variant="outlined">
         <FileIcon
-          color={bill.isRefund ? 'var(--validColor)' : undefined}
+          color={bill.isRefund ? 'var(--successColor)' : undefined}
           className="u-flex-shrink-0"
         />
         {bill.isRefund ? (


### PR DESCRIPTION
introduced by https://github.com/cozy/cozy-banks/pull/2221
We didn't make all the changes to the BC in v49 of cozy-ui, but since the old version of the cozy-bar was using a version prior to v49 of cozy-ui this was not a problem. Now this is not the case anymore.

⚠️ à rapatrier sur Master https://github.com/cozy/cozy-banks/pull/2240