### PR TITLE
Update groupedExpenses selectors when state documents updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 🐛 Bug Fixes
 
 * Transactions page indicated `isDesktop undefined` when changing month in the date selector
+* Reimbursements shows correct datas even if coming from the home page
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -216,7 +216,7 @@
     "redux-logger": "3.0.6",
     "redux-raven-middleware": "1.2.0",
     "redux-thunk": "2.3.0",
-    "reselect": "4.0.0",
+    "reselect": "4.1.5",
     "timezone": "1.0.22",
     "velocity-animate": "1.5.2",
     "whatwg-fetch": "3.0.0"

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -63,16 +63,23 @@ export const queryDataSelector = (queryName, options) =>
     query => (query && query.data) || []
   )
 
-export const getTransactionsRaw = state =>
-  createSelector([x => x], documents => {
+export const documentSelector = (doctype, options = {}) =>
+  createSelector([state => state.cozy.documents[doctype]], documents => {
     const client = getClient()
     const docs = Object.values(documents || {})
-    const partialTransactions = client.hydrateDocuments(
-      TRANSACTION_DOCTYPE,
-      docs
-    )
+    return options.hydrated ? client.hydrateDocuments(doctype, docs) : docs
+  })
+
+export const getTransactionsRaw = createSelector(
+  [
+    documentSelector(TRANSACTION_DOCTYPE, {
+      hydrated: true
+    })
+  ],
+  partialTransactions => {
     return partialTransactions.filter(x => !!x.label)
-  })(state.cozy.documents[TRANSACTION_DOCTYPE])
+  }
+)
 
 export const getGroups = queryDataSelector('groups', {
   hydrated: true

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,19 +1,22 @@
+import isEqual from 'lodash/isEqual'
+import keyBy from 'lodash/keyBy'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
+
+import { getQueryFromState } from 'cozy-client'
+
+import { ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
 import { buildAutoGroups, isAutoGroup } from 'ducks/groups/helpers'
 import {
   buildVirtualAccounts,
   isReimbursementsAccount
 } from 'ducks/account/helpers'
-import { getQueryFromState } from 'cozy-client'
-import getClient from './getClient'
-import keyBy from 'lodash/keyBy'
 import {
   getDefaultedSettings,
   isConfigurationSetting,
   getNotificationFromConfig,
   getWarningLimitsPerAccount as getWarningLimitsPerAccountRaw
 } from 'ducks/settings/helpers'
-import { ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
+import getClient from 'selectors/getClient'
 
 const updatedAtSameTime = (currentQuery, prevQuery) => {
   return (
@@ -63,19 +66,22 @@ export const queryDataSelector = (queryName, options) =>
     query => (query && query.data) || []
   )
 
-export const documentSelector = (doctype, options = {}) =>
-  createSelector([state => state.cozy.documents[doctype]], documents => {
+export const documentSelector = createSelector(
+  state => ({ ...state.cozy.documents[TRANSACTION_DOCTYPE] }),
+  documents => {
     const client = getClient()
     const docs = Object.values(documents || {})
-    return options.hydrated ? client.hydrateDocuments(doctype, docs) : docs
-  })
+    return client.hydrateDocuments(TRANSACTION_DOCTYPE, docs)
+  },
+  {
+    memoizeOptions: {
+      equalityCheck: (a, b) => isEqual(a, b)
+    }
+  }
+)
 
 export const getTransactionsRaw = createSelector(
-  [
-    documentSelector(TRANSACTION_DOCTYPE, {
-      hydrated: true
-    })
-  ],
+  documentSelector,
   partialTransactions => {
     return partialTransactions.filter(x => !!x.label)
   }
@@ -89,7 +95,7 @@ export const getSettings = queryDataSelector('settings', {
   hydrated: true
 })
 
-export const getConfig = createSelector([getSettings], settings =>
+export const getConfig = createSelector(getSettings, settings =>
   getDefaultedSettings(settings.find(isConfigurationSetting))
 )
 
@@ -99,12 +105,12 @@ export const getRecurrences = queryDataSelector('recurrence', {
 })
 
 export const getTransactions = createSelector(
-  [getTransactionsRaw],
+  getTransactionsRaw,
   transactions => transactions.filter(Boolean)
 )
 
 export const getVirtualAccounts = createSelector(
-  [getTransactions],
+  getTransactions,
   transactions => buildVirtualAccounts(transactions)
 )
 
@@ -113,7 +119,7 @@ export const getAllAccounts = createSelector(
   (accounts, virtualAccounts) => [...accounts, ...virtualAccounts]
 )
 
-export const getAutoGroups = createSelector([getGroups], groups =>
+export const getAutoGroups = createSelector(getGroups, groups =>
   groups.filter(isAutoGroup)
 )
 
@@ -155,10 +161,10 @@ export const getAllGroups = createSelector(
   (groups, virtualGroups) => [...groups, ...virtualGroups]
 )
 
-export const getGroupsById = createSelector([getAllGroups], groups =>
+export const getGroupsById = createSelector(getAllGroups, groups =>
   keyBy(groups, '_id')
 )
 
-export const getAccountsById = createSelector([getAccounts], accounts =>
+export const getAccountsById = createSelector(getAccounts, accounts =>
   keyBy(accounts, '_id')
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -17510,10 +17510,10 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
-reselect@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
-  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
+reselect@4.1.5:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 reselect@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
Depuis la home, on récupère les transactions pour les stocker dans le store. Mais si on navigue sur la page des remboursements, une nouvelle requête est faite sur les transactions et le store est mis à jour.

Dans la page des remboursements, on se base sur les transactions pour construire les groupes de remboursement. On souhaite donc se baser sur ces nouvelles transactions.

Or malgré le fait que le store soit bien mis à jour avec les nouvelles transactions, le selecteur qu'on utilisait pour construire ces groupes n'était pas ré-exécuté. Car selon la doc https://github.com/reduxjs/reselect/ `un selecteur recalcule un nouveau résultat uniquement si l'un de ses arguments change`. Dans notre cas, l'argument ne changeait pas car un `===` était utilisait sur l’argument, alors que la référence à l’argument ne changeait pas, ce qui renvoyait `false` c'est à dire "ne pas recalculer de nouveau résultat".

Pour rappel `reselect` permet de la mémoisation et de retourner l'ancien résultat si les arguments sont inchangés.

J'ai fait des tests de performances depuis le commit 15944aebbeaa47ea0890ea0f339ed0007b335e36 (c'est à dire avant la PR https://github.com/cozy/cozy-banks/pull/2319 qui introduit un premier fix et ralenti considérablement l'app), à part le fait qu'on perd un peu car on passe de 1000 transactions max à la totalité des transactions, il n'y a pas de différence. Pour info cela revient au même qu'aller dans un compte par exemple.

Des tests vont arriver dans une autre PR