### PR TITLE
fix: Ugrade harvest to 9.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update cozy-stack-client and cozy-pouch-link to sync with cozy-client version
 * Use DropdownText comp instead of custom in AccountSwitch
 * cozy-harvest-lib 9.8.0 : Add reconnect to bi Webviews  [PR](https://github.com/cozy/cozy-libs/pull/1656)
+* cozy-harvest-lib 9.10.0 : Add custom intentsApi prop to TriggerManager [PR](https://github.com/cozy/cozy-libs/pull/1663)
 
 ## 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Update cozy-stack-client and cozy-pouch-link to sync with cozy-client version
 * Use DropdownText comp instead of custom in AccountSwitch
 * cozy-harvest-lib 9.8.0 : Add reconnect to bi Webviews  [PR](https://github.com/cozy/cozy-libs/pull/1656)
-* cozy-harvest-lib 9.10.0 : Add custom intentsApi prop to TriggerManager [PR](https://github.com/cozy/cozy-libs/pull/1663)
+* cozy-harvest-lib 9.10.1 : Add custom intentsApi prop to TriggerManager [PR](https://github.com/cozy/cozy-libs/pull/1663)
 
 ## 🐛 Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update cozy-stack-client and cozy-pouch-link to sync with cozy-client version
 * Use DropdownText comp instead of custom in AccountSwitch
+* cozy-harvest-lib 9.8.0 : Add reconnect to bi Webviews  [PR](https://github.com/cozy/cozy-libs/pull/1656)
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.10.0",
+    "cozy-harvest-lib": "^9.10.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.4.0",
+    "cozy-harvest-lib": "^9.8.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.8.0",
+    "cozy-harvest-lib": "^9.10.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.4.0:
-  version "9.4.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.4.0.tgz#647b406a04f87adb32536a3008f161b98b2cba8c"
-  integrity sha512-VyDhDhASfkgsZzp5ikivKmUrJBLaGwptsjX7dQKMfnQ/JmvHwtBaZnGJf96Sbr00CRNmUrBLNWPul68nlKi5jA==
+cozy-harvest-lib@^9.8.0:
+  version "9.8.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.8.0.tgz#3904c0ff81dc0e89fb807b48da828d17ff37e561"
+  integrity sha512-tb84+ks7B5umtbA4rqidgy1vjkosaTjgtHvFfO+oKwwJILILzMu98aWlde+0drmAPLaqaL9fbNb8oS+wyPg/4w==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.10.0:
-  version "9.10.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.10.0.tgz#c861d5508e020ecf0fa7b7def7c94f29d31a3bc7"
-  integrity sha512-DC5oeRLAowuh0qJ0lEzPHm8scXNO28xTVKVSY0/s9f5sXaFA1v/ClOFc05wkilhAUjMlLilYjYeqSKLwVZ4r8g==
+cozy-harvest-lib@^9.10.1:
+  version "9.10.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.10.1.tgz#adc0ae23801f4d8fc3c75799f7a645440acf7ef7"
+  integrity sha512-0dNBME3iCDDFErmLuqzwgitZOueOv7OqkAXWRlP1YS9Ve10Fg4EitBrMsAXTg522H7JbWIpbkadiBx6gjgQ2Vg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.8.0:
-  version "9.8.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.8.0.tgz#3904c0ff81dc0e89fb807b48da828d17ff37e561"
-  integrity sha512-tb84+ks7B5umtbA4rqidgy1vjkosaTjgtHvFfO+oKwwJILILzMu98aWlde+0drmAPLaqaL9fbNb8oS+wyPg/4w==
+cozy-harvest-lib@^9.10.0:
+  version "9.10.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.10.0.tgz#c861d5508e020ecf0fa7b7def7c94f29d31a3bc7"
+  integrity sha512-DC5oeRLAowuh0qJ0lEzPHm8scXNO28xTVKVSY0/s9f5sXaFA1v/ClOFc05wkilhAUjMlLilYjYeqSKLwVZ4r8g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
@@ -13558,9 +13558,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
To get BI reconnection via webviews and custom Intent api for native apps other than the flagship app