### PR TITLE
fix: Query by date and account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Show empty page title only for mobile
 * Reimbursement block is visible again on the balance page if it is shown first
+* Show operations by date and by account (and not the reverse) in group details
 
 ## 🔧 Tech
 

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -47,9 +47,11 @@ export const makeFilteredTransactionsConn = options => {
         // with only the account. We haven't found a satisfactory solution
         // yet.
         const accounts = makeAccounts(filteringDoc, groups)
+        indexFields = [dateAttribute, 'account']
         whereClause = {
           account: { $in: accounts }
         }
+        sortByClause = [{ [dateAttribute]: 'desc' }, { account: 'desc' }]
       } else if (filteringDoc._type === ACCOUNT_DOCTYPE) {
         whereClause = { account: filteringDoc._id }
       } else if (Array.isArray(filteringDoc)) {

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -49,11 +49,11 @@ describe('makeFilteredTransactionsConn', () => {
 
     expect(query).toEqual(
       expect.objectContaining({
-        indexedFields: ['account', 'date'],
+        indexedFields: ['date', 'account'],
         selector: {
           account: { $in: ['a1', 'a2', 'a3'] }
         },
-        sort: [{ account: 'desc' }, { date: 'desc' }]
+        sort: [{ date: 'desc' }, { account: 'desc' }]
       })
     )
   })
@@ -83,11 +83,11 @@ describe('makeFilteredTransactionsConn', () => {
 
     expect(query).toEqual(
       expect.objectContaining({
-        indexedFields: ['account', 'date'],
+        indexedFields: ['date', 'account'],
         selector: {
           account: { $in: ['a1', 'a2', 'a3'] }
         },
-        sort: [{ account: 'desc' }, { date: 'desc' }]
+        sort: [{ date: 'desc' }, { account: 'desc' }]
       })
     )
   })


### PR DESCRIPTION
We made changes to optimize transaction requests(https://github.com/cozy/cozy-banks/commit/644084663e01cc69792c0f677eed4faf6016fa03).

This resulted in a functional regression, we had displayed data only on
an account-by-account. Except we want to have them first by date.

We know that we are not following our recommendations (https://docs.cozy.io/en/tutorials/data/advanced/#indexes-performances-and-design) but we consider that there are fewer accounts than operations, performance will
be slightly degraded.