### PR TITLE
Disable account line in import group panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   * 9.12.2 : Do not pre encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1685) and Do not show popup when intentsApi is given [[PR]](https://github.com/cozy/cozy-libs/pull/1686)
   * 9.12.3 : Do not double encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1687)
   * 9.14.1 : Change RedirectToAccountFormButton label & size [[PR]](https://github.com/cozy/cozy-libs/pull/1688)
+* Disable account line in import group panel to prevent accessing an account not yet ready
 
 ## 🐛 Bug Fixes
 

--- a/src/ducks/balance/ImportGroupPanel.jsx
+++ b/src/ducks/balance/ImportGroupPanel.jsx
@@ -106,7 +106,12 @@ const Row = React.memo(({ account, t }) => {
   const slug = account.konnector
 
   return (
-    <ListItem button disableRipple>
+    <ListItem
+      disabled
+      onClick={ev => {
+        ev.stopPropagation()
+      }}
+    >
       <ListItemIcon>
         <AccountIcon
           account={{


### PR DESCRIPTION
to prevent accessing an account not yet ready

We stop the click propagation to avoid closing the accordion when
clicking an account

PR sur master : https://github.com/cozy/cozy-banks/pull/2400