### PR TITLE
feat: Remove icon on ReconnectTriggerButton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   * 9.15.1 : Update trigger while status changed [[PR]](https://github.com/cozy/cozy-libs/pull/1697)
 * Disable account line in import group panel to prevent accessing an account not yet ready
 * Change wording for toast message when importing data from a bank is completed
+* Remove icon on ReconnectTriggerButton
 
 ## 🐛 Bug Fixes
 

--- a/src/ducks/transactions/TransactionPageErrors/ReconnectTriggerButton.jsx
+++ b/src/ducks/transactions/TransactionPageErrors/ReconnectTriggerButton.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { ButtonLink } from 'cozy-ui/transpiled/react/Button'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import OpenWithIcon from 'cozy-ui/transpiled/react/Icons/Openwith'
 
 import HarvestBankAccountSettings from 'ducks/settings/HarvestBankAccountSettings'
 
@@ -23,7 +22,6 @@ const ReconnectTriggerButton = ({ trigger, label }) => {
         extension={isMobile ? 'full' : 'narrow'}
         className="u-mh-0"
         label={label || t('Transactions.trigger-error.cta')}
-        icon={OpenWithIcon}
         onClick={handleClick}
       />
       {harvestConnectionId ? (


### PR DESCRIPTION
lié à https://github.com/cozy/cozy-banks/pull/2408

on souhaite ici simplement supprimer l'icon présent dans le bouton de "reconnexion" dans le push d'erreur lorsqu'un compte est en erreur.