### PR TITLE
Fix delayed notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* Scheduled notification are created only if a notification will be sent in the next day, and only if there is no already notification in the futur
+
 ## 🔧 Tech
 
 # 1.39.0

--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -1,11 +1,10 @@
-import { Q } from 'cozy-client'
 import flag from 'cozy-flags'
 
-import { TRIGGER_DOCTYPE, JOBS_DOCTYPE } from 'doctypes'
 import { logger } from 'ducks/konnectorAlerts'
 import { runService } from './service'
 import { sendTriggerNotifications } from './konnectorAlerts/sendTriggerNotifications'
 import { createScheduledTrigger } from './konnectorAlerts/createTriggerAt'
+import { setIgnoredErrorsFlag } from './konnectorAlerts/setIgnoredErrorsFlag'
 
 const main = async ({ client }) => {
   client.registerPlugin(flag.plugin)
@@ -19,48 +18,7 @@ const main = async ({ client }) => {
     return
   }
 
-  let serviceTrigger = undefined
-  let serviceJob = undefined
-  const triggerId = process.env.COZY_TRIGGER_ID
-  const jobId = process.env.COZY_JOB_ID?.split('/').pop()
-
-  logger(
-    'info',
-    `Executing job notifications service by trigger: ${triggerId}, job: ${jobId}...`
-  )
-
-  try {
-    const { data } = await client.query(Q(TRIGGER_DOCTYPE).getById(triggerId))
-    serviceTrigger = data
-  } catch (e) {
-    logger(
-      'error',
-      `❗ Error when getting trigger with id: ${triggerId}, reason: ${e.message}`
-    )
-  }
-
-  try {
-    const { data } = await client.query(Q(JOBS_DOCTYPE).getById(jobId))
-    serviceJob = data
-  } catch (e) {
-    logger(
-      'error',
-      `❗ Error when getting job with id: ${jobId}, reason: ${e.message}`
-    )
-  }
-
-  const forcedIgnoredErrors =
-    serviceTrigger?.message?.forceIgnoredErrors ||
-    serviceJob?.message?.forceIgnoredErrors
-
-  if (forcedIgnoredErrors) {
-    flag('banks.konnector-alerts.ignored-errors', forcedIgnoredErrors)
-    logger(
-      'info',
-      `Forced flag banks.konnector-alerts.ignored-errors to: ${forcedIgnoredErrors}`
-    )
-  }
-
+  await setIgnoredErrorsFlag(client)
   await sendTriggerNotifications(client)
   await createScheduledTrigger(client)
 }

--- a/src/targets/services/konnectorAlerts/createTriggerAt.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.js
@@ -1,7 +1,7 @@
 import { TRIGGER_DOCTYPE } from 'doctypes'
 import { logger } from 'ducks/konnectorAlerts'
 import { ONE_DAY } from 'ducks/recurrence/constants'
-import { getTriggerStates, fetchRelatedAtTriggers } from './helpers'
+import { getTriggerStates, fetchRelatedFuturAtTriggers } from './helpers'
 
 const dateInDays = (referenceDate, n) => {
   return new Date(+new Date(referenceDate) + n * ONE_DAY)
@@ -51,12 +51,12 @@ export const createScheduledTrigger = async client => {
       continue
     }
 
-    const relatedAtTriggers = await fetchRelatedAtTriggers(client, id)
+    const relatedFuturAtTriggers = await fetchRelatedFuturAtTriggers(client, id)
 
-    if (relatedAtTriggers.length > 0) {
+    if (relatedFuturAtTriggers.length > 0) {
       logger(
         'info',
-        `⚠️  Not created: @at triggers already existing for this konnector trigger`
+        `⚠️  Not created: @at triggers already existing in the futur for this konnector trigger`
       )
       continue
     }

--- a/src/targets/services/konnectorAlerts/createTriggerAt.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.js
@@ -43,17 +43,10 @@ export const createScheduledTrigger = async client => {
       `⌛ Try to create @at triggers for konnectorTriggerId: ${id}...`
     )
 
-    if (triggerStates?.status !== 'errored') {
-      logger('info', `⚠️  Not created: this konnector trigger isn't in error`)
-      continue
-    }
-
-    if (
-      triggerStates?.shouldNotify?.reason !== 'last-failure-already-notified'
-    ) {
+    if (triggerStates?.shouldNotify?.ok !== true) {
       logger(
         'info',
-        `⚠️  Not created: this konnector trigger doesn't match last-failure-already-notified condition`
+        `⚠️  Not created: this konnector trigger doesn't sent any notification`
       )
       continue
     }

--- a/src/targets/services/konnectorAlerts/createTriggerAt.spec.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.spec.js
@@ -1,12 +1,12 @@
 import { createMockClient } from 'cozy-client'
 
 import { createScheduledTrigger, containerForTesting } from './createTriggerAt'
-import { getTriggerStates, fetchRelatedAtTriggers } from './helpers'
+import { getTriggerStates, fetchRelatedFuturAtTriggers } from './helpers'
 
 jest.mock('./helpers', () => ({
   ...jest.requireActual('./helpers'),
   getTriggerStates: jest.fn(),
-  fetchRelatedAtTriggers: jest.fn()
+  fetchRelatedFuturAtTriggers: jest.fn()
 }))
 
 jest.spyOn(containerForTesting, 'createTriggerAt')
@@ -36,13 +36,13 @@ describe('createTriggerAt', () => {
     expect(containerForTesting.createTriggerAt).not.toHaveBeenCalled()
   })
 
-  it('should not create @at triggers if there are already created', async () => {
+  it('should not create @at triggers if there are already created in the futur', async () => {
     getTriggerStates.mockResolvedValue({
       trigger01Id: {
         shouldNotify: { ok: true }
       }
     })
-    fetchRelatedAtTriggers.mockResolvedValue([
+    fetchRelatedFuturAtTriggers.mockResolvedValue([
       { type: '@at', message: { konnectorTriggerId: 'trigger01Id' } }
     ])
 
@@ -57,7 +57,7 @@ describe('createTriggerAt', () => {
         shouldNotify: { ok: true }
       }
     })
-    fetchRelatedAtTriggers.mockResolvedValue([])
+    fetchRelatedFuturAtTriggers.mockResolvedValue([])
 
     await createScheduledTrigger(client)
 

--- a/src/targets/services/konnectorAlerts/createTriggerAt.spec.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.spec.js
@@ -26,9 +26,9 @@ describe('createTriggerAt', () => {
     expect(containerForTesting.createTriggerAt).not.toHaveBeenCalled()
   })
 
-  it("should not create @at triggers if the konnector doesn't match last-failure-already-notified condition", async () => {
+  it("should not create @at triggers if the konnector doesn't sent notification", async () => {
     getTriggerStates.mockResolvedValue({
-      trigger01Id: { shouldNotify: { reason: 'error-not-actionable' } }
+      trigger01Id: { shouldNotify: { ok: false } }
     })
 
     await createScheduledTrigger(client)
@@ -39,7 +39,7 @@ describe('createTriggerAt', () => {
   it('should not create @at triggers if there are already created', async () => {
     getTriggerStates.mockResolvedValue({
       trigger01Id: {
-        shouldNotify: { reason: 'last-failure-already-notified' }
+        shouldNotify: { ok: true }
       }
     })
     fetchRelatedAtTriggers.mockResolvedValue([
@@ -51,25 +51,10 @@ describe('createTriggerAt', () => {
     expect(containerForTesting.createTriggerAt).not.toHaveBeenCalled()
   })
 
-  it('should not create @at triggers if the konnector status is not errored ', async () => {
-    getTriggerStates.mockResolvedValue({
-      trigger01Id: {
-        shouldNotify: { reason: 'last-failure-already-notified' },
-        status: 'done'
-      }
-    })
-    fetchRelatedAtTriggers.mockResolvedValue([])
-
-    await createScheduledTrigger(client)
-
-    expect(containerForTesting.createTriggerAt).not.toHaveBeenCalled()
-  })
-
   it('should create two @at triggers', async () => {
     getTriggerStates.mockResolvedValue({
       trigger01Id: {
-        shouldNotify: { reason: 'last-failure-already-notified' },
-        status: 'errored'
+        shouldNotify: { ok: true }
       }
     })
     fetchRelatedAtTriggers.mockResolvedValue([])

--- a/src/targets/services/konnectorAlerts/helpers.js
+++ b/src/targets/services/konnectorAlerts/helpers.js
@@ -104,11 +104,12 @@ export const isErrorActionable = errorMessage => {
   )
 }
 
-export const fetchRelatedAtTriggers = async (client, id) => {
+export const fetchRelatedFuturAtTriggers = async (client, id) => {
   const { data } = await client.query(
     Q(TRIGGER_DOCTYPE).where({
       type: '@at',
-      'message.konnectorTriggerId': id
+      'message.konnectorTriggerId': id,
+      arguments: { $gt: new Date(Date.now()).toISOString() }
     })
   )
 

--- a/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
+++ b/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
@@ -1,0 +1,49 @@
+import { Q } from 'cozy-client'
+import flag from 'cozy-flags'
+
+import { TRIGGER_DOCTYPE, JOBS_DOCTYPE } from 'doctypes'
+import { logger } from 'ducks/konnectorAlerts'
+
+export const setIgnoredErrorsFlag = async client => {
+  let serviceTrigger = undefined
+  let serviceJob = undefined
+  const triggerId = process.env.COZY_TRIGGER_ID
+  const jobId = process.env.COZY_JOB_ID?.split('/').pop()
+
+  logger(
+    'info',
+    `Executing job notifications service by trigger: ${triggerId}, job: ${jobId}...`
+  )
+
+  try {
+    const { data } = await client.query(Q(TRIGGER_DOCTYPE).getById(triggerId))
+    serviceTrigger = data
+  } catch (e) {
+    logger(
+      'error',
+      `❗ Error when getting trigger with id: ${triggerId}, reason: ${e.message}`
+    )
+  }
+
+  try {
+    const { data } = await client.query(Q(JOBS_DOCTYPE).getById(jobId))
+    serviceJob = data
+  } catch (e) {
+    logger(
+      'error',
+      `❗ Error when getting job with id: ${jobId}, reason: ${e.message}`
+    )
+  }
+
+  const forcedIgnoredErrors =
+    serviceTrigger?.message?.forceIgnoredErrors ||
+    serviceJob?.message?.forceIgnoredErrors
+
+  if (forcedIgnoredErrors) {
+    flag('banks.konnector-alerts.ignored-errors', forcedIgnoredErrors)
+    logger(
+      'info',
+      `Forced flag banks.konnector-alerts.ignored-errors to: ${forcedIgnoredErrors}`
+    )
+  }
+}

--- a/src/targets/services/service.js
+++ b/src/targets/services/service.js
@@ -26,7 +26,7 @@ export const runService = async service => {
 
   return service({ client }).catch(e => {
     // eslint-disable-next-line no-console
-    console.error(e)
+    console.error('❗ The service catched an error:', e)
     process.exit(1)
   })
 }


### PR DESCRIPTION
- le service ne fetch plus les triggers donc ne s'arrêtera plus s'il essaye de fetcher un trigger inexistant
- on se base maintenant sur le fait d'envoyer une notif à J pour programmer les J+3 et J+7
- on vérifie seulement les triggers existants dans le futur (et non toutes dates confondues) pour vérifier qu'il y a déjà des triggers de posé ou non