### PR TITLE
Upgrade cozy-harvest-lib to 9.15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@
   * 9.12.0 : Do not show Popup when intentsApi parameter is given [[PR]](https://github.com/cozy/cozy-libs/pull/1683)
   * 9.12.2 : Do not pre encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1685) and Do not show popup when intentsApi is given [[PR]](https://github.com/cozy/cozy-libs/pull/1686)
   * 9.12.3 : Do not double encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1687)
-  * 9.14.1 : Change RedirectToAccountFormButton label & size [[PR]](https://github.com/cozy/cozy-libs/pull/1688)
   * 9.15.1 : Update trigger while status changed [[PR]](https://github.com/cozy/cozy-libs/pull/1697)
 * Disable account line in import group panel to prevent accessing an account not yet ready
 * Change wording for toast message when importing data from a bank is completed

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.15.1",
+    "cozy-harvest-lib": "^9.15.4",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.15.1:
-  version "9.15.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.15.1.tgz#a0db9b2e8bb9429676fea363e73cacffd82d5815"
-  integrity sha512-cJNWMrv6igjklL6/2kZl1ujO/T52XoOlVXv5cVlMka3taTBBwBeFj2VYJQI3XqyyF+hU0sBAqJ4znEPWCf4BVw==
+cozy-harvest-lib@^9.15.4:
+  version "9.15.4"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.15.4.tgz#08db87d5b30f2e8810e120ed565b295b70b3ff7b"
+  integrity sha512-lQzsCM4y5UquUJFnlqPnCNECeXkRmz/DE8yiRZz3+saYc6wEd7NIOFku4XYyohtuoH6st2WDHldxQlsh4x3yfA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
lié à https://github.com/cozy/cozy-banks/pull/2411

Pour bénéficier de https://github.com/cozy/cozy-libs/pull/1706 . Suite à une incompréhension on avait modifié par erreur un bouton dans harvest. Cette modif était passé dans la version 9.14 d'harvest. Le correctif fait dans harvest, il faut maintenant mettre la lib à jour ici.