### PR TITLE
fix: Add replaceHistory method for Harvest

### DIFF
--- a/src/ducks/settings/HarvestSwitch.jsx
+++ b/src/ducks/settings/HarvestSwitch.jsx
@@ -68,7 +68,10 @@ class Switch extends React.Component {
     }
 
     this.pushHistory = this.pushHistory.bind(this)
-    this.mountPointContext = { pushHistory: this.pushHistory }
+    this.mountPointContext = {
+      pushHistory: this.pushHistory,
+      replaceHistory: this.pushHistory
+    }
   }
 
   pushHistory(fragment) {


### PR DESCRIPTION
Harvest uses a new API for internal routing.
The MountPointContext provides a replaceHistory method.
But it doesn't provide it in cozy-banks because the context is
not provided by Harvest but by the application.
It is needed to add the method to cozy-banks context.
It will use the same method as pushHistory,
as it's not a real router method here but a component state.
To avoid such problems in the future: use typed interfaces,
or do not replace old interfaces with new interfaces.
Instead, try something like pushHistory(args, withReplace?: boolean).