### PR TITLE
fix(documentSelector): remove useless memoization after cozy-client fix

### DIFF
--- a/src/ducks/reimbursements/NoReimbursedExpenses.jsx
+++ b/src/ducks/reimbursements/NoReimbursedExpenses.jsx
@@ -31,11 +31,10 @@ const NoReimbursedExpenses = ({ hasHealthBrands, doc }) => {
     [doc.categoryId]
   )
 
-  const message = useMemo(() => makeMessage({ doc, categoryName, t }), [
-    categoryName,
-    doc,
-    t
-  ])
+  const message = useMemo(
+    () => makeMessage({ doc, categoryName, t }),
+    [categoryName, doc, t]
+  )
 
   return (
     <Padded className="u-pv-0">

--- a/src/ducks/reimbursements/Reimbursements.jsx
+++ b/src/ducks/reimbursements/Reimbursements.jsx
@@ -44,10 +44,8 @@ export const DumbReimbursements = ({
     return <Loading loadingType />
   }
 
-  const {
-    reimbursed: reimbursedExpenses,
-    pending: pendingExpenses
-  } = groupedExpenses
+  const { reimbursed: reimbursedExpenses, pending: pendingExpenses } =
+    groupedExpenses
 
   const pendingAmount = sumBy(pendingExpenses, t => -t.amount)
 

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -1,4 +1,3 @@
-import isEqual from 'lodash/isEqual'
 import keyBy from 'lodash/keyBy'
 import { createSelector, createSelectorCreator, defaultMemoize } from 'reselect'
 
@@ -72,11 +71,6 @@ export const documentSelector = createSelector(
     const client = getClient()
     const docs = Object.values(documents || {})
     return client.hydrateDocuments(TRANSACTION_DOCTYPE, docs)
-  },
-  {
-    memoizeOptions: {
-      equalityCheck: (a, b) => isEqual(a, b)
-    }
   }
 )
 

--- a/src/selectors/index.spec.jsx
+++ b/src/selectors/index.spec.jsx
@@ -65,9 +65,6 @@ describe('getTransactions selectors', () => {
 
     state = reducer(state, anotherObject)
     expect(getTransactions(state)).toEqual([{ label: 1 }])
-    expect(getTransactions.recomputations()).toEqual(1) // this tests the memoizeOptions
-    // when cozy-client fixed extractAndMergeDocument, we can uncomment this
-    // https://github.com/cozy/cozy-client/pull/1122
-    // expect(getTransactions.recomputations()).toEqual(2)
+    expect(getTransactions.recomputations()).toEqual(2)
   })
 })


### PR DESCRIPTION
This PR reverts the fix - but not the styles of this [commit](https://github.com/cozy/cozy-banks/commit/fe4c90cc21c3c7744350b6a99612a21a5f50b737).

Memoization is not needed anymore, since [cozy-client has been fixed](https://github.com/cozy/cozy-client/pull/1122/files).
