### PR TITLE
Change sentry url + add instance in tags context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## ✨ Features
 
+* Change Sentry url + add instance in tags context
+
 ## 🐛 Bug Fixes
 
 ## 🔧 Tech

--- a/config/webpack.config.plugins.js
+++ b/config/webpack.config.plugins.js
@@ -15,7 +15,7 @@ module.exports = {
     new webpack.DefinePlugin({
       __APP_VERSION__: JSON.stringify(manifest.version),
       __SENTRY_URL__: JSON.stringify(
-        'https://ea2067ca88504d9cbc9115b55d0b2d55:e52e64f57486417bb1b5fa6529e1cfcb@sentry.cozycloud.cc/11'
+        'https://d18802c5412f4b8babe4aad094618d37@errors.cozycloud.cc/38'
       ),
       __PIWIK_SITEID__: 8,
       __PIWIK_DIMENSION_ID_APP__: 1,

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -230,7 +230,7 @@
     },
     "reporting": {
       "description": "Allow to report unexpected errors to the support team",
-      "type": "cc.cozycloud.sentry",
+      "type": "cc.cozycloud.errors",
       "verbs": ["POST"]
     },
     "autocategorization": {

--- a/src/lib/sentry.js
+++ b/src/lib/sentry.js
@@ -36,7 +36,7 @@ const getSentryConfiguration = cozyClient => {
         data: JSON.stringify(data)
       }
       cozyClient.stackClient
-        .fetchJSON('POST', '/remote/cc.cozycloud.sentry', parameters)
+        .fetchJSON('POST', '/remote/cc.cozycloud.errors', parameters)
         .catch(options.onError)
         .then(options.onSuccess)
     }
@@ -56,7 +56,7 @@ export const getSentryMiddleware = cozyClient => {
 
 export const configureSentry = cozyClient => {
   Raven.config(__SENTRY_URL__, getSentryConfiguration(cozyClient)).install()
-  Raven.setTagsContext({ target: __TARGET__ })
+  Raven.setTagsContext({ instance: cozyClient.stackClient.uri, target: __TARGET__ })
 }
 
 // Normalize


### PR DESCRIPTION
Suite à la migration de Sentry et le changement du remote doctype https://github.com/cozy/cozy-doctypes/pull/195

On en profite pour rajouter le tag d'instance comme sur Drive https://github.com/cozy/cozy-drive/blob/master/src/drive/lib/reporter.js#L57-L59