### PR TITLE
feat: Update harvest to 9.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ## 🐛 Bug Fixes
 
 * Fix App Amirale UI issues by updating cozy-ui [[PR]](https://github.com/cozy/cozy-banks/pull/2380)
+* Update cozy-harvest-lib
+  * 9.12.2 : Do not pre encode oauth url [PR](https://github.com/cozy/cozy-libs/pull/1685) and Do not show popup when intentsApi is given [PR](https://github.com/cozy/cozy-libs/pull/1686)
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.12.0",
+    "cozy-harvest-lib": "^9.12.2",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.12.0.tgz#3799a0230554f9ff7efe1808d4a3e20e61eba1a3"
-  integrity sha512-zQzcz11T8ib4gEAmhnF1rPk+re0ejWD0Esz4TWKngAN/ZixxMZ5r4Ot2jKad9leF4wnMKB0EDenXVaeWIc6qnA==
+cozy-harvest-lib@^9.12.2:
+  version "9.12.2"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.12.2.tgz#ea2d105c6d6cbb492441a1ddd35be8f4c5349a54"
+  integrity sha512-EC7riwrPKxMXznaH7rfudim54ukWzxMuxHX36lagJGw2ZQK3FlavlmxTMxUWnPwwA0EdqRkMgMGgZ/eaap4wkQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get harvest fixes:
 - do not encode oauth url
 - do not show popup when intentsApi is given
