### PR TITLE
refactor: Change small-screen to custom-screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## 🔧 Tech
 
 * Update Cozy App Publish (Fix travis icon on mattermost publish announcement)
+* Allows to have possibility to override the behavior some components. For example, change small breakpoint to medium, it allows to keep mobile behavior in tablet mode
 
 # 1.37.0
 

--- a/src/components/Padded/Padded.styl
+++ b/src/components/Padded/Padded.styl
@@ -1,16 +1,17 @@
 @require 'settings/breakpoints'
+@require '~styles/utilities'
 
 .Padded
     padding 1.5rem 2rem
 
-    +small-screen()
+    +breakpoint-screen()
         padding 1rem
 
 .Unpadded--vertical
     margin-top -1.5rem
     margin-bottom -1.5rem
 
-    +small-screen()
+    +breakpoint-screen()
         margin-top -1rem
         margin-bottom -1rem
 
@@ -18,6 +19,6 @@
     margin-left -2rem
     margin-right -2rem
 
-    +small-screen()
+    +breakpoint-screen()
         margin-left -1rem
         margin-right -1rem

--- a/src/components/Select/styles.styl
+++ b/src/components/Select/styles.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints'
+@require '~styles/utilities'
 
 select-date-height-small=2.75rem
 
@@ -28,7 +29,7 @@ select-date-height-small=2.75rem
         display none
 
 :global
-    +small-screen()
+    +breakpoint-screen()
         .cz__indicators
             height select-date-height-small
             justify-content center

--- a/src/components/SelectDates/SelectDates.styl
+++ b/src/components/SelectDates/SelectDates.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints'
+@require '~styles/utilities'
 
 // Due to discrepancies between Chrome and Firefox in
 // how select height is computed, we set it directly
@@ -29,7 +30,7 @@ select-date-height-small = 2.75rem
     .SelectDates__separator
         border-left 1px solid var(--silver)
 
-    +small-screen()
+    +breakpoint-screen()
         border-bottom 1px solid var(--silver)
         background var(--white)
         width auto
@@ -67,7 +68,7 @@ select-date-height-small = 2.75rem
         .SelectDatesButtonColor
             color var(--selectDatesButtonPrimaryColor)
 
-    +small-screen()
+    +breakpoint-screen()
         padding .5rem
 
         .SelectDates__chip
@@ -83,7 +84,7 @@ select-date-height-small = 2.75rem
 .SelectDates__month
     width 9rem
 
-+small-screen()
++breakpoint-screen()
     .SelectDates
         z-index 2
         display flex

--- a/src/ducks/categories/CategoriesChart.styl
+++ b/src/ducks/categories/CategoriesChart.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints'
+@require '~styles/utilities'
 
 .CategoriesChart
     height 182px
@@ -12,10 +13,10 @@
         border-radius 50%
         border 2px solid var(--white)
 
-        +small-screen()
+        +breakpoint-screen()
             margin-top 0
 
-    +small-screen()
+    +breakpoint-screen()
         margin-right auto
         margin-left auto
 
@@ -46,5 +47,5 @@
     font-size 1.5rem
     line-height 1.33
 
-    +small-screen()
+    +breakpoint-screen()
         padding-bottom 0

--- a/src/ducks/categories/CategoriesHeader/CategoriesHeader.styl
+++ b/src/ducks/categories/CategoriesHeader/CategoriesHeader.styl
@@ -1,4 +1,5 @@
 @require 'settings/breakpoints'
+@require '~styles/utilities'
 
 .CategoriesHeader
     display flex
@@ -7,7 +8,7 @@
     flex-shrink 0
     color var(--primaryTextColor)
 
-    +small-screen()
+    +breakpoint-screen()
         margin-top 3rem
         display block
         align-items flex-start
@@ -36,7 +37,7 @@
         left inherit
         margin-top 0
 
-+small-screen()
++breakpoint-screen()
     .SubcategoryChart
         margin-top 1rem
 
@@ -76,6 +77,6 @@
         input:checked + label
             background-color var(--successColor)
 
-    +small-screen()
+    +breakpoint-screen()
         &.normal, &.inverted
             padding-top 0

--- a/src/styles/utilities.styl
+++ b/src/styles/utilities.styl
@@ -27,3 +27,8 @@
             opacity 1
             transform translateY(0px)
 
+screen=force-screen is defined ? force-screen : small-screen
+breakpoint-screen(screen = screen)
+    +screen()
+        {block}
+


### PR DESCRIPTION
Allows to have possibility to override the behavior some components.
For example, change small breakpoint to medium, it allows to keep mobile
behavior in tablet mode.

Usage example:
screen=medium-screen

If not value setted so small-screen is default value