### PR TITLE
fix: Shrink lodash bundles with lodash-webpack-plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * fix undefined var in the categ service
 * Transaction Label is now truncated if too long in the Transaction details modal
 * Fix Search Link when clicking on the magnifying glasse if label contained an "/"
+* Shrink lodash bundles with lodash-webpack-plugin
 
 ## 🔧 Tech
 

--- a/config/webpack.config.plugins.js
+++ b/config/webpack.config.plugins.js
@@ -6,12 +6,20 @@ const fs = require('fs')
 
 const VersionPlugin = require('cozy-scripts/plugins/VersionPlugin')
 
+const LodashModuleReplacementPlugin = require('lodash-webpack-plugin')
+
 const manifest = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '../manifest.webapp')).toString()
 )
 
 module.exports = {
   plugins: [
+    new LodashModuleReplacementPlugin({
+      shorthands: true,
+      collections: true,
+      flattening: true,
+      paths: true
+    }),
     new webpack.DefinePlugin({
       __APP_VERSION__: JSON.stringify(manifest.version),
       __SENTRY_URL__: JSON.stringify(

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "jest": "26.6.3",
     "jest-localstorage-mock": "2.4.0",
     "lint-staged": "9.2.5",
+    "lodash-webpack-plugin": "0.11.6",
     "madge": "3.4.4",
     "mailhog": "4.7.0",
     "mockdate": "2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11461,6 +11461,13 @@ lodash-id@^0.14.0:
   resolved "https://registry.yarnpkg.com/lodash-id/-/lodash-id-0.14.0.tgz#baf48934e543a1b5d6346f8c84698b1a8c803896"
   integrity sha1-uvSJNOVDobXWNG+MhGmLGoyAOJY=
 
+lodash-webpack-plugin@0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/lodash-webpack-plugin/-/lodash-webpack-plugin-0.11.6.tgz#8204c6b78beb62ce5211217dfe783c21557ecd33"
+  integrity sha512-nsHN/+IxZK/C425vGC8pAxkKJ8KQH2+NJnhDul14zYNWr6HJcA95w+oRR7Cp0oZpOdMplDZXmjVROp8prPk7ig==
+  dependencies:
+    lodash "^4.17.20"
+
 lodash._getnative@^3.0.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"


### PR DESCRIPTION
gain of 16kb for parsed size, 5kb for gzipped size