### PR TITLE
fix: Search when clicking on the magnifying glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Remove third level import from Mui in HistoryChart
 * fix undefined var in the categ service
 * Transaction Label is now truncated if too long in the Transaction details modal
+* Fix Search Link when clicking on the magnifying glasse if label contained an "/"
 
 ## 🔧 Tech
 

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -44,7 +44,9 @@ const SearchPage = () => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
 
-  const [search, setSearch] = useState(params.search || '')
+  const [search, setSearch] = useState(
+    params.search ? decodeURIComponent(params.search) : ''
+  )
   const [resultIds, setResultIds] = useState([])
 
   useTrackPage('recherche')

--- a/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.jsx
+++ b/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.jsx
@@ -8,7 +8,7 @@ import MagnifierIcon from 'cozy-ui/transpiled/react/Icons/Magnifier'
 const SearchForTransactionIcon = ({ transaction }) => {
   const label = getLabel(transaction)
   return (
-    <a href={`#/search/${label}`}>
+    <a href={`#/search/${encodeURIComponent(label)}`}>
       <Icon className="u-ml-half u-coolGrey" icon={MagnifierIcon} />
     </a>
   )


### PR DESCRIPTION
If the transaction label contained a "/" then the search did not work
since the character was not escaped.