### PR TITLE
Fix/notifs wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## ✨ Features
 
 * Alert notifications for KO connectors link to the accounts page in the settings
+* Change wording push content notification
+    * Change EUR by €
+    * Replace '.' in amount by ','
+    * Capitalize each transaction label word
+    * Show by line 50 char max Example if the label from transaction is `Salaire du mois de Septembre 2021 (01/09/2021)` with an amount `1234.56` so we display that: `Salaire Du Mois De Septembre 2021 (01/0 : 1234,56€`
 
 ## 🐛 Bug Fixes
 

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -5,14 +5,12 @@ import overEvery from 'lodash/overEvery'
 import merge from 'lodash/merge'
 import groupBy from 'lodash/groupBy'
 import fromPairs from 'lodash/fromPairs'
-import sortBy from 'lodash/sortBy'
 
 import log from 'cozy-logger'
 import { toText } from 'cozy-notifications'
 
 import NotificationView from 'ducks/notifications/BaseNotificationView'
 import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
-import { getAccountLabel } from 'ducks/account/helpers'
 import { isTransactionAmountGreaterThan } from 'ducks/notifications/helpers'
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import {
@@ -23,6 +21,7 @@ import {
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 
 import template from './template.hbs'
+import { formatTransaction } from './utils'
 
 const getDocumentId = x => x._id
 
@@ -255,34 +254,18 @@ class TransactionGreater extends NotificationView {
   }
 
   getPushContent(templateData) {
-    const notificationSubtype = this.getNotificationSubtype(templateData)
+    const { transactions } = templateData
 
-    const accountsById = templateData.accounts
-    const transactions = templateData.transactions
-    const [transaction] = sortBy(transactions, getDate).reverse()
+    const pushContent =
+      transactions.length > 3
+        ? transactions
+            .slice(0, 3)
+            .map(formatTransaction)
+            .join('\n')
+            .concat('...')
+        : transactions.map(formatTransaction).join('\n')
 
-    if (notificationSubtype === SINGLE_TRANSACTION) {
-      return `${transaction.label} : ${formatAmount(
-        transaction.amount
-      )}${getCurrencySymbol(transaction.currency)}`
-    } else {
-      const transactionGroupedByAccount = groupBy(transactions, x => x.account)
-      const groups = Object.entries(transactionGroupedByAccount).map(
-        ([accountId, transactions]) => ({
-          account: accountsById[accountId],
-          transactions
-        })
-      )
-      return groups
-        .map(
-          g =>
-            `${getAccountLabel(g.account)}: ${this.t(
-              'Notifications.if-transaction-greater.notification.content-transaction-mention',
-              { smart_count: g.transactions.length }
-            )}`
-        )
-        .join('\n')
-    }
+    return pushContent
   }
 }
 

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -7,7 +7,6 @@ import groupBy from 'lodash/groupBy'
 import fromPairs from 'lodash/fromPairs'
 
 import log from 'cozy-logger'
-import { toText } from 'cozy-notifications'
 
 import NotificationView from 'ducks/notifications/BaseNotificationView'
 import { getDate, isNew as isNewTransaction } from 'ducks/transactions/helpers'
@@ -21,13 +20,9 @@ import {
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 
 import template from './template.hbs'
-import { formatTransaction } from './utils'
+import { customToText, formatTransaction } from './utils'
 
 const getDocumentId = x => x._id
-
-const ACCOUNT_SEL = '.js-account'
-const DATE_SEL = '.js-date'
-const TRANSACTION_SEL = '.js-transaction'
 
 const SINGLE_TRANSACTION = 'single'
 const MULTI_TRANSACTION = 'multi'
@@ -49,39 +44,6 @@ const MULTI_TRANSACTION_MULTI_RULES = 'multi-rules'
 // is why we deactivate the isNewTransaction during tests
 const isNewTransactionOutsideTests =
   process.env.IS_TESTING === 'test' ? () => true : isNewTransaction
-
-const customToText = cozyHTMLEmail => {
-  const getTextTransactionRow = $row =>
-    $row
-      .find('td')
-      .map((i, td) =>
-        $row
-          .find(td)
-          .text()
-          .trim()
-      )
-      .toArray()
-      .join(' ')
-      .replace(/\n/g, '')
-      .replace(' €', '€')
-      .trim()
-
-  const getContent = $ =>
-    $([ACCOUNT_SEL, DATE_SEL, TRANSACTION_SEL].join(', '))
-      .toArray()
-      .map(node => {
-        const $node = $(node)
-        if ($node.is(ACCOUNT_SEL)) {
-          return '\n\n### ' + $node.text()
-        } else if ($node.is(DATE_SEL)) {
-          return '\n' + $node.text() + '\n'
-        } else if ($node.is(TRANSACTION_SEL)) {
-          return '- ' + getTextTransactionRow($node)
-        }
-      })
-      .join('\n')
-  return toText(cozyHTMLEmail, getContent)
-}
 
 const isTransactionFromAccount = account => transaction =>
   transaction.account === account._id

--- a/src/ducks/notifications/TransactionGreater/utils.js
+++ b/src/ducks/notifications/TransactionGreater/utils.js
@@ -1,0 +1,24 @@
+import { getCurrencySymbol } from 'utils/currencySymbol'
+import capitalize from 'lodash/capitalize'
+
+export const MAX_CHAR_BY_LINE = 50
+const SEPARATOR = ' : '
+
+const capitalizeEachWords = str =>
+  str
+    .split(' ')
+    .map(capitalize)
+    .join(' ')
+
+export const formatTransaction = transaction => {
+  const { amount, currency } = transaction
+  const amountFormat = `${amount}${getCurrencySymbol(currency)}`.replace(
+    '.',
+    ','
+  )
+  const REMAINS_LENGTH =
+    MAX_CHAR_BY_LINE - SEPARATOR.length - amountFormat.length
+  const labelCapitalize = capitalizeEachWords(transaction.label)
+  const transactionName = labelCapitalize.substr(0, REMAINS_LENGTH)
+  return `${transactionName}${SEPARATOR}${amountFormat}`
+}

--- a/src/ducks/notifications/TransactionGreater/utils.js
+++ b/src/ducks/notifications/TransactionGreater/utils.js
@@ -1,5 +1,10 @@
 import { getCurrencySymbol } from 'utils/currencySymbol'
 import capitalize from 'lodash/capitalize'
+import { toText } from 'cozy-notifications'
+
+const ACCOUNT_SEL = '.js-account'
+const DATE_SEL = '.js-date'
+const TRANSACTION_SEL = '.js-transaction'
 
 export const MAX_CHAR_BY_LINE = 50
 const SEPARATOR = ' : '
@@ -21,4 +26,38 @@ export const formatTransaction = transaction => {
   const labelCapitalize = capitalizeEachWords(transaction.label)
   const transactionName = labelCapitalize.substr(0, REMAINS_LENGTH)
   return `${transactionName}${SEPARATOR}${amountFormat}`
+}
+
+// TODO add tests
+export const customToText = cozyHTMLEmail => {
+  const getTextTransactionRow = $row =>
+    $row
+      .find('td')
+      .map((i, td) =>
+        $row
+          .find(td)
+          .text()
+          .trim()
+      )
+      .toArray()
+      .join(' ')
+      .replace(/\n/g, '')
+      .replace(' €', '€')
+      .trim()
+
+  const getContent = $ =>
+    $([ACCOUNT_SEL, DATE_SEL, TRANSACTION_SEL].join(', '))
+      .toArray()
+      .map(node => {
+        const $node = $(node)
+        if ($node.is(ACCOUNT_SEL)) {
+          return '\n\n### ' + $node.text()
+        } else if ($node.is(DATE_SEL)) {
+          return '\n' + $node.text() + '\n'
+        } else if ($node.is(TRANSACTION_SEL)) {
+          return '- ' + getTextTransactionRow($node)
+        }
+      })
+      .join('\n')
+  return toText(cozyHTMLEmail, getContent)
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -444,7 +444,6 @@
         "accountOrGroup": "On account/group"
       },
       "notification": {
-        "content-transaction-mention": "%{smart_count} transaction |||| %{smart_count} transactions",
         "debit": {
           "title": "Debit of %{amount}%{currency}"
         },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -445,7 +445,6 @@
         "accountOrGroup": "sur"
       },
       "notification": {
-        "content-transaction-mention": "%{smart_count} mouvement |||| %{smart_count} mouvements",
         "debit": {
           "title": "Dépense de %{amount}%{currency}"
         },

--- a/test/fixtures/transaction-greater-fixtures.json
+++ b/test/fixtures/transaction-greater-fixtures.json
@@ -1,0 +1,78 @@
+{
+  "io.cozy.bank.operations": [
+    {
+      "_id": "reimbursement",
+      "demo": true,
+      "manualCategoryId": "401010",
+      "account": "compteisa1",
+      "label": "REMBOURSEMENT PRET LCL",
+      "currency": "EUR",
+      "amount": -1231,
+      "date": "2021-09-02T00:00:00Z"
+    },
+    {
+      "_id": "edf",
+      "demo": true,
+      "manualCategoryId": "401080",
+      "account": "compteisa1",
+      "label": "EDF PARTICULIERS",
+      "currency": "EUR",
+      "amount": 77.5,
+      "date": "2021-09-03T00:00:00Z"
+    },
+    {
+      "_id": "salaireseptembre",
+      "demo": true,
+      "manualCategoryId": "401010",
+      "account": "compteisa1",
+      "label": "Salaire du mois de Septembre 2021 (01/09/2021)",
+      "currency": "EUR",
+      "amount": 1234.56,
+      "date": "2021-09-01T00:00:00Z"
+    },
+    {
+      "_id": "salaireoctobre",
+      "demo": true,
+      "manualCategoryId": "401010",
+      "account": "compteisa1",
+      "label": "Salaire du mois de Octobre 2021 (01/10/2021)",
+      "currency": "EUR",
+      "amount": 1234.56,
+      "date": "2021-10-01T00:00:00Z"
+    },
+    {
+      "_id": "salairenovembre",
+      "demo": true,
+      "manualCategoryId": "401010",
+      "account": "compteisa1",
+      "label": "Salaire du mois de Novembre 2021 (01/11/2021)",
+      "currency": "EUR",
+      "amount": 2000.12,
+      "date": "2021-11-01T00:00:00Z"
+    },
+
+    {
+      "_id": "salairedecembre",
+      "demo": true,
+      "manualCategoryId": "401010",
+      "account": "compteisa1",
+      "label": "Salaire du mois de Decembre 2021 (01/12/2021)",
+      "currency": "EUR",
+      "amount": 900.24,
+      "date": "2021-12-01T00:00:00Z"
+    }
+  ],
+  "io.cozy.bank.accounts": [
+    {
+      "_id": "compteisa1",
+      "label": "Compte courant Isabelle",
+      "institutionLabel": "BNPP",
+      "number": "{{int 1000000 9999999}}",
+      "balance": 3974.20,
+      "type": "Checkings",
+      "cozyMetadata": {
+        "createdByApp": "bnpparibas82"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Change wording push content notification
- Change EUR by €
- Replace '.' in amount by ','
- Capitalize each transaction label word
- Show by line 50 char max
Example if the label from transaction is `Salaire du mois de Septembre 2021 (01/09/2021)` with
an amount `1234.56` so we display that: `Salaire Du Mois De Septembre 2021 (01/0 : 1234,56€`
