### PR TITLE
fix: UseBankingSlugs konnectors query

### DIFF
--- a/src/components/App.spec.jsx
+++ b/src/components/App.spec.jsx
@@ -38,7 +38,7 @@ describe('App', () => {
 
   const setup = () => {
     const client = new CozyClient({ links: [link] })
-    jest.spyOn(client, 'queryAll').mockResolvedValue({ data: [] })
+    jest.spyOn(client, 'queryAll').mockResolvedValue([])
     const root = render(
       <AppLike client={client}>
         <App>

--- a/src/ducks/balance/ImportGroupPanel.spec.jsx
+++ b/src/ducks/balance/ImportGroupPanel.spec.jsx
@@ -14,9 +14,12 @@ describe('ImportGroupPanel', () => {
   const setup = ({ jobsInProgress, mockResolvedValue }) => {
     const client = new CozyClient({})
     client.query = jest.fn().mockResolvedValue(mockResolvedValue)
-    client.queryAll = jest.fn().mockResolvedValue({
-      data: [{ slug: 'caissedepargne1' }, { slug: 'boursorama83' }]
-    })
+    client.queryAll = jest
+      .fn()
+      .mockResolvedValue([
+        { slug: 'caissedepargne1' },
+        { slug: 'boursorama83' }
+      ])
 
     CozyRealtime.mockReturnValue({
       subscribe: () => {},

--- a/src/ducks/context/BanksContext.spec.jsx
+++ b/src/ducks/context/BanksContext.spec.jsx
@@ -36,9 +36,10 @@ describe('Banks Context', () => {
     client.query.mockResolvedValue({
       data: [{ slug: 'caissedepargne1' }, { slug: 'boursorama83' }]
     })
-    client.queryAll.mockResolvedValue({
-      data: [{ slug: 'caissedepargne1' }, { slug: 'boursorama83' }]
-    })
+    client.queryAll.mockResolvedValue([
+      { slug: 'caissedepargne1' },
+      { slug: 'boursorama83' }
+    ])
     CozyRealtime.mockImplementation(() => {
       return {
         subscribe: (eventName, doctype, handleRealtime) => {

--- a/src/hooks/useBankingSlugs.jsx
+++ b/src/hooks/useBankingSlugs.jsx
@@ -20,7 +20,7 @@ const useBankingSlugs = () => {
           })
           .indexFields(['categories'])
       )
-      const result = bankingKonnectors?.data?.map(konnector => konnector.slug)
+      const result = bankingKonnectors?.map(konnector => konnector.slug)
       setBankingSlugs(result)
       setIsFetchingBankSlugs(false)
     }


### PR DESCRIPTION
client.queryAll returns an array in useBankingSlugs and not an object with data attribute.


