### PR TITLE
Add a tab in the settings to list all the tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## ✨ Features
 
 * Add tags on transactions
+* Add a tab in the settings to list all the tags
 
 ## 🐛 Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -182,6 +182,7 @@
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",
+    "diacritics": "^1.3.0",
     "element-scroll-polyfill": "1.0.1",
     "eslint-config-cozy-app": "^4.0.0",
     "fastclick": "^1.0.6",

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { IndexRoute, Route, Redirect } from 'react-router'
 import App from 'components/App'
 import { isWebApp } from 'cozy-device-helper'
+import flag from 'cozy-flags'
 
 import { CategoriesPage } from 'ducks/categories'
 import {
@@ -10,6 +11,7 @@ import {
   GroupsSettings,
   ExistingGroupSettings,
   NewGroupSettings,
+  TagsSettings,
   Configuration
 } from 'ducks/settings'
 import { Balance, BalanceDetailsPage } from 'ducks/balance'
@@ -87,6 +89,9 @@ const AppRoute = () => (
           <IndexRoute component={Configuration} />
           <Route path="accounts" component={AccountsSettings} />
           <Route path="groups" component={GroupsSettings} />
+          {flag('banks.tags.enabled') && (
+            <Route path="tags" component={TagsSettings} />
+          )}
           <Route path="configuration" component={Configuration} />
         </Route>
       </Route>

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -1,0 +1,65 @@
+import React, { useMemo } from 'react'
+import PropTypes from 'prop-types'
+import debounce from 'lodash/debounce'
+
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup'
+import Input from 'cozy-ui/transpiled/react/Input'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import MagnifierIcon from 'cozy-ui/transpiled/react/Icons/Magnifier'
+
+const useStyles = makeStyles(theme => ({
+  input: {
+    borderRadius: '1.25rem',
+    maxWidth: 'none',
+    height: '2.5rem',
+    flex: '1',
+    boxShadow: theme.shadows[1],
+    border: '0',
+    '&:hover, &:focus, &:active': {
+      border: '0',
+      boxShadow: theme.shadows[6]
+    },
+    '& input': {
+      maxWidth: 'none',
+      padding: '.625rem 1rem',
+      borderRadius: '1.25rem'
+    }
+  }
+}))
+
+const SearchInput = ({ placeholder, setValue }) => {
+  const styles = useStyles()
+
+  const delayedSetValue = useMemo(
+    () => debounce(searchValue => setValue(searchValue), 375),
+    [setValue]
+  )
+
+  return (
+    <>
+      <InputGroup
+        className={styles.input}
+        prepend={
+          <Icon
+            className="u-pl-1"
+            icon={MagnifierIcon}
+            color="var(--secondaryTextColor)"
+          />
+        }
+      >
+        <Input
+          placeholder={placeholder}
+          onChange={event => delayedSetValue(event.target.value)}
+        />
+      </InputGroup>
+    </>
+  )
+}
+
+SearchInput.propTypes = {
+  placeholder: PropTypes.string,
+  setValue: PropTypes.func.isRequired
+}
+
+export default SearchInput

--- a/src/components/SelectInput.jsx
+++ b/src/components/SelectInput.jsx
@@ -1,0 +1,103 @@
+import React, { useRef, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import ActionMenu, {
+  ActionMenuItem,
+  ActionMenuRadio
+} from 'cozy-ui/transpiled/react/ActionMenu'
+import DropdownText from 'cozy-ui/transpiled/react/DropdownText'
+import InputGroup from 'cozy-ui/transpiled/react/InputGroup'
+
+const useStyles = makeStyles({
+  mobileInput: {
+    width: '100%',
+    maxWidth: 'none',
+    border: '0',
+    '&:hover, &:focus, &:active': {
+      border: '0'
+    }
+  },
+  desktopInput: {
+    height: '2.5rem',
+    borderRadius: '1.25rem',
+    flex: '0'
+  },
+  mobileButton: {
+    boxSizing: 'border-box',
+    padding: '.625rem .5rem',
+    lineHeight: '1.25rem',
+    whiteSpace: 'nowrap',
+    '& span, & p': {
+      display: 'inline'
+    }
+  },
+  desktopButton: {
+    boxSizing: 'border-box',
+    margin: '-.063rem',
+    padding: '.625rem 1rem',
+    borderRadius: '1.25rem',
+    lineHeight: '1.25rem',
+    whiteSpace: 'nowrap',
+    '& span, & p': {
+      display: 'inline'
+    }
+  }
+})
+
+const SelectInput = ({ options, name, value, setValue }) => {
+  const { isMobile } = useBreakpoints()
+  const styles = useStyles()
+  const [isOpened, setIsOpened] = useState(false)
+
+  const anchorRef = useRef()
+
+  return (
+    <InputGroup className={isMobile ? styles.mobileInput : styles.desktopInput}>
+      <DropdownText
+        className={isMobile ? styles.mobileButton : styles.desktopButton}
+        variant="caption"
+        onClick={() => setIsOpened(true)}
+        ref={anchorRef}
+      >
+        {options[value]}
+      </DropdownText>
+      {isOpened && (
+        <ActionMenu
+          className={styles.menu}
+          anchorElRef={anchorRef}
+          autoclose={true}
+          onClose={() => setIsOpened(false)}
+        >
+          {Object.entries(options).map(([optionValue, optionLabel]) => {
+            return (
+              <ActionMenuItem
+                key={optionValue}
+                left={
+                  <ActionMenuRadio
+                    name={name}
+                    value={optionValue}
+                    checked={optionValue === value}
+                  />
+                }
+                onClick={() => setValue(optionValue)}
+              >
+                {optionLabel}
+              </ActionMenuItem>
+            )
+          })}
+        </ActionMenu>
+      )}
+    </InputGroup>
+  )
+}
+
+SelectInput.propTypes = {
+  options: PropTypes.objectOf(PropTypes.string),
+  name: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  setValue: PropTypes.func.isRequired
+}
+
+export default SelectInput

--- a/src/ducks/settings/TabsHeader/index.jsx
+++ b/src/ducks/settings/TabsHeader/index.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 
+import flag from 'cozy-flags'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 
@@ -11,6 +12,11 @@ import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import { useLocation, useHistory } from 'components/RouterContext'
 
 export const tabNames = ['configuration', 'accounts', 'groups']
+
+if (flag('banks.tags.enabled')) {
+  tabNames.push('tags')
+}
+
 const TabsHeader = () => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()

--- a/src/ducks/settings/TagListItem.jsx
+++ b/src/ducks/settings/TagListItem.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import TagIcon from 'cozy-ui/transpiled/react/Icons/Tag'
+
+import { countTransactions } from 'components/Tag/helpers'
+
+const useStyles = makeStyles({
+  desktopListItem: {
+    paddingLeft: '2rem',
+    paddingRight: '2rem'
+  }
+})
+
+const TagListItem = ({ tag }) => {
+  const { isMobile } = useBreakpoints()
+  const styles = useStyles()
+  const { t } = useI18n()
+
+  const handleListItemClick = () => {
+    // TODO: this should open a dialog to manage the tag
+    alert('Not implemented')
+  }
+
+  return (
+    <ListItem
+      button
+      onClick={handleListItemClick}
+      className={!isMobile ? styles.desktopListItem : null}
+    >
+      <ListItemIcon>
+        <Icon icon={TagIcon} />
+      </ListItemIcon>
+      <ListItemText
+        primary={tag.label}
+        secondary={t('Tag.transactions', {
+          smart_count: countTransactions(tag)
+        })}
+      />
+      <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
+    </ListItem>
+  )
+}
+
+TagListItem.propTypes = {
+  tag: PropTypes.object.isRequired
+}
+
+export default TagListItem

--- a/src/ducks/settings/TagsList.jsx
+++ b/src/ducks/settings/TagsList.jsx
@@ -1,0 +1,61 @@
+import React, { Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+
+import TagListItem from 'ducks/settings/TagListItem'
+import { filterTags, sortTags } from 'ducks/settings/tagsSettingsHelpers'
+
+const useStyles = makeStyles({
+  list: {
+    padding: '.5rem 0'
+  },
+  desktopDivider: {
+    marginLeft: '5rem'
+  }
+})
+
+const TagsList = ({ tags, filter, sort }) => {
+  const { isMobile } = useBreakpoints()
+  const styles = useStyles()
+  const [sortKey, sortOrder] = sort.split('-')
+  const filteredAndSortedTags = sortTags(
+    filterTags(tags, filter),
+    sortKey,
+    sortOrder
+  )
+
+  return (
+    <>
+      {isMobile && filteredAndSortedTags.length !== 0 && <Divider />}
+      <List className={styles.list}>
+        {filteredAndSortedTags.map((tag, index) => {
+          return (
+            <Fragment key={tag._id}>
+              {index !== 0 && (
+                <Divider
+                  variant="inset"
+                  component="li"
+                  className={!isMobile ? styles.desktopDivider : null}
+                />
+              )}
+              <TagListItem tag={tag} />
+            </Fragment>
+          )
+        })}
+      </List>
+      {isMobile && <Divider />}
+    </>
+  )
+}
+
+TagsList.propTypes = {
+  tags: PropTypes.array.isRequired,
+  filter: PropTypes.string.isRequired,
+  sort: PropTypes.string.isRequired
+}
+
+export default TagsList

--- a/src/ducks/settings/TagsListSettings.jsx
+++ b/src/ducks/settings/TagsListSettings.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import SearchInput from 'components/SearchInput'
+import SelectInput from 'components/SelectInput'
+import { Unpadded } from 'components/Padded'
+import TagsList from 'ducks/settings/TagsList'
+
+const useStyles = makeStyles({
+  mobileBox: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: '.5rem',
+    gap: '.5rem'
+  },
+  desktopBox: {
+    display: 'flex',
+    flexDirection: 'row',
+    margin: '2rem 2rem 1rem 2rem',
+    gap: '.625rem'
+  }
+})
+
+const TagsListSettings = ({ tags }) => {
+  const { isMobile } = useBreakpoints()
+  const styles = useStyles()
+  const { t } = useI18n()
+  const [filter, setFilter] = useState('')
+  const [sort, setSort] = useState('label-asc')
+
+  const filterPlaceholder = t('Tag.search')
+
+  const sortOptions = {
+    'label-asc': t('Tag.sortLabelAsc'),
+    'label-desc': t('Tag.sortLabelDesc'),
+    'transactions.count-desc': t('Tag.sortCountDesc'),
+    'transactions.count-asc': t('Tag.sortCountAsc')
+  }
+
+  return (
+    <Unpadded horizontal vertical>
+      <div className={isMobile ? styles.mobileBox : styles.desktopBox}>
+        <SearchInput placeholder={filterPlaceholder} setValue={setFilter} />
+        <SelectInput
+          options={sortOptions}
+          name="sort"
+          value={sort}
+          setValue={setSort}
+        />
+      </div>
+      <TagsList tags={tags} filter={filter} sort={sort} />
+    </Unpadded>
+  )
+}
+
+TagsList.propTypes = {
+  tags: PropTypes.array.isRequired
+}
+
+export default TagsListSettings

--- a/src/ducks/settings/TagsSettings.jsx
+++ b/src/ducks/settings/TagsSettings.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+import { tagsConn } from 'doctypes'
+import { useQueryAll, isQueryLoading } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import TagsListSettings from 'ducks/settings/TagsListSettings'
+
+const TagsSettings = () => {
+  const { t } = useI18n()
+  const response = useQueryAll(tagsConn.query, tagsConn)
+  const hasFailed = response.fetchStatus === 'failed'
+
+  if (hasFailed) {
+    return (
+      <>
+        <p>{t('Loading.error')}</p>
+        <p>{response.lastError?.message}</p>
+      </>
+    )
+  }
+
+  const isLoading = isQueryLoading(response) || response.hasMore
+
+  if (isLoading) {
+    return (
+      <Spinner
+        size="xxlarge"
+        className="u-flex u-flex-justify-center u-mt-2 u-h-5"
+      />
+    )
+  }
+
+  return <TagsListSettings tags={response.data} />
+}
+
+export default TagsSettings

--- a/src/ducks/settings/index.js
+++ b/src/ducks/settings/index.js
@@ -3,6 +3,7 @@ import AccountsSettings from 'ducks/settings/AccountsSettings'
 import ExistingGroupSettings from 'ducks/settings/GroupSettings/ExistingGroupSettings'
 import NewGroupSettings from 'ducks/settings/GroupSettings/NewGroupSettings'
 import GroupsSettings from 'ducks/settings/GroupsSettings'
+import TagsSettings from 'ducks/settings/TagsSettings'
 import Configuration from 'ducks/settings/Configuration'
 
 export { getDefaultedSettingsFromCollection } from './helpers'
@@ -14,5 +15,6 @@ export {
   GroupsSettings,
   ExistingGroupSettings,
   NewGroupSettings,
+  TagsSettings,
   Configuration
 }

--- a/src/ducks/settings/tagsSettingsHelpers.js
+++ b/src/ducks/settings/tagsSettingsHelpers.js
@@ -1,0 +1,31 @@
+import { remove as removeDiacritics } from 'diacritics'
+import Fuse from 'fuse.js'
+import orderBy from 'lodash/orderBy'
+
+const whitespace = /\s+/gu
+
+function removeWhitespace(string) {
+  return string.replace(whitespace, '')
+}
+
+const fuse = new Fuse([], {
+  findAllMatches: true,
+  threshold: 0.3,
+  keys: ['label'],
+  getFn: (object, path) => {
+    return removeDiacritics(removeWhitespace(Fuse.config.getFn(object, path)))
+  }
+})
+
+export function filterTags(tags, filter) {
+  const trimmedFilter = removeDiacritics(removeWhitespace(filter))
+  if (trimmedFilter.length === 0) {
+    return Array.from(tags)
+  }
+  fuse.setCollection(tags)
+  return fuse.search(trimmedFilter).map(result => result.item)
+}
+
+export function sortTags(tags, sortKey, sortOrder) {
+  return orderBy(tags, [sortKey], [sortOrder])
+}

--- a/src/ducks/settings/tagsSettingsHelpers.spec.js
+++ b/src/ducks/settings/tagsSettingsHelpers.spec.js
@@ -1,0 +1,69 @@
+import { filterTags, sortTags } from './tagsSettingsHelpers'
+
+const tags = [
+  {
+    _id: 0,
+    label: 'Achats compulsifs',
+    transactions: {
+      count: 1
+    }
+  },
+  {
+    _id: 1,
+    label: 'Boulangerie',
+    transactions: {
+      count: 136
+    }
+  },
+  {
+    _id: 2,
+    label: 'Baptême Léo',
+    transactions: {
+      count: 15
+    }
+  },
+  {
+    _id: 3,
+    label: 'Chien',
+    transactions: {
+      count: 19
+    }
+  }
+]
+
+describe('filterTags', () => {
+  it.each`
+    tags    | filter             | result
+    ${tags} | ${''}              | ${tags}
+    ${tags} | ${'  '}            | ${tags}
+    ${tags} | ${'c'}             | ${[tags[3], tags[0]]}
+    ${tags} | ${'C'}             | ${[tags[3], tags[0]]}
+    ${tags} | ${' c '}           | ${[tags[3], tags[0]]}
+    ${tags} | ${' C '}           | ${[tags[3], tags[0]]}
+    ${tags} | ${' ch '}          | ${[tags[3], tags[0]]}
+    ${tags} | ${' chiens '}      | ${[tags[3]]}
+    ${tags} | ${' c h i e n s '} | ${[tags[3]]}
+    ${tags} | ${' leo '}         | ${[tags[2]]}
+    ${tags} | ${'abc'}           | ${[]}
+  `(
+    `should filter the tags when passed arguments: $filter`,
+    ({ tags, filter, result }) => {
+      expect(filterTags(tags, filter)).toStrictEqual(result)
+    }
+  )
+})
+
+describe('sortTags', () => {
+  it.each`
+    tags    | sortKey                 | sortOrder | result
+    ${tags} | ${'label'}              | ${'asc'}  | ${[tags[0], tags[2], tags[1], tags[3]]}
+    ${tags} | ${'label'}              | ${'desc'} | ${[tags[0], tags[2], tags[1], tags[3]].reverse()}
+    ${tags} | ${'transactions.count'} | ${'asc'}  | ${[tags[0], tags[2], tags[3], tags[1]]}
+    ${tags} | ${'transactions.count'} | ${'desc'} | ${[tags[0], tags[2], tags[3], tags[1]].reverse()}
+  `(
+    `should sort the tags when passed arguments: $sortKey, $sortOrder`,
+    ({ tags, sortKey, sortOrder, result }) => {
+      expect(sortTags(tags, sortKey, sortOrder)).toStrictEqual(result)
+    }
+  )
+})

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -541,6 +541,7 @@
     "title": "Settings",
     "accounts": "Accounts",
     "groups": "Groups",
+    "tags": "Tags",
     "configuration": "Config.",
     "debug": "Debug",
     "personal-info": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -945,6 +945,13 @@
     "add-new-tag": "Add a new tag",
     "new-tag": "New tag",
     "tag-name": "Name of the tag",
-    "transactions": "%{smart_count} tagged transaction |||| %{smart_count} tagged transactions"
+    "transactions": "%{smart_count} tagged transaction |||| %{smart_count} tagged transactions",
+    "search": "Search for a tag",
+    "sortLabelAsc": "A-Z",
+    "sortLabelDesc": "Z-A",
+    "sortCountAsc": "Least used first",
+    "sortCountDesc": "Most used first",
+    "sortDateAsc": "Least common first",
+    "sortDateDesc": "Most common first"
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -542,6 +542,7 @@
     "title": "Paramètres",
     "accounts": "Comptes",
     "groups": "Groupes",
+    "tags": "Labels",
     "configuration": "Config.",
     "debug": "Debug",
     "personal-info": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -947,6 +947,13 @@
     "add-new-tag": "Ajouter un nouveau label",
     "new-tag": "Nouveau label",
     "tag-name": "Nom du libellé",
-    "transactions": "%{smart_count} opération libellée |||| %{smart_count} opérations libellées"
+    "transactions": "%{smart_count} opération libellée |||| %{smart_count} opérations libellées",
+    "search": "Rechercher un label",
+    "sortLabelAsc": "A-Z",
+    "sortLabelDesc": "Z-A",
+    "sortCountAsc": "Les moins utilisés en premier",
+    "sortCountDesc": "Les plus utilisés en premier",
+    "sortDateAsc": "Les moins fréquents en premier",
+    "sortDateDesc": "Les plus fréquents en premier"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6631,6 +6631,11 @@ dezalgo@^1.0.0, dezalgo@^1.0.1, dezalgo@^1.0.2, dezalgo@~1.0.3:
     asap "^2.0.0"
     wrappy "1"
 
+diacritics@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/diacritics/-/diacritics-1.3.0.tgz#3efa87323ebb863e6696cebb0082d48ff3d6f7a1"
+  integrity sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==
+
 diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
@@ -13398,9 +13403,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
+"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.6":
   version "1.0.6"
-  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
+  resolved "https://github.com/cozy/mui-bottom-sheet.git#494c40416ecde95732c864f9b921e7e545075aa5"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"


### PR DESCRIPTION
This PR is on top of #2426 and thus should wait for it to be merged on master.

This adds a page to see all the tags that have been created. It also implements search and sort on the tags. The "most / least common" criteria is not yet implemented and currently clicking on a tag in the list does not open any dedicated page to the tag.