### PR TITLE
fix: Avoid notifying bill notifications twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fix recurrence service that was triggering itself in an infinite loop [[PR]](https://github.com/cozy/cozy-banks/pull/2429)
 * Fix typo in French translation [[PR]](https://github.com/cozy/cozy-banks/pull/2430)
 * Transactions actions style on mobile
+* Notifications based on transactions changes will only be sent once, even if the transaction is modified after the first trigger [[PR]](https://github.com/cozy/cozy-banks/pull/2437)
 
 ## 🔧 Tech
 

--- a/src/ducks/notifications/HealthBillLinked/index.spec.js
+++ b/src/ducks/notifications/HealthBillLinked/index.spec.js
@@ -1,0 +1,109 @@
+import CozyClient from 'cozy-client'
+import { BankTransaction, Document } from 'cozy-doctypes'
+import { sendNotification } from 'cozy-notifications'
+
+import HealthBillLinked from './index'
+import { Bill } from 'src/models'
+import { setAlreadyNotified } from 'ducks/transactions/helpers'
+import billsFixtures from 'test/fixtures/matching-service/bill-reimbursement.json'
+
+const mockAccounts = [{ _id: 'accountId3' }]
+const mockBills = billsFixtures['io.cozy.bills']
+const mockTransactions = [
+  {
+    _id: 't1',
+    amount: -mockBills[0].amount,
+    date: '2018-09-18T12:00',
+    label: '3',
+    manualCategoryId: '400610',
+    account: 'accountId3',
+    reimbursements: [{ billId: `io.cozy.bills:${mockBills[0]._id}` }]
+  }
+]
+
+describe('HealthBillLinked', () => {
+  const setup = ({ lang, data }) => {
+    const localeStrings = require(`locales/${lang}.json`)
+    const {
+      initTranslation
+    } = require('cozy-ui/transpiled/react/I18n/translation')
+    const translation = initTranslation(lang, () => localeStrings)
+    const t = translation.t.bind(translation)
+    const notification = new HealthBillLinked({
+      t,
+      data,
+      lang: 'en',
+      locales: {
+        en: localeStrings
+      },
+      client: { stackClient: { uri: 'http://cozy.tools:8080' } },
+      value: 20
+    })
+    return { notification }
+  }
+
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(msg => {
+      throw new Error(`Warning during tests ${msg}`)
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe('buildData', () => {
+    it('should fetch transactions with a linked bill', async () => {
+      jest.spyOn(Bill, 'getAll').mockResolvedValue(mockBills)
+
+      const { notification } = setup({
+        lang: 'en',
+        data: { transactions: mockTransactions }
+      })
+      const data = await notification.buildData()
+      expect(data.transactions).toHaveLength(1)
+    })
+
+    it('should not fetch transactions already notified', async () => {
+      jest.spyOn(Bill, 'getAll').mockResolvedValue(mockBills)
+
+      const { notification } = setup({
+        lang: 'en',
+        data: {
+          transactions: mockTransactions.map(translation =>
+            setAlreadyNotified({ ...translation }, HealthBillLinked)
+          )
+        }
+      })
+      const data = await notification.buildData()
+      expect(data).toBeUndefined()
+    })
+  })
+
+  describe('onSuccess', () => {
+    it('should be called after successfuly sending notifications', async () => {
+      jest.spyOn(Bill, 'getAll').mockResolvedValue(mockBills)
+      jest.spyOn(BankTransaction, 'updateAll').mockImplementation()
+
+      const client = new CozyClient({
+        uri: 'http://localhost:8080'
+      })
+      Document.registerClient(client)
+      jest.spyOn(client.stackClient, 'fetchJSON').mockResolvedValue({})
+
+      const { notification } = setup({
+        lang: 'en',
+        data: { transactions: mockTransactions, accounts: mockAccounts }
+      })
+      jest.spyOn(notification, 'onSuccess')
+
+      await sendNotification(client, notification)
+      expect(notification.onSuccess).toHaveBeenCalled()
+      expect(BankTransaction.updateAll).toHaveBeenCalledWith(
+        mockTransactions.map(transaction =>
+          setAlreadyNotified(transaction, HealthBillLinked)
+        )
+      )
+    })
+  })
+})

--- a/src/ducks/notifications/TransactionGreater/index.spec.js
+++ b/src/ducks/notifications/TransactionGreater/index.spec.js
@@ -9,6 +9,7 @@ import maxBy from 'lodash/maxBy'
 import minBy from 'lodash/minBy'
 import frLocale from 'locales/fr.json'
 import { formatTransaction, MAX_CHAR_BY_LINE } from './utils'
+import { setAlreadyNotified } from 'ducks/transactions/helpers'
 
 const unique = arr => Array.from(new Set(arr))
 
@@ -288,6 +289,22 @@ describe('transaction greater', () => {
       expect(transactionSalaire).toEqual(
         'Salaire Du Mois De Septembre 2021 (01/0 : 1234,56€'
       )
+    })
+  })
+
+  describe('buildData', () => {
+    const operations = fixturesTransactionGreater['io.cozy.bank.operations']
+
+    it('should filter out transactions which have already been notified', async () => {
+      const transactions = operations
+        .filter(({ amount }) => amount > 1000)
+        .map((op, i) => {
+          return i % 2 === 0 ? setAlreadyNotified(op, TransactionGreater) : op
+        })
+      const { notification } = setup({ transactions, value: 1000 })
+
+      const data = await notification.buildData()
+      expect(data.transactions).toHaveLength(1)
     })
   })
 })

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -1,6 +1,7 @@
 import find from 'lodash/find'
 import findLast from 'lodash/findLast'
 import get from 'lodash/get'
+import set from 'lodash/set'
 import sumBy from 'lodash/sumBy'
 
 import flag from 'cozy-flags'
@@ -228,6 +229,16 @@ export const isAlreadyNotified = (transaction, notificationClass) => {
       `cozyMetadata.notifications.${notificationClass.settingKey}`
     )
   )
+}
+
+export const setAlreadyNotified = (transaction, notificationClass) => {
+  const today = new Date()
+  set(
+    transaction,
+    `cozyMetadata.notifications.${notificationClass.settingKey}`,
+    today.toISOString()
+  )
+  return transaction
 }
 
 export const setTransactionCategory = (transaction, category) => {

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -182,6 +182,12 @@ const onOperationOrBillCreate = async (client, options) => {
     log('info', 'Skip transactions matching')
   }
 
+  // Select which notifications should be be sent
+  // BalanceLower - does not depend on transactions modifications
+  // TransactionGreater
+  // HealthBillLinked
+  // LateHealthReimbursement
+  // DelayedDebit - does not depend on transactions modifications
   await doSendNotifications(setting, notifChanges)
   setting = await updateSettings(client, setting)
 


### PR DESCRIPTION
Some notifications sent by the `onOperationOrBillCreate` service can
be sent multiple times as we're not saving anywhere the fact that
they've already been sent.
This is the case of `HealthBillLinked` notifications for example.
These are sent when a reimbursement bill is linked to a transaction
but if that transaction gets updated somehow later, then the service
will send another notification once it runs.

The `TransactionGreater` notification class had a mechanism based on
the `cozyMetadata` to save this information on the transactions
themselves so we just use it for all transaction based notifications
(i.e `HealthBillLinked`, `LateHealthReimbursement` and
`TransactionGreater`).

This will generate changes on the transactions as we're saving the
state in their metadata but now that the recurrence service does not
call itself in a loop anymore, this should be fine.