### PR TITLE
chore: Use absolute import instead of relative

### DIFF
--- a/src/ducks/settings/HarvestBankAccountSettings.jsx
+++ b/src/ducks/settings/HarvestBankAccountSettings.jsx
@@ -16,8 +16,8 @@ import HarvestVaultProvider from 'cozy-harvest-lib/dist/components/HarvestVaultP
 import { TrackingContext as HarvestTrackingContext } from 'cozy-harvest-lib/dist/components/hoc/tracking'
 
 import { useTracker } from 'ducks/tracking/browser'
-import HarvestAccountModal from './HarvestAccountModal'
-import HarvestSwitch from './HarvestSwitch'
+import HarvestAccountModal from 'ducks/settings/HarvestAccountModal'
+import HarvestSwitch from 'ducks/settings/HarvestSwitch'
 import {
   COZY_ACCOUNT_DOCTYPE,
   cronKonnectorTriggersConn,


### PR DESCRIPTION
to be able to override it. Override is not possible with relative import

lié à https://github.com/cozy/cozy-banks/pull/2395