### PR TITLE
feat: Change the time for sending notifications from 6am to 5am

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## 🐛 Bug Fixes
 
 * Scheduled notification are created only if a notification will be sent in the next day, and only if there is no already notification in the futur
+* Notifications for errored connector are now sent at 5am local time (UTC for cozy servers) instead of 6am
+* Scheduling notifications if sending is between 10pm and 5am local time (UTC for cozy servers) instead of 11pm and 6am
 
 ## 🔧 Tech
 

--- a/src/ducks/konnectorAlerts/notification.js
+++ b/src/ducks/konnectorAlerts/notification.js
@@ -17,17 +17,17 @@ import {
 } from 'cozy-harvest-lib/dist/helpers/konnectors'
 
 /**
- * Returns the next date time at 6ish
+ * Returns the next date time at 5ish server local time (UTC for cozy servers)
  *
- * If now is earlier than 6AM, return today at 6, otherwise
- * tomorrow at 6.
+ * If now is earlier than 5AM, return today at 5, otherwise
+ * tomorrow at 5.
  *
  * A bit of fuzziness is added so that every notification is not sent
  * exactly at the same time, to reduce the spike on the servers.
  */
 export const getScheduleDate = currentDate => {
   let date = currentDate || new Date()
-  let hours = 6
+  let hours = 5
   let minutes = Math.round(15 * Math.random())
 
   if (

--- a/src/ducks/konnectorAlerts/notification.spec.js
+++ b/src/ducks/konnectorAlerts/notification.spec.js
@@ -1,19 +1,21 @@
 import { getScheduleDate } from './notification'
 
 describe('getScheduleDate', () => {
-  it('should return a date the same day if before 6', () => {
-    const date = new Date(2020, 0, 1, 5, 15)
+  it('should return a date the same day if before 5', () => {
+    const date = new Date(2020, 0, 1, 4, 15)
     const scheduled = getScheduleDate(date)
-    expect(scheduled.getHours()).toBe(6)
+
+    expect(scheduled.getHours()).toBe(5)
     expect(scheduled.getFullYear()).toBe(2020)
     expect(scheduled.getMonth()).toBe(0)
     expect(scheduled.getDate()).toBe(1)
   })
 
-  it('should return a date the next day if past 6', () => {
+  it('should return a date the next day if past 5', () => {
     const date = new Date(2020, 0, 1, 7, 15)
     const scheduled = getScheduleDate(date)
-    expect(scheduled.getHours()).toBe(6)
+
+    expect(scheduled.getHours()).toBe(5)
     const minutes = scheduled.getMinutes()
     expect(minutes >= 0 && minutes < 16).toBe(true)
     expect(scheduled.getFullYear()).toBe(2020)

--- a/src/ducks/notifications/helpers.js
+++ b/src/ducks/notifications/helpers.js
@@ -47,19 +47,19 @@ export const getAccountNewBalance = creditCard => {
 }
 
 /**
- * Returns the next date at 6AM
- * if current date is between 23h - 6h
+ * Returns the next date at 5AM server local time (UTC for cozy server)
+ * if current date is between 22h - 5h
  */
 export const getScheduleDate = currentDate => {
   let date = new Date(currentDate)
-  const hours = 6
+  const hours = 5
   const minutes = Math.round(15 * Math.random())
 
-  if (date.getHours() >= 23) {
+  if (date.getHours() >= 22) {
     date = new Date(+date + ONE_DAY)
   }
 
-  if (date.getHours() <= 5 || date.getHours() >= 23) {
+  if (date.getHours() <= 4 || date.getHours() >= 22) {
     date.setHours(hours)
     date.setMinutes(minutes)
   }

--- a/src/ducks/notifications/helpers.spec.js
+++ b/src/ducks/notifications/helpers.spec.js
@@ -42,34 +42,34 @@ describe('getReimbursementBillIds', () => {
 })
 
 describe('getScheduleDate', () => {
-  it('should return a date the next day at 6AM', () => {
-    const date = new Date('2021-11-01T23:30:00')
+  it('should return a date the next day at 5AM', () => {
+    const date = new Date('2021-11-01T22:30:00')
 
     expect(getScheduleDate(date).getDay()).toBe(2)
-    expect(getScheduleDate(date).getHours()).toBe(6)
+    expect(getScheduleDate(date).getHours()).toBe(5)
   })
 
-  it('should return the same date at 6AM', () => {
+  it('should return the same date at 5AM', () => {
     const date = new Date('2021-11-02T01:30:00')
 
     expect(getScheduleDate(date).getDay()).toBe(2)
-    expect(getScheduleDate(date).getHours()).toBe(6)
+    expect(getScheduleDate(date).getHours()).toBe(5)
   })
 
   it('should return the same date and same hours', () => {
-    let date = new Date('2021-11-01T22:30:00')
+    let date = new Date('2021-11-01T21:30:00')
     let scheduledDate = getScheduleDate(date)
 
     expect(date).toEqual(scheduledDate)
 
-    date = new Date('2021-11-02T06:30:00')
+    date = new Date('2021-11-02T05:30:00')
     scheduledDate = getScheduleDate(date)
 
     expect(date).toEqual(scheduledDate)
   })
 
   it('should not mutate the initial date', () => {
-    let date = new Date('2021-11-01T23:30:00')
+    let date = new Date('2021-11-01T22:30:00')
     let scheduledDate = getScheduleDate(date)
 
     expect(date).not.toEqual(scheduledDate)


### PR DESCRIPTION
Comme le calcul de l'heure est basée sur l'heure locale, et que les serveurs sont en UTC, on retarde l'envoie de notif d'une heure pour coller à un créneau correct concernant la France.

amélioration possible notée ici https://github.com/cozy/cozy-banks/issues/2298
