### PR TITLE
fix: Sentry permission

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -228,9 +228,14 @@
       "type": "io.cozy.settings",
       "verbs": ["GET"]
     },
-    "reporting": {
+    "errorsreporting": {
       "description": "Allow to report unexpected errors to the support team",
       "type": "cc.cozycloud.errors",
+      "verbs": ["POST"]
+    },
+    "reporting": {
+      "description": "Allow to report unexpected errors to the support team",
+      "type": "cc.cozycloud.sentry",
       "verbs": ["POST"]
     },
     "autocategorization": {


### PR DESCRIPTION
We recently migrated from sentry.cozycloud.cc
to errors.cozycloud.cc. By doing so, we just
change the type of the permission and the stack
doesn't like that ATM.

Also, this change can not be done like it was
done due to the fact that mobile application is
linked to the web application. The OAuth scope
is kind dynamic based on the webapp.manifest.

So if we remove the cc.cozycloud.sentry perm,
then the current mobile app will not have this
right and will not be able to send report to
Sentry.

I know that a better fix should be to deploy
the banks mobile application, but for now we're
not able to do that.