### PR TITLE
Building virtual accounts works even for empty transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 
 ## 🐛 Bug Fixes
 
-*
+* Show empty page title only for mobile
+* Reimbursement block is visible again on the balance page if it is shown first
 
 ## 🔧 Tech
 

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -234,9 +234,6 @@ export const buildOthersReimbursementsVirtualAccount = buildReimbursementsVirtua
 )
 
 export const buildVirtualAccounts = transactions => {
-  if (transactions.length === 0) {
-    return []
-  }
   return [
     buildHealthReimbursementsVirtualAccount(transactions),
     buildProfessionalReimbursementsVirtualAccount(transactions),

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -236,10 +236,10 @@ describe('buildVirtualAccounts', () => {
     expect(othersExpenseAccount).toBeDefined()
   })
 
-  it('should not build virtual accounts if there are no transactions', () => {
+  it('should build virtual accounts even if there are no transactions', () => {
     flag.mockReturnValue(true)
     const virtualAccounts = buildVirtualAccounts([])
-    expect(virtualAccounts.length).toBe(0)
+    expect(virtualAccounts.length).toBe(3)
   })
 })
 

--- a/src/ducks/balance/NoAccount.jsx
+++ b/src/ducks/balance/NoAccount.jsx
@@ -23,7 +23,7 @@ export const NoAccount = ({ buttonTheme, children }) => {
   const contentProps = isMobile ? { center: true } : { bottom: true }
   return (
     <CozyTheme variant="inverted">
-      <PageTitle>{t('Balance.title')}</PageTitle>
+      {isMobile && <PageTitle>{t('Balance.title')}</PageTitle>}
       <Container className={styles.NoAccount}>
         <BarTheme theme="primary" />
         <Content {...contentProps}>


### PR DESCRIPTION
revert of https://github.com/cozy/cozy-banks/pull/1828/commits/e061e376b972e86fb6dfe3ee8ae2b3f43effc2b9

il n'y a pas de souci pour autant avec la page Empty lorsqu'il n'y a aucune data (le bloc de remboursement n'apparaît pas pour autant)