### PR TITLE
fix: Prevent recurrence service from running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Update trigger without fetch policy in AccountModal, while reconnecting a konnector [[PR]](https://github.com/cozy/cozy-banks/pull/2404)
 * Use the right color for input text
 * Colors when importing account
+* Prevent recurrence service from running until we figure out why it is triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2423)
 
 ## 🔧 Tech
 

--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -1,6 +1,15 @@
 import { runService } from './service'
-import runRecurrenceService from 'ducks/recurrence/service'
+import logger from 'cozy-logger'
 
-runService(async ({ client }) => {
-  await runRecurrenceService({ client })
+const log = logger.namespace('recurrence')
+// import runRecurrenceService from 'ducks/recurrence/service'
+
+runService(async (/* { client }*/) => {
+  // FIXME: Find out why this service loops (i.e. modifies transactions which
+  // re-triggers it).
+  log(
+    'debug',
+    'Not running the service as it keeps modifying transactions triggering further service calls'
+  )
+  // await runRecurrenceService({ client })
 })


### PR DESCRIPTION
  We could not figure out yet why the recurrence service keeps modifying
  transactions thus triggering further calls to itself.

  Until we do, we'll prevent the service from running altogether.