### PR TITLE
feat: Upgrade Harvest to 9.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,25 @@
   * 9.12.2 : Do not pre encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1685) and Do not show popup when intentsApi is given [[PR]](https://github.com/cozy/cozy-libs/pull/1686)
   * 9.12.3 : Do not double encode oauth url [[PR]](https://github.com/cozy/cozy-libs/pull/1687)
   * 9.15.1 : Update trigger while status changed [[PR]](https://github.com/cozy/cozy-libs/pull/1697)
+  * 9.16.0 :
+    * Allow EditAccountModal to have intentsApi ([43c5910](https://github.com/cozy/cozy-libs/commit/43c5910aba989fa09534cdfab8933512da606b2e))
+    * Now open the BI manage webview to the correct connection id ([2f3da74](https://github.com/cozy/cozy-libs/commit/2f3da74213710a06ad8877dd350bcd04b86d5e64))
+  * 9.17.0 :
+    * All oauth methods to handle reconection case ([b1a6033](https://github.com/cozy/cozy-libs/commit/b1a6033b393b1732d985807328ea83e1c87e5373))
+    * Do not show identifiers with bi Webviews ([58e1bb1](https://github.com/cozy/cozy-libs/commit/58e1bb16c7703590c7396c33d50c1c17ec58e512))
+  * 9.18.0 :
+    * Add error message display in OAuthForm component ([f29b3c4](https://github.com/cozy/cozy-libs/commit/f29b3c4d8357b3f58b37dfe1a50233ceddd42ff7))
+    * Handle user dismiss in Oauth window ([a6dcba8](https://github.com/cozy/cozy-libs/commit/a6dcba86de227d9c5a3271554b31598e3611ebf9))
 * Disable account line in import group panel to prevent accessing an account not yet ready
 * Change wording for toast message when importing data from a bank is completed
 * Remove icon on ReconnectTriggerButton
+* Add intentsApi prop to HarvestBankAccountSettings
 
 ## 🐛 Bug Fixes
 
 * Fix App Amirale UI issues by updating cozy-ui [[PR]](https://github.com/cozy/cozy-banks/pull/2380)
 * Update trigger without fetch policy in AccountModal, while reconnecting a konnector [[PR]](https://github.com/cozy/cozy-banks/pull/2404)
+* Use the right color for input text
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.15.4",
+    "cozy-harvest-lib": "^9.18.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5358,10 +5358,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.15.4:
-  version "9.15.4"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.15.4.tgz#08db87d5b30f2e8810e120ed565b295b70b3ff7b"
-  integrity sha512-lQzsCM4y5UquUJFnlqPnCNECeXkRmz/DE8yiRZz3+saYc6wEd7NIOFku4XYyohtuoH6st2WDHldxQlsh4x3yfA==
+cozy-harvest-lib@^9.18.0:
+  version "9.18.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.18.0.tgz#e1a1ba418a4690e92f027fa2a0941a19099363cb"
+  integrity sha512-0UcE70JL/oyQM4kKXZBtmF4pZB1rD5OroHxAO4DbkEIwC4F+w06zc56a+do+YvrNj/oSuPjV614KhFtHgX5glQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get :
  * 9.16.0 :
    * Allow EditAccountModal to have intentsApi ([43c5910](https://github.com/cozy/cozy-libs/commit/43c5910aba989fa09534cdfab8933512da606b2e))
    * Now open the BI manage webview to the correct connection id ([2f3da74](https://github.com/cozy/cozy-libs/commit/2f3da74213710a06ad8877dd350bcd04b86d5e64))
  * 9.17.0 :
    * All oauth methods to handle reconection case ([b1a6033](https://github.com/cozy/cozy-libs/commit/b1a6033b393b1732d985807328ea83e1c87e5373))
    * Do not show identifiers with bi Webviews ([58e1bb1](https://github.com/cozy/cozy-libs/commit/58e1bb16c7703590c7396c33d50c1c17ec58e512))
  * 9.18.0 :
    * Add error message display in OAuthForm component ([f29b3c4](https://github.com/cozy/cozy-libs/commit/f29b3c4d8357b3f58b37dfe1a50233ceddd42ff7))
    * Handle user dismiss in Oauth window ([a6dcba8](https://github.com/cozy/cozy-libs/commit/a6dcba86de227d9c5a3271554b31598e3611ebf9))
