### PR TITLE
feat: Upgrade Harvest and CozyClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,8 @@
 * Prevent recurrence service from running until we figure out why it is triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2423)
 * Do not allways show the same bank in BI webview
 * Do fail the connector for banks with multiple bank ids
-* Update cozy-client to 32.2.6 :
+* Update cozy-client to 32.2.7 :
+  * Lodash.merge is not creating a new object  [PR](https://github.com/cozy/cozy-client/pull/1201)
   * fix temporary token cache when beginning with an empty cache [PR](https://github.com/cozy/cozy-client/pull/1198)
   * Breaking changes are not supposed to affect cozy-banks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,6 @@
   * fix temporary token cache when beginning with an empty cache [PR](https://github.com/cozy/cozy-client/pull/1198)
   * Breaking changes are not supposed to affect cozy-banks
 
-
 ## 🔧 Tech
 
 * Extract import of AccountModalContent in HarvestAccountModal to be able to override it easily

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@
 * Update trigger without fetch policy in AccountModal, while reconnecting a konnector [[PR]](https://github.com/cozy/cozy-banks/pull/2404)
 * Use the right color for input text
 * Colors when importing account
+* Prevent recurrence service from running until we figure out why it is triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2423)
+* Do not allways show the same bank in BI webview
+* Do fail the connector for banks with multiple bank ids
+* Update cozy-client to 32.2.6 :
+  * fix temporary token cache when beginning with an empty cache [PR](https://github.com/cozy/cozy-client/pull/1198)
+  * Breaking changes are not supposed to affect cozy-banks
+
 
 ## 🔧 Tech
 

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "cozy-authentication": "2.1.0",
     "cozy-bar": "^8.7.5",
     "cozy-ci": "0.4.1",
-    "cozy-client": "^29.1.1",
+    "cozy-client": "^32.2.6",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.26.0",
+    "cozy-harvest-lib": "^9.26.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "cozy-authentication": "2.1.0",
     "cozy-bar": "^8.7.5",
     "cozy-ci": "0.4.1",
-    "cozy-client": "^32.2.6",
+    "cozy-client": "^32.2.7",
     "cozy-client-js": "0.16.4",
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5212,6 +5212,30 @@ cozy-client@^29.1.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
+cozy-client@^32.2.6:
+  version "32.2.6"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.2.6.tgz#54ee1acf471197568edbc6303ac6791173a70ab9"
+  integrity sha512-9KOcaTXjaV4xAeA3TTfMegh5ro/C8jDiJGfFCwR1LAoPfT0c88BtTRBkQHhzavK6ZJ3gh5J3fvYG0qqrssIHIg==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-stack-client "^32.2.5"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
+
 cozy-client@^6.58.0:
   version "6.64.5"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-6.64.5.tgz#33302c3190387ad42928189ae916f5afb28c3a84"
@@ -5286,10 +5310,10 @@ cozy-doctypes@^1.82.3:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.83.8:
-  version "1.83.8"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.83.8.tgz#99ec864059034bd032f6f01e322b57fea130a5d3"
-  integrity sha512-S88VzjnfZTHo7Mix7M3qId0YF6gOmL+C0X2LZnQp6F2cEOKa7sOlDiMD18u2kfPwyvlxxM+tQBI9ArEM/Xqkog==
+cozy-doctypes@^1.85.1:
+  version "1.85.2"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.2.tgz#a899c5be5d4d5e45064d507f62511309a845b94f"
+  integrity sha512-iLalLjhozqCKpYpQKH/L3JTOYneqt+WEO63reLeGV6ZFkOCp5GRZ8xWJiAXRkaA6NzvYo1OEyAaikN04aHe6jA==
   dependencies:
     cozy-logger "^1.9.0"
     date-fns "^1.30.1"
@@ -5599,6 +5623,15 @@ cozy-stack-client@^29.1.0:
   version "29.1.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-29.1.0.tgz#a101e164b45088560df828ff39e369cd9e5a5466"
   integrity sha512-KxLTdGhqNFDX4TpstzuyROROTGkvvMy4sSiRS5yHir8hfudCuME6pyRIKTslTlMx/y7vjYqcInaEnrwlZP7zaA==
+  dependencies:
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^32.2.5:
+  version "32.2.5"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-32.2.5.tgz#ffb798fb8a9de6126d53abbf68b7b6f90a0db9e2"
+  integrity sha512-RJKOc7Vd6CAmDEpdohU84PT8KYTnC/UsYm1IsBPrqzzeZCZXceHJWtALB1rpwfTdLTvu3heYYAuLjJqtqVbBGQ==
   dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5212,10 +5212,10 @@ cozy-client@^29.1.1:
     sift "^6.0.0"
     url-search-params-polyfill "^8.0.0"
 
-cozy-client@^32.2.6:
-  version "32.2.6"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.2.6.tgz#54ee1acf471197568edbc6303ac6791173a70ab9"
-  integrity sha512-9KOcaTXjaV4xAeA3TTfMegh5ro/C8jDiJGfFCwR1LAoPfT0c88BtTRBkQHhzavK6ZJ3gh5J3fvYG0qqrssIHIg==
+cozy-client@^32.2.7:
+  version "32.2.7"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-32.2.7.tgz#4149c6463e24e9f36dac13547476ee719266d2c8"
+  integrity sha512-Vqv7l9iNuPiO2Okn5FQCqRrCq21fIKnEGyKSd1D+DAdkAbmsrqYve2duDv6mJ/VOhj7/vDxRn94oN61kienN5Q==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5310,7 +5310,7 @@ cozy-doctypes@^1.82.3:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.85.1:
+cozy-doctypes@^1.85.2:
   version "1.85.2"
   resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.2.tgz#a899c5be5d4d5e45064d507f62511309a845b94f"
   integrity sha512-iLalLjhozqCKpYpQKH/L3JTOYneqt+WEO63reLeGV6ZFkOCp5GRZ8xWJiAXRkaA6NzvYo1OEyAaikN04aHe6jA==
@@ -5335,15 +5335,15 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.26.0:
-  version "9.26.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.0.tgz#09a8548687d2cbd547bc9a4ece1bcedbaff2d1e9"
-  integrity sha512-7+ZqK5YgR58ouSb5fHSVjIvqfulcVyx2PTQufSghtsu6coi0Q+AVMF/RG53Rahsy+GDuk9m5caMn0GxM8rF/hQ==
+cozy-harvest-lib@^9.26.1:
+  version "9.26.4"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.4.tgz#b093504d9f0ddc4d39b5a08eea92034593bf291c"
+  integrity sha512-yOn09cXwYL7lEpltIcxoauRUmmeB5q+UcjwzvjQf/kfRVzH+dGniN0tIDJkd2fvtwjitv8zi8Togf+waLSGe4g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
     cozy-bi-auth "0.0.25"
-    cozy-doctypes "^1.85.1"
+    cozy-doctypes "^1.85.2"
     cozy-logger "^1.9.0"
     date-fns "^1.30.1"
     final-form "^4.18.5"


### PR DESCRIPTION
Harvest to 9.22.2 to get :
 * fix: Do not use biBankId from cache
 * feat: Allow disabled banks to be clickable
 * fix: Add BI bankIds to createTemporaryToken params
Cozy-client to 32.2.6 to get :
 * fix temporary token cache when beginning with an empty cache [PR](https://github.com/cozy/cozy-client/pull/1198)
