### PR TITLE
fix: Prevent recurrence service calls loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## 🐛 Bug Fixes
 
+* Fix recurrence service that was triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2429)
+
 ## 🔧 Tech
 
 * Remove dev dependency to cozy-ach [[PR]](https://github.com/cozy/cozy-banks/pull/2418)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ## 🐛 Bug Fixes
 
-* Prevent recurrence service from running until we figure out why it is triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2423)
-
 ## 🔧 Tech
 
 * Remove dev dependency to cozy-ach [[PR]](https://github.com/cozy/cozy-banks/pull/2418)

--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -1,15 +1,6 @@
 import { runService } from './service'
-import logger from 'cozy-logger'
+import runRecurrenceService from 'ducks/recurrence/service'
 
-const log = logger.namespace('recurrence')
-// import runRecurrenceService from 'ducks/recurrence/service'
-
-runService(async (/* { client }*/) => {
-  // FIXME: Find out why this service loops (i.e. modifies transactions which
-  // re-triggers it).
-  log(
-    'debug',
-    'Not running the service as it keeps modifying transactions triggering further service calls'
-  )
-  // await runRecurrenceService({ client })
+runService(async ({ client }) => {
+  await runRecurrenceService({ client })
 })


### PR DESCRIPTION
The recurrence service is triggered when transactions are created or
updated but the service itself updates transactions when recurrence
bundles are created or modified, thus triggering another service call.
This behavior is fine as long as it ends in a stable state where no
transactions are updated and no service calls are triggered anymore.

However, the service was updating all bundled transactions whether
they were already bundled before or not thus triggering infinite
loops.
We now only update transactions whose bundle was changed during the
current service call whether the transaction was already in a bundle
or not.

This PR reverts a temporary fix that was preventing the service from
doing anything at all.