### PR TITLE
fix: Prevent recurrence service calls loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* Fix recurrence service that was triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2422)
+
 ## 🔧 Tech
 
 # 1.43.1


### PR DESCRIPTION
  The recurrence service is triggered when transactions are created or
  updated but the service itself updates transactions when recurrence
  bundles are created or modified, thus triggering another service call.
  This behavior is fine as long as it ends in a stable state where no
  transactions are updated and no service calls are triggered anymore.

  However, the service was updating all bundled transactions whether
  they were already bundled before or not thus triggering infinite
  loops.
  We now only update transactions whose bundle was changed during the
  current service call whether the transaction was already in a bundle
  or not.