### PR TITLE
feat: Update cozy-ui to 62.1.4 and material-ui to 4.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ## 🔧 Tech
 
+* Update cozy-ui to 62.1.4 and material-ui to 4.12.3
+
 # 1.42.0
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
   "dependencies": {
     "@babel/core": "7.9.0",
     "@cozy/minilog": "^1.0.0",
-    "@material-ui/core": "4",
+    "@material-ui/core": "4.12.3",
     "@material-ui/styles": "^4.10.0",
     "@testing-library/react-hooks": "^3.4.2",
     "@types/classnames": "^2.3.1",
@@ -178,7 +178,7 @@
     "cozy-scripts": "^6.1.4",
     "cozy-sharing": "3.12.2",
     "cozy-stack-client": "^27.17.0",
-    "cozy-ui": "^60.11.0",
+    "cozy-ui": "^62.1.4",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/test/jest.setup.js
+++ b/test/jest.setup.js
@@ -56,6 +56,11 @@ const ignoredWarnings = {
     reason:
       'Deprecated but could be in an external component on which we have no control',
     matcher: makeDeprecatedLifecycleMatcher('Radio')
+  },
+  withMobileDialog: {
+    reason:
+      'Deprecated but could be in an external component on which we have no control',
+    matcher: makeDeprecatedLifecycleMatcher('withMobileDialog')
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1449,15 +1449,15 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@material-ui/core@4":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.11.3.tgz#f22e41775b0bd075e36a7a093d43951bf7f63850"
-  integrity sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==
+"@material-ui/core@4.12.3":
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
+  integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
   dependencies:
     "@babel/runtime" "^7.4.4"
-    "@material-ui/styles" "^4.11.3"
-    "@material-ui/system" "^4.11.3"
-    "@material-ui/types" "^5.1.0"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.12.1"
+    "@material-ui/types" "5.1.0"
     "@material-ui/utils" "^4.11.2"
     "@types/react-transition-group" "^4.2.0"
     clsx "^1.0.4"
@@ -1467,7 +1467,7 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
-"@material-ui/styles@^4.10.0", "@material-ui/styles@^4.11.3":
+"@material-ui/styles@^4.10.0":
   version "4.11.3"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.3.tgz#1b8d97775a4a643b53478c895e3f2a464e8916f2"
   integrity sha512-HzVzCG+PpgUGMUYEJ2rTEmQYeonGh41BYfILNFb/1ueqma+p1meSdu4RX6NjxYBMhf7k+jgfHFTTz+L1SXL/Zg==
@@ -1489,17 +1489,39 @@
     jss-plugin-vendor-prefixer "^10.5.1"
     prop-types "^15.7.2"
 
-"@material-ui/system@^4.11.3":
-  version "4.11.3"
-  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.11.3.tgz#466bc14c9986798fd325665927c963eb47cc4143"
-  integrity sha512-SY7otguNGol41Mu2Sg6KbBP1ZRFIbFLHGK81y4KYbsV2yIcaEPOmsCK6zwWlp+2yTV3J/VwT6oSBARtGIVdXPw==
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.5.1"
+    jss-plugin-camel-case "^10.5.1"
+    jss-plugin-default-unit "^10.5.1"
+    jss-plugin-global "^10.5.1"
+    jss-plugin-nested "^10.5.1"
+    jss-plugin-props-sort "^10.5.1"
+    jss-plugin-rule-value-function "^10.5.1"
+    jss-plugin-vendor-prefixer "^10.5.1"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@material-ui/utils" "^4.11.2"
     csstype "^2.5.2"
     prop-types "^15.7.2"
 
-"@material-ui/types@^5.1.0":
+"@material-ui/types@5.1.0", "@material-ui/types@^5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
   integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
@@ -5626,10 +5648,10 @@ cozy-ui@^51.8.0:
     react-select "^4.3.0"
     react-swipeable-views "^0.13.3"
 
-cozy-ui@^60.11.0:
-  version "60.11.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-60.11.0.tgz#fddb5edcd144ab5cde74bfc8ff2ea327287e53cf"
-  integrity sha512-9L3MZ1ZOal1i50cPXQdFba2qGSXA1wPA+SYu2xNMYVWPNdaAz+95xdqiXe/nQcLXnWjpHWmrvCfGz0VUXCUX7Q==
+cozy-ui@^62.1.4:
+  version "62.1.4"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-62.1.4.tgz#2e2184acd30a7448224a868d214b269bcb840d4f"
+  integrity sha512-Gxw4/Lj7ZK0rNZSIHfa4raGPEbAoKsho3S/jayRrEDQ72w79bLX4GIaMa6RdGW8xcVu0xeYJm+tv7YXjHgQYBw==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@popperjs/core" "^2.4.4"


### PR DESCRIPTION
En lien à https://github.com/cozy/cozy-ui/pull/2072

Il avait était décelé un souci sur Banks à l'upgrade de cozy-ui, on a donc isolé cette feature dans un PR afin de corriger les problèmes éventuels.

C'est donc un besoin purement technique (et Banks bénéficie au passage et amélio cozy-ui). Au final il se trouve qu'il n'y a pas de souci.

note sur les tests : on refuse strictement les warning dans les tests. Sauf qu'ils peuvent venir de lib externe (comme ici), on doit donc faire des exceptions...