### PR TITLE
Add missing withBreakpoints in transaction page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ## 🐛 Bug Fixes
 
+* Transactions page indicated `isDesktop undefined` when changing month in the date selector
+
 ## 🔧 Tech
 
 # 1.40.0
 
 ## ✨ Features
-- cozy-harvest-lib 6.15.0 : get support email according to the contect [PR](https://github.com/cozy/cozy-libs/pull/1392)
+
+* cozy-harvest-lib 6.15.0 : get support email according to the contect [PR](https://github.com/cozy/cozy-libs/pull/1392)
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -74,11 +74,6 @@
     "service": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/services/cli.js",
     "service:autogroups": "BABEL_ENV=cli babel-node --ignore /some-fake-path src/targets/services/autogroups.js"
   },
-  "husky": {
-    "hooks": {
-      "pre-push": "yarn test:changes"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/cozy/cozy-banks.git"

--- a/src/ducks/transactions/TransactionsPage.jsx
+++ b/src/ducks/transactions/TransactionsPage.jsx
@@ -15,6 +15,7 @@ import {
 } from 'cozy-client'
 import { translate } from 'cozy-ui/transpiled/react/I18n'
 import Typography from 'cozy-ui/transpiled/react/Typography'
+import withBreakpoints from 'cozy-ui/transpiled/react/helpers/withBreakpoints'
 import flag from 'cozy-flags'
 
 import {
@@ -303,7 +304,8 @@ const addTransactions = Component => {
 export const DumbTransactionsPage = TransactionsPage
 export const UnpluggedTransactionsPage = compose(
   withRouter,
-  translate()
+  translate(),
+  withBreakpoints()
 )(TransactionsPage)
 
 const ConnectedTransactionsPage = compose(


### PR DESCRIPTION
to avoid `undefined isDesktop` error when changing month