### PR TITLE
fix: Always display the magnifying glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - 'node-forge', 'node-jose', 'tldjs'
 * Remove third level import from Mui in HistoryChart
 * fix undefined var in the categ service
+* Transaction Label is now truncated if too long in the Transaction details modal
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/TransactionModal/TransactionLabel.jsx
+++ b/src/ducks/transactions/TransactionModal/TransactionLabel.jsx
@@ -9,15 +9,22 @@ const TransactionLabel = ({ transaction }) => {
   const label = getLabel(transaction)
 
   return (
-    <Typography variant="h6" gutterBottom>
-      {label}
+    <div className="u-flex">
+      <Typography
+        variant="h6"
+        gutterBottom
+        className="u-ellipsis"
+        title={label}
+      >
+        {label}
+      </Typography>
       {
         <>
           {' '}
           <SearchForTransactionIcon transaction={transaction} />
         </>
       }
-    </Typography>
+    </div>
   )
 }
 


### PR DESCRIPTION
Even if the label is long
![Capture d’écran 2021-09-27 à 17 09 56](https://user-images.githubusercontent.com/1107936/134935798-698d1f0a-0aed-4543-b979-2847cd08580e.png)
.