### PR TITLE
Add advanced filters with tags

### DIFF
--- a/src/components/Tag/TagAddModal.jsx
+++ b/src/components/Tag/TagAddModal.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import TagAddModalContent from 'components/Tag/TagAddModalContent'
 
@@ -13,7 +14,8 @@ const TagAddModal = ({
   isLoading,
   toggleAddNewTagModal,
   onClick,
-  onClose
+  onClose,
+  withButton
 }) => {
   const { t } = useI18n()
 
@@ -30,12 +32,25 @@ const TagAddModal = ({
             className="u-flex u-flex-justify-center u-mv-1"
           />
         ) : (
-          <TagAddModalContent
-            toggleAddNewTagModal={toggleAddNewTagModal}
-            selectedTagIds={selectedTagIds}
-            tags={tags}
-            onClick={onClick}
-          />
+          <>
+            <TagAddModalContent
+              toggleAddNewTagModal={toggleAddNewTagModal}
+              selectedTagIds={selectedTagIds}
+              tags={tags}
+              onClick={onClick}
+              withButton={withButton}
+            />
+
+            {withButton && (
+              <div className="u-p-1">
+                <Button
+                  fullWidth
+                  onClick={onClose}
+                  label={t('General.valid')}
+                />
+              </div>
+            )}
+          </>
         )
       }
       onClose={isSaving ? undefined : onClose}

--- a/src/components/Tag/TagAddModalContent.jsx
+++ b/src/components/Tag/TagAddModalContent.jsx
@@ -14,7 +14,8 @@ const TagAddModalContent = ({
   toggleAddNewTagModal,
   selectedTagIds,
   tags,
-  onClick
+  onClick,
+  withButton
 }) => {
   const { t } = useI18n()
 
@@ -37,6 +38,7 @@ const TagAddModalContent = ({
       toggleAddNewTagModal={toggleAddNewTagModal}
       selectedTagIds={selectedTagIds}
       onClick={onClick}
+      withButton={withButton}
     />
   )
 }

--- a/src/components/Tag/TagAddModalContentList.jsx
+++ b/src/components/Tag/TagAddModalContentList.jsx
@@ -15,29 +15,38 @@ const TagAddModalContentList = ({
   tags,
   toggleAddNewTagModal,
   selectedTagIds,
-  onClick
+  onClick,
+  withButton
 }) => {
   const { t } = useI18n()
 
   return (
-    <List>
-      {tags.map((tag, index) => (
-        <Fragment key={`${tag.label} ${index}`}>
-          <TagAddModalContentListItem
-            tag={tag}
-            checked={selectedTagIds.some(id => id === tag._id)}
-            onClick={onClick}
-          />
-          <Divider component="li" variant="inset" />
-        </Fragment>
-      ))}
-      <ListItem button onClick={toggleAddNewTagModal}>
-        <ListItemIcon>
-          <Icon icon={PlusIcon} />
-        </ListItemIcon>
-        <ListItemText primary={t('Tag.new-tag')} />
-      </ListItem>
-    </List>
+    <>
+      <List>
+        {tags.map((tag, index) => (
+          <Fragment key={`${tag.label} ${index}`}>
+            <TagAddModalContentListItem
+              tag={tag}
+              checked={selectedTagIds.some(id => id === tag._id)}
+              onClick={onClick}
+            />
+            {tags.length - 1 > index && (
+              <Divider component="li" variant="inset" />
+            )}
+          </Fragment>
+        ))}
+        {withButton ? (
+          <Divider component="li" />
+        ) : (
+          <ListItem button onClick={toggleAddNewTagModal}>
+            <ListItemIcon>
+              <Icon icon={PlusIcon} />
+            </ListItemIcon>
+            <ListItemText primary={t('Tag.new-tag')} />
+          </ListItem>
+        )}
+      </List>
+    </>
   )
 }
 

--- a/src/components/Tag/TagBottomSheet.jsx
+++ b/src/components/Tag/TagBottomSheet.jsx
@@ -8,6 +8,7 @@ import Typography from 'cozy-ui/transpiled/react/Typography'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
 import Overlay from 'cozy-ui/transpiled/react/Overlay'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import TagAddModalContent from 'components/Tag/TagAddModalContent'
 
@@ -18,7 +19,8 @@ const TagBottomSheet = ({
   isLoading,
   toggleAddNewTagModal,
   onClick,
-  onClose
+  onClose,
+  withButton
 }) => {
   const { t } = useI18n()
 
@@ -41,7 +43,13 @@ const TagBottomSheet = ({
           selectedTagIds={selectedTagIds}
           tags={tags}
           onClick={onClick}
+          withButton={withButton}
         />
+        {withButton && (
+          <div className="u-p-1">
+            <Button fullWidth onClick={onClose} label={t('General.valid')} />
+          </div>
+        )}
       </BottomSheetItem>
     </BottomSheet>
   )

--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
@@ -6,13 +6,27 @@ import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
 import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+import Overlay from 'cozy-ui/transpiled/react/Overlay'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+import { isQueryLoading, useQueryAll } from 'cozy-client'
 
+import { tagsConn } from 'doctypes'
 import IncomeListItem from 'ducks/categories/AdvancedFilterModal/IncomeListItem'
 import TagListItem from 'components/Tag/TagListItem'
+import TagListItem from 'ducks/categories/CategoriesTags/TagListItem'
 
-const AdvancedFilterModal = ({ onClose, onConfirm, withIncome }) => {
+const AdvancedFilterModal = ({
+  onClose,
+  onConfirm,
+  withIncome,
+  setSelectedTags,
+  selectedTags
+}) => {
   const [isWithIncomeChecked, setIsWithIncomeChecked] = useState(withIncome)
+  const [tagListSelected, setTagListSelected] = useState(selectedTags)
   const { t } = useI18n()
+  const { data: tags, ...tagsQueryRest } = useQueryAll(tagsConn.query, tagsConn)
+  const isLoading = isQueryLoading(tagsQueryRest) || tagsQueryRest.hasMore
 
   const toogleIncome = () => {
     setIsWithIncomeChecked(prev => !prev)
@@ -20,7 +34,26 @@ const AdvancedFilterModal = ({ onClose, onConfirm, withIncome }) => {
 
   const handleConfirm = () => {
     onConfirm(isWithIncomeChecked)
+    setSelectedTags(tagListSelected)
     onClose()
+  }
+
+  const handleDeleteTag = tagToDelete => {
+    const newTagList = tagListSelected.filter(
+      tagSelected => tagSelected._id !== tagToDelete._id
+    )
+    setTagListSelected(newTagList)
+  }
+  const handleConfirmSelectedTag = selectedTagIds => {
+    setTagListSelected(selectedTagIds)
+  }
+
+  if (isLoading) {
+    return (
+      <Overlay className="u-flex u-flex-items-center u-flex-justify-center">
+        <Spinner size="xlarge" color="white" />
+      </Overlay>
+    )
   }
 
   return (
@@ -30,9 +63,18 @@ const AdvancedFilterModal = ({ onClose, onConfirm, withIncome }) => {
       title={t('Categories.filter.advancedFilters.title')}
       content={
         <List style={{ margin: '0 -1rem 0 -0.5rem' }}>
-          <IncomeListItem onChange={toogleIncome} value={isWithIncomeChecked} />
+          <IncomeListItem
+            onChange={toogleIncome}
+            value={!isWithIncomeChecked}
+          />
           <Divider variant="inset" component="li" />
-          <TagListItem disableGutters />
+          <TagListItem
+            tags={tags}
+            tagListSelected={tagListSelected}
+            disableGutters
+            onDelete={handleDeleteTag}
+            onConfirm={handleConfirmSelectedTag}
+          />
         </List>
       }
       actions={

--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import Divider from 'cozy-ui/transpiled/react/MuiCozyTheme/Divider'
+
+import IncomeListItem from 'ducks/categories/AdvancedFilterModal/IncomeListItem'
+import TagListItem from 'components/Tag/TagListItem'
+
+const AdvancedFilterModal = ({ onClose, onConfirm, withIncome }) => {
+  const [isWithIncomeChecked, setIsWithIncomeChecked] = useState(withIncome)
+  const { t } = useI18n()
+
+  const toogleIncome = () => {
+    setIsWithIncomeChecked(prev => !prev)
+  }
+
+  const handleConfirm = () => {
+    onConfirm(isWithIncomeChecked)
+    onClose()
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={t('Categories.filter.advancedFilters.title')}
+      content={
+        <List style={{ margin: '0 -1rem 0 -0.5rem' }}>
+          <IncomeListItem onChange={toogleIncome} value={isWithIncomeChecked} />
+          <Divider variant="inset" component="li" />
+          <TagListItem disableGutters />
+        </List>
+      }
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            onClick={onClose}
+            label={t('General.cancel')}
+          />
+          <Button label={t('General.apply')} onClick={handleConfirm} />
+        </>
+      }
+    />
+  )
+}
+
+AdvancedFilterModal.prototype = {
+  onClose: PropTypes.func,
+  onConfirm: PropTypes.func,
+  withIncome: PropTypes.bool
+}
+
+export default AdvancedFilterModal

--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
@@ -12,7 +12,7 @@ import { isQueryLoading, useQueryAll } from 'cozy-client'
 
 import { tagsConn } from 'doctypes'
 import IncomeListItem from 'ducks/categories/AdvancedFilterModal/IncomeListItem'
-import TagListItem from 'components/Tag/TagListItem'
+import style from 'ducks/categories/AdvancedFilterModal/AdvancedFilterModal.styl'
 import TagListItem from 'ducks/categories/CategoriesTags/TagListItem'
 
 const AdvancedFilterModal = ({
@@ -60,14 +60,19 @@ const AdvancedFilterModal = ({
     <ConfirmDialog
       open
       onClose={onClose}
+      className={style.no_padding}
       title={t('Categories.filter.advancedFilters.title')}
       content={
-        <List style={{ margin: '0 -1rem 0 -0.5rem' }}>
+        <List style={{ margin: '0 -1rem' }}>
           <IncomeListItem
             onChange={toogleIncome}
             value={!isWithIncomeChecked}
           />
-          <Divider variant="inset" component="li" />
+          <Divider
+            variant="inset"
+            component="li"
+            style={{ marginLeft: '3rem' }}
+          />
           <TagListItem
             tags={tags}
             tagListSelected={tagListSelected}

--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.styl
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.styl
@@ -1,0 +1,6 @@
+@require 'settings/breakpoints'
+
+.no_padding
+    +small-screen()
+        div[role="dialog"]
+            padding-right 0

--- a/src/ducks/categories/AdvancedFilterModal/IncomeListItem.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/IncomeListItem.jsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Checkbox from 'cozy-ui/transpiled/react/Checkbox'
+import EyeClosedIcon from 'cozy-ui/transpiled/react/Icons/EyeClosed'
+import EyeIcon from 'cozy-ui/transpiled/react/Icons/Eye'
+
+const IncomeListItem = ({ onChange, value }) => {
+  const { t } = useI18n()
+
+  return (
+    <ListItem button disableGutters onClick={onChange}>
+      <ListItemIcon>
+        <Icon icon={value ? EyeIcon : EyeClosedIcon} />
+      </ListItemIcon>
+      <ListItemText
+        primary={t('Categories.filter.advancedFilters.hideIncomes')}
+      />
+      <ListItemSecondaryAction>
+        <Checkbox checked={value} onChange={onChange} />
+      </ListItemSecondaryAction>
+    </ListItem>
+  )
+}
+
+IncomeListItem.prototype = {
+  onChange: PropTypes.func,
+  value: PropTypes.bool
+}
+
+export default IncomeListItem

--- a/src/ducks/categories/AdvancedFilterModal/IncomeListItem.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/IncomeListItem.jsx
@@ -22,7 +22,7 @@ const IncomeListItem = ({ onChange, value }) => {
       <ListItemText
         primary={t('Categories.filter.advancedFilters.hideIncomes')}
       />
-      <ListItemSecondaryAction>
+      <ListItemSecondaryAction className="u-pr-half">
         <Checkbox checked={value} onChange={onChange} />
       </ListItemSecondaryAction>
     </ListItem>

--- a/src/ducks/categories/CategoriesHeader/AdvancedFilter.jsx
+++ b/src/ducks/categories/CategoriesHeader/AdvancedFilter.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import List from 'cozy-ui/transpiled/react/MuiCozyTheme/List'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemSecondaryAction from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemSecondaryAction'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import SettingIcon from 'cozy-ui/transpiled/react/Icons/Setting'
+import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+
+const AdvancedFilter = ({ onClick, className }) => {
+  const { isMobile } = useBreakpoints()
+  const { t } = useI18n()
+
+  if (isMobile) {
+    return (
+      <List>
+        <ListItem button onClick={onClick}>
+          <ListItemIcon>
+            <Icon icon={SettingIcon} />
+          </ListItemIcon>
+          <ListItemText
+            primary={t('Categories.filter.advancedFilters.title')}
+          />
+          <ListItemSecondaryAction className="u-mr-1">
+            <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
+          </ListItemSecondaryAction>
+        </ListItem>
+      </List>
+    )
+  }
+
+  return (
+    <Button
+      label={t('Categories.filter.advancedFilters.title')}
+      variant="text"
+      onClick={onClick}
+      startIcon={<Icon icon={SettingIcon} />}
+      className={className}
+    />
+  )
+}
+
+AdvancedFilter.prototype = {
+  onClick: PropTypes.func,
+  className: PropTypes.string
+}
+
+export default AdvancedFilter

--- a/src/ducks/categories/CategoriesHeader/AdvancedFilter.jsx
+++ b/src/ducks/categories/CategoriesHeader/AdvancedFilter.jsx
@@ -12,10 +12,21 @@ import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 import SettingIcon from 'cozy-ui/transpiled/react/Icons/Setting'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
+import Badge from 'cozy-ui/transpiled/react/Badge'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
 
-const AdvancedFilter = ({ onClick, className }) => {
+const useStyles = makeStyles({
+  badge: {
+    top: '50%',
+    right: '2.2rem'
+  }
+})
+
+const AdvancedFilter = ({ onClick, selectedTagsLength, className }) => {
   const { isMobile } = useBreakpoints()
   const { t } = useI18n()
+  const classes = useStyles()
 
   if (isMobile) {
     return (
@@ -28,7 +39,18 @@ const AdvancedFilter = ({ onClick, className }) => {
             primary={t('Categories.filter.advancedFilters.title')}
           />
           <ListItemSecondaryAction className="u-mr-1">
-            <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
+            <Badge
+              badgeContent={selectedTagsLength}
+              classes={{ badge: classes.badge }}
+              showZero={false}
+              color="primary"
+              variant="standard"
+              size="medium"
+            >
+              <IconButton data-testid="SwitchButton" size="small">
+                <Icon icon={RightIcon} color="var(--secondaryTextColor)" />
+              </IconButton>
+            </Badge>
           </ListItemSecondaryAction>
         </ListItem>
       </List>
@@ -48,6 +70,7 @@ const AdvancedFilter = ({ onClick, className }) => {
 
 AdvancedFilter.prototype = {
   onClick: PropTypes.func,
+  hasSelectedTags: PropTypes.bool,
   className: PropTypes.string
 }
 

--- a/src/ducks/categories/CategoriesHeader/DesktopFragment.jsx
+++ b/src/ducks/categories/CategoriesHeader/DesktopFragment.jsx
@@ -1,23 +1,23 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Empty from 'cozy-ui/transpiled/react/Empty'
-import Header from 'components/Header'
-import Padded from 'components/Padded'
 import Stack from 'cozy-ui/transpiled/react/Stack'
-import Table from 'components/Table'
-import styles from 'ducks/categories/CategoriesHeader/CategoriesHeader.styl'
-import AddAccountButton from 'ducks/categories/AddAccountButton'
-
 import Fade from 'cozy-ui/transpiled/react/Fade'
 import Breadcrumb from 'cozy-ui/transpiled/react/Breadcrumbs'
-import CategoryAccountSwitch from 'ducks/categories/CategoryAccountSwitch'
 
+import Table from 'components/Table'
+import Header from 'components/Header'
+import Padded from 'components/Padded'
 import HeaderLoadingProgress from 'components/HeaderLoadingProgress'
-
+import AddAccountButton from 'ducks/categories/AddAccountButton'
+import CategoriesTableHead from 'ducks/categories/CategoriesHeader/CategoriesTableHead'
+import styles from 'ducks/categories/CategoriesHeader/CategoriesHeader.styl'
+import CategoryAccountSwitch from 'ducks/categories/CategoryAccountSwitch'
 import catStyles from 'ducks/categories/styles.styl'
-import CategoriesTableHead from './CategoriesTableHead'
+
 const stTableCategory = catStyles['bnk-table-category']
 
 const DesktopFragment = React.memo(

--- a/src/ducks/categories/CategoriesHeader/DesktopFragment.jsx
+++ b/src/ducks/categories/CategoriesHeader/DesktopFragment.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
+import flag from 'cozy-flags'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Empty from 'cozy-ui/transpiled/react/Empty'
 import Stack from 'cozy-ui/transpiled/react/Stack'
@@ -14,6 +15,7 @@ import Padded from 'components/Padded'
 import HeaderLoadingProgress from 'components/HeaderLoadingProgress'
 import AddAccountButton from 'ducks/categories/AddAccountButton'
 import CategoriesTableHead from 'ducks/categories/CategoriesHeader/CategoriesTableHead'
+import AdvancedFilter from 'ducks/categories/CategoriesHeader/AdvancedFilter'
 import styles from 'ducks/categories/CategoriesHeader/CategoriesHeader.styl'
 import CategoryAccountSwitch from 'ducks/categories/CategoryAccountSwitch'
 import catStyles from 'ducks/categories/styles.styl'
@@ -31,7 +33,8 @@ const DesktopFragment = React.memo(
     incomeToggle,
     isFetching,
     isFetchingNewData,
-    selectedCategory
+    selectedCategory,
+    showAdvancedFilter
   }) => {
     const { t } = useI18n()
 
@@ -58,7 +61,14 @@ const DesktopFragment = React.memo(
                       <Breadcrumb className="u-mt-1" items={breadcrumbItems} />
                     </Fade>
                   )}
-                  {incomeToggle}
+                  {flag('banks.tags.enabled') ? (
+                    <AdvancedFilter
+                      onClick={showAdvancedFilter}
+                      className="u-mt-1"
+                    />
+                  ) : (
+                    incomeToggle
+                  )}
                 </div>
                 {chart}
               </>
@@ -99,7 +109,8 @@ DesktopFragment.propTypes = {
   incomeToggle: PropTypes.node.isRequired,
   isFetching: PropTypes.bool.isRequired,
   isFetchingNewData: PropTypes.bool.isRequired,
-  selectedCategory: PropTypes.object
+  selectedCategory: PropTypes.object,
+  showAdvancedFilter: PropTypes.func
 }
 
 export default DesktopFragment

--- a/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
+++ b/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
@@ -1,17 +1,20 @@
 import React, { Fragment } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
+
+import flag from 'cozy-flags'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import Empty from 'cozy-ui/transpiled/react/Empty'
+
 import Header from 'components/Header'
 import Padded from 'components/Padded'
-import styles from 'ducks/categories/CategoriesHeader/CategoriesHeader.styl'
 import AddAccountButton from 'ducks/categories/AddAccountButton'
-
 import HeaderLoadingProgress from 'components/HeaderLoadingProgress'
 import LegalMention from 'ducks/legal/LegalMention'
 import DateSelectorHeader from 'ducks/categories/DateSelectorHeader'
+import AdvancedFilter from 'ducks/categories/CategoriesHeader/AdvancedFilter'
+import styles from 'ducks/categories/CategoriesHeader/CategoriesHeader.styl'
 
 const MobileFragment = React.memo(props => {
   const { t } = useI18n()
@@ -27,7 +30,8 @@ const MobileFragment = React.memo(props => {
     incomeToggle,
     isFetching,
     isFetchingNewData,
-    selectedCategory
+    selectedCategory,
+    showAdvancedFilter
   } = props
 
   return (
@@ -44,6 +48,9 @@ const MobileFragment = React.memo(props => {
           })}
           theme={isMobile ? 'normal' : 'inverted'}
         >
+          {flag('banks.tags.enabled') && (
+            <AdvancedFilter onClick={showAdvancedFilter} />
+          )}
           <HeaderLoadingProgress
             isFetching={!!isFetchingNewData && !isFetching}
           />
@@ -87,7 +94,8 @@ MobileFragment.propTypes = {
   incomeToggle: PropTypes.node.isRequired,
   isFetching: PropTypes.bool.isRequired,
   isFetchingNewData: PropTypes.bool.isRequired,
-  selectedCategory: PropTypes.object
+  selectedCategory: PropTypes.object,
+  showAdvancedFilter: PropTypes.func
 }
 
 export default MobileFragment

--- a/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
+++ b/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
@@ -31,7 +31,8 @@ const MobileFragment = React.memo(props => {
     isFetching,
     isFetchingNewData,
     selectedCategory,
-    showAdvancedFilter
+    showAdvancedFilter,
+    selectedTags
   } = props
 
   return (
@@ -49,7 +50,10 @@ const MobileFragment = React.memo(props => {
           theme={isMobile ? 'normal' : 'inverted'}
         >
           {flag('banks.tags.enabled') && (
-            <AdvancedFilter onClick={showAdvancedFilter} />
+            <AdvancedFilter
+              onClick={showAdvancedFilter}
+              selectedTagsLength={selectedTags.length}
+            />
           )}
           <HeaderLoadingProgress
             isFetching={!!isFetchingNewData && !isFetching}

--- a/src/ducks/categories/CategoriesHeader/index.jsx
+++ b/src/ducks/categories/CategoriesHeader/index.jsx
@@ -45,7 +45,9 @@ const CategoriesHeader = props => {
     isFetchingNewData,
     categoryName,
     subcategoryName,
-    classes
+    classes,
+    setSelectedTags,
+    selectedTags
   } = props
 
   const hasData =
@@ -130,12 +132,15 @@ const CategoriesHeader = props => {
         isFetching={isFetching}
         isFetchingNewData={isFetchingNewData}
         showAdvancedFilter={showAdvancedFilter}
+        selectedTags={selectedTags}
       />
       {isAdvancedFilterDisplayed && (
         <AdvancedFilterModal
           onClose={hideAdvancedFilter}
           onConfirm={onWithIncomeToggle}
           withIncome={withIncome}
+          setSelectedTags={setSelectedTags}
+          selectedTags={selectedTags}
         />
       )}
     </>

--- a/src/ducks/categories/CategoriesHeader/index.jsx
+++ b/src/ducks/categories/CategoriesHeader/index.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useCallback } from 'react'
+import React, { useMemo, useCallback, useState } from 'react'
 import PropTypes from 'prop-types'
 import cx from 'classnames'
 
@@ -25,10 +25,14 @@ import IncomeToggle from 'ducks/categories/IncomeToggle'
 import DesktopFragment from './DesktopFragment'
 import MobileFragment from './MobileFragment'
 import { makeBreadcrumbs } from './utils'
+import AdvancedFilterModal from '../AdvancedFilterModal/AdvancedFilterModal'
 
 const CategoriesHeader = props => {
   const { t } = useI18n()
   const { isMobile } = useBreakpoints()
+  const [isAdvancedFilterDisplayed, setIsAdvancedFilterDisplayed] =
+    useState(false)
+
   const {
     emptyIcon,
     hasAccount,
@@ -102,22 +106,39 @@ const CategoriesHeader = props => {
     />
   )
 
+  const showAdvancedFilter = () => {
+    setIsAdvancedFilterDisplayed(true)
+  }
+  const hideAdvancedFilter = () => {
+    setIsAdvancedFilterDisplayed(false)
+  }
+
   const Fragment = isMobile ? MobileFragment : DesktopFragment
 
   return (
-    <Fragment
-      breadcrumbItems={breadcrumbItems}
-      chart={chart}
-      classes={classes}
-      dateSelector={dateSelector}
-      emptyIcon={emptyIcon}
-      hasAccount={hasAccount}
-      hasData={hasData}
-      selectedCategory={selectedCategory}
-      incomeToggle={incomeToggle}
-      isFetching={isFetching}
-      isFetchingNewData={isFetchingNewData}
-    />
+    <>
+      <Fragment
+        breadcrumbItems={breadcrumbItems}
+        chart={chart}
+        classes={classes}
+        dateSelector={dateSelector}
+        emptyIcon={emptyIcon}
+        hasAccount={hasAccount}
+        hasData={hasData}
+        selectedCategory={selectedCategory}
+        incomeToggle={incomeToggle}
+        isFetching={isFetching}
+        isFetchingNewData={isFetchingNewData}
+        showAdvancedFilter={showAdvancedFilter}
+      />
+      {isAdvancedFilterDisplayed && (
+        <AdvancedFilterModal
+          onClose={hideAdvancedFilter}
+          onConfirm={onWithIncomeToggle}
+          withIncome={withIncome}
+        />
+      )}
+    </>
   )
 }
 

--- a/src/ducks/categories/CategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage.jsx
@@ -110,7 +110,9 @@ export class CategoriesPage extends Component {
       accounts,
       settings,
       isFetching: isFetchingNewData,
-      filteredTransactionsByAccount
+      filteredTransactionsByAccount,
+      setSelectedTags,
+      selectedTags
     } = this.props
     const isFetching = some(
       [accounts, transactions, settings, transactionsByApplicationDate],
@@ -150,6 +152,8 @@ export class CategoriesPage extends Component {
           isFetchingNewData={isFetchingNewData}
           hasAccount={hasAccount}
           chart={!isSubcategory}
+          setSelectedTags={setSelectedTags}
+          selectedTags={selectedTags}
         />
         <Delayed delay={this.props.delayContent}>
           {hasAccount &&

--- a/src/ducks/categories/CategoriesTags/TagAdd.jsx
+++ b/src/ducks/categories/CategoriesTags/TagAdd.jsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+
+import TagAddChip from 'components/Tag/TagAddChip'
+import TagAddModalOrBottomSheet from 'ducks/categories/CategoriesTags/TagAddModalOrBottomSheet'
+
+const TagAdd = ({ tags, tagListSelected, onConfirm }) => {
+  const [showModalOrBottomSheet, setShowModalOrBottomSheet] = useState(false)
+
+  const handleClose = selectedTagIds => {
+    onConfirm(selectedTagIds)
+    setShowModalOrBottomSheet(false)
+  }
+
+  return (
+    <>
+      <TagAddChip onClick={() => setShowModalOrBottomSheet(true)} />
+      {showModalOrBottomSheet && (
+        <TagAddModalOrBottomSheet
+          tags={tags}
+          tagListSelected={tagListSelected}
+          onClose={handleClose}
+        />
+      )}
+    </>
+  )
+}
+
+export default TagAdd

--- a/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
+++ b/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
@@ -37,6 +37,7 @@ const TagAddModalOrBottomSheet = ({ tags, tagListSelected, onClose }) => {
       selectedTagIds={selectedTagIds}
       onClick={handleClick}
       onClose={handleClose}
+      withButton
     />
   )
 }

--- a/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
+++ b/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+
+import TagAddModal from 'components/Tag/TagAddModal'
+import TagBottomSheet from 'components/Tag/TagBottomSheet'
+
+const isAlreadyChecked = (selectedTagIds, tag) =>
+  selectedTagIds.some(tagId => tagId === tag._id)
+
+const TagAddModalOrBottomSheet = ({ tags, tagListSelected, onClose }) => {
+  const { isMobile } = useBreakpoints()
+  const [selectedTagIds, setSelectedTagIds] = useState(
+    tagListSelected.map(tagSelected => tagSelected._id)
+  )
+
+  const handleClick = tag => {
+    if (isAlreadyChecked(selectedTagIds, tag)) {
+      setSelectedTagIds(prev => prev.filter(id => id !== tag._id))
+    } else if (selectedTagIds.length < 5) {
+      setSelectedTagIds(prev => [...prev, tag._id])
+    }
+  }
+
+  const handleClose = () => {
+    const selectedTagList = tags.filter(tag =>
+      selectedTagIds.some(selectedTagId => selectedTagId === tag._id)
+    )
+    onClose(selectedTagList)
+  }
+
+  const ModalOrBottomSheet = isMobile ? TagBottomSheet : TagAddModal
+
+  return (
+    <ModalOrBottomSheet
+      tags={tags}
+      selectedTagIds={selectedTagIds}
+      onClick={handleClick}
+      onClose={handleClose}
+    />
+  )
+}
+
+export default TagAddModalOrBottomSheet

--- a/src/ducks/categories/CategoriesTags/TagChip.jsx
+++ b/src/ducks/categories/CategoriesTags/TagChip.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import TagIcon from 'cozy-ui/transpiled/react/Icons/Tag'
+import Chip from 'cozy-ui/transpiled/react/Chips'
+
+const TagChip = ({ tag, className, onDelete, onClick }) => {
+  return (
+    <Chip
+      style={{ marginBottom: '0.25rem', marginRight: '0.25rem' }}
+      className={className}
+      icon={<Icon className="u-ml-half" icon={TagIcon} />}
+      label={tag.label}
+      clickable
+      onDelete={() => onDelete(tag)}
+      onClick={onClick}
+    />
+  )
+}
+
+export default TagChip

--- a/src/ducks/categories/CategoriesTags/TagChipList.jsx
+++ b/src/ducks/categories/CategoriesTags/TagChipList.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import TagChip from 'ducks/categories/CategoriesTags/TagChip'
+
+const TagChips = ({ tags, onDelete, className }) => {
+  return tags.map(tag => (
+    <TagChip
+      key={tag._id}
+      tag={tag}
+      className={className}
+      onDelete={onDelete}
+    />
+  ))
+}
+
+export default TagChips

--- a/src/ducks/categories/CategoriesTags/TagListItem.jsx
+++ b/src/ducks/categories/CategoriesTags/TagListItem.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import ListItem from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItem'
+import ListItemIcon from 'cozy-ui/transpiled/react/MuiCozyTheme/ListItemIcon'
+import ListItemText from 'cozy-ui/transpiled/react/ListItemText'
+import TagIcon from 'cozy-ui/transpiled/react/Icons/Tag'
+
+import TagChipList from 'ducks/categories/CategoriesTags/TagChipList'
+import TagAdd from 'ducks/categories/CategoriesTags/TagAdd'
+
+const TagListItem = ({
+  tags,
+  tagListSelected,
+  onDelete,
+  onConfirm,
+  ...props
+}) => {
+  return (
+    <ListItem button disableRipple {...props}>
+      <ListItemIcon>
+        <Icon icon={TagIcon} />
+      </ListItemIcon>
+      <ListItemText
+        ellipsis={false}
+        primary={
+          <>
+            <TagChipList tags={tagListSelected} onDelete={onDelete} />
+            <TagAdd
+              tags={tags}
+              tagListSelected={tagListSelected}
+              onConfirm={onConfirm}
+            />
+          </>
+        }
+      />
+    </ListItem>
+  )
+}
+
+export default TagListItem

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -8,7 +8,8 @@
     "back": "Back",
     "choose": "Choose",
     "reload": "Reload",
-    "tag": "Tag"
+    "tag": "Tag",
+    "valid": "Confirm"
   },
 
   "Loading": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,6 @@
 {
   "General": {
+    "apply": "Apply",
     "delete": "Delete",
     "deleting": "Deleting...",
     "cancel": "Cancel",
@@ -275,6 +276,10 @@
       "select-all": "Select all"
     },
     "filter": {
+      "advancedFilters": {
+        "hideIncomes": "Hide incomes",
+        "title": "Advanced filters"
+      },
       "credit": "earnings",
       "total": "Total",
       "debit": "Total excl. earnings",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "General": {
+    "apply": "Appliquer",
     "delete": "Supprimer",
     "deleting": "Suppression...",
     "cancel": "Annuler",
@@ -212,6 +213,10 @@
       "total-header": "Total"
     },
     "filter": {
+      "advancedFilters": {
+        "hideIncomes": "Masquer les revenus",
+        "title": "Filtres avancés"
+      },
       "debit": "Total hors categ. revenus",
       "credit": "Revenus",
       "total": "Total",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,7 +8,8 @@
     "back": "Revenir",
     "choose": "Choisir",
     "reload": "Recharger",
-    "tag": "Label"
+    "tag": "Label",
+    "valid": "Valider"
   },
 
   "Loading": {


### PR DESCRIPTION
Ce développement permet d'afficher une modale de filtres avancées, reprenant le filtre d'affichage des revenues déjà existant et ajoute le filtre par Tags.

Etant très en retard sur les délais, la refactorisation des composants "Tags" sera fait ultérieurement.