### PR TITLE
fix(account): Update trigger without fetch policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* Update trigger without fetch policy in AccountModal, while reconnecting a konnector
+
 ## 🔧 Tech
 
 # 1.44.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ## ✨ Features
 
+* Update cozy-harvest-lib
+  * 9.15.1 : Update trigger while status changed [[PR]](https://github.com/cozy/cozy-libs/pull/1697)
+
 ## 🐛 Bug Fixes
 
-* Update trigger without fetch policy in AccountModal, while reconnecting a konnector
+* Update trigger without fetch policy in AccountModal, while reconnecting a konnector [[PR]](https://github.com/cozy/cozy-banks/pull/2404)
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.14.1",
+    "cozy-harvest-lib": "^9.15.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -207,8 +207,7 @@ export const cronKonnectorTriggersConn = {
       worker: 'konnector',
       type: '@cron'
     }),
-  as: 'triggers',
-  fetchPolicy: older30s
+  as: 'triggers'
 }
 
 export const transactionsConn = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.14.1:
-  version "9.14.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.14.1.tgz#810fce5c76fade8347b575bcc338bb59966dad07"
-  integrity sha512-EWsRMpVkpnisg2rtMSx6GKp5YA3oMoHZxFQr0/wUpgJvtuXoWO1hGZXIHmlhQrf1jPKX81me4n8AnKq13x67zQ==
+cozy-harvest-lib@^9.15.1:
+  version "9.15.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.15.1.tgz#a0db9b2e8bb9429676fea363e73cacffd82d5815"
+  integrity sha512-cJNWMrv6igjklL6/2kZl1ujO/T52XoOlVXv5cVlMka3taTBBwBeFj2VYJQI3XqyyF+hU0sBAqJ4znEPWCf4BVw==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
Two PR are needed to remove the error message staying, after reconnection of a konnector, this one and https://github.com/cozy/cozy-libs/pull/1697 . We need to update cozy-harvest-lib also to fix the bug. => draft

The [HarvestBankAccountSettings](https://github.com/cozy/cozy-banks/blob/master/src/ducks/settings/HarvestBankAccountSettings.jsx#L253) give data to HarvestAccountModal using the [HarvestLoader](https://github.com/cozy/cozy-banks/blob/dbc8d428fbeac34bafea11213607fd565e8daed7/src/ducks/settings/HarvestBankAccountSettings.jsx#L179) .
I noticed the data "trigger" that contains `trigger.current_state.status` (knowing if errored or done) was given inside the "accountsAndTriggers" . 

I also modified AccountModal.componentDidUpdate to update the data (flowState), used by harvest lib, to remove the error message displayed. (Other PR in cozy-harvest-lib)

Then, I noticed the request to refresh trigger was executed sometimes. When fetchPolicy returns previous konnector with "errored" status, then the error message was not removed. When a fresh request happens, updating the triggers, then the status was done and the error message was removed.

That's why the solution is to remove the fetchPolicy, as we are not using realtime here + our date trigger can change in this scenario  (This PR in cozy-banks)