### PR TITLE
feat: Upgrade Harvest to 9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   * 9.8.0 : Add reconnect to bi Webviews [PR](https://github.com/cozy/cozy-libs/pull/1656)
   * 9.10.1 : Add custom intentsApi prop to TriggerManager [PR](https://github.com/cozy/cozy-libs/pull/1663)
   * 9.11.1 : Add sync date on ContractItem and overrides ability in AccountModal [[PR]](https://github.com/cozy/cozy-libs/pull/1678) and [[PR]](https://github.com/cozy/cozy-libs/pull/1679)
+  * 9.12.0 : Do not show Popup when intentsApi parameter is given [PR](https://github.com/cozy/cozy-libs/pull/1683)
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.11.1",
+    "cozy-harvest-lib": "^9.12.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.11.1:
-  version "9.11.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.11.1.tgz#8df78a25d103c4a9952196ccca211ec911e134bd"
-  integrity sha512-SD8QORyVluTWYlx8yx7knqrGyI0hMe8JNPDGCSR43DcAHliGisbaEhOr0K1ZJi5yRvlim/U6y3+JH49+vZqYgQ==
+cozy-harvest-lib@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.12.0.tgz#3799a0230554f9ff7efe1808d4a3e20e61eba1a3"
+  integrity sha512-zQzcz11T8ib4gEAmhnF1rPk+re0ejWD0Esz4TWKngAN/ZixxMZ5r4Ot2jKad9leF4wnMKB0EDenXVaeWIc6qnA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To not show Popup when intentsApi parameter is given. This is a cherry-pick from the release branch
