### PR TITLE
Add a page for managing a tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add tags on transactions
 * Add a tab in the settings to list all the tags
 * Upgrade cozy-ui from 69.3.0 to 70.2.4
+* Add a page for managing a given tag
 
 ## 🐛 Bug Fixes
 

--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -27,6 +27,7 @@ import UserActionRequired from 'components/UserActionRequired'
 import scrollToTopOnMount from 'components/scrollToTopOnMount'
 import PlannedTransactionsPage from 'ducks/future/PlannedTransactionsPage'
 import SetFilterAndRedirect from 'ducks/balance/SetFilterAndRedirect'
+import TagPage from 'ducks/tags/TagPage'
 
 // Use a function to delay instantation and have access to AppRoute.renderExtraRoutes
 const AppRoute = () => (
@@ -95,6 +96,9 @@ const AppRoute = () => (
           <Route path="configuration" component={Configuration} />
         </Route>
       </Route>
+      {flag('banks.tags.enabled') && (
+        <Route path="tag/:tagId" component={scrollToTopOnMount(TagPage)} />
+      )}
       <Route path="transfers" component={scrollToTopOnMount(TransferPage)} />
       <Route path="search" component={scrollToTopOnMount(SearchPage)} />
       <Route path="search/:search" component={scrollToTopOnMount(SearchPage)} />

--- a/src/components/RouterContext.jsx
+++ b/src/components/RouterContext.jsx
@@ -13,10 +13,13 @@ export const useParams = () => {
 
 export const useHistory = () => {
   const router = useRouter()
+  const goBack = useMemo(() => {
+    return router.goBack.bind(router)
+  }, [router])
   const push = useMemo(() => {
     return router.push.bind(router)
   }, [router])
-  return { push }
+  return { goBack, push }
 }
 
 export const useLocation = () => {

--- a/src/components/Tag/TagChip.jsx
+++ b/src/components/Tag/TagChip.jsx
@@ -6,10 +6,12 @@ import TagIcon from 'cozy-ui/transpiled/react/Icons/Tag'
 
 import { TAGS_DOCTYPE } from 'doctypes'
 import useDocument from 'components/useDocument'
+import { useHistory } from 'components/RouterContext'
 import { removeTag } from 'ducks/transactions/helpers'
 
 const TagChip = ({ className, transaction, tag, clickable, deletable }) => {
   const tagFromDoctype = useDocument(TAGS_DOCTYPE, tag._id)
+  const history = useHistory()
 
   const handleDelete = deletable
     ? () => removeTag(transaction, tagFromDoctype)
@@ -17,7 +19,9 @@ const TagChip = ({ className, transaction, tag, clickable, deletable }) => {
 
   const handleClick = ev => {
     ev?.preventDefault() // works only on desktop, hammer is used to prevent click on mobile
-    clickable && alert('TODO click!') // TODO: should open tags management url
+    if (clickable) {
+      history.push(`tag/${tag._id}`)
+    }
   }
 
   return (

--- a/src/components/Tag/TagDeleteTagModal.jsx
+++ b/src/components/Tag/TagDeleteTagModal.jsx
@@ -1,0 +1,61 @@
+import React, { useReducer } from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import { useHistory } from 'components/RouterContext'
+
+import { countTransactions } from 'components/Tag/helpers'
+import { removeTransaction } from 'ducks/transactions/helpers'
+
+const TagDeleteTagModal = ({ tag, transactions, onClose }) => {
+  const client = useClient()
+  const { t } = useI18n()
+  const history = useHistory()
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
+
+  const handleClick = async () => {
+    toggleBusy()
+    const { data: newTag } = await removeTransaction(tag, transactions)
+    await client.destroy(newTag)
+    history.goBack()
+    onClose()
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={t('Tag.deleteModal.title')}
+      content={t('Tag.deleteModal.content', {
+        smart_count: countTransactions(tag)
+      })}
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            label={t('Tag.deleteModal.actions.cancel')}
+            onClick={onClose}
+          />
+          <Button
+            color="error"
+            label={t('Tag.deleteModal.actions.submit')}
+            busy={isBusy}
+            onClick={handleClick}
+          />
+        </>
+      }
+    />
+  )
+}
+
+TagDeleteTagModal.propTypes = {
+  tag: PropTypes.object.isRequired,
+  transactions: PropTypes.array.isRequired,
+  onClose: PropTypes.func.isRequired
+}
+
+export default TagDeleteTagModal

--- a/src/components/Tag/TagRenameTagModal.jsx
+++ b/src/components/Tag/TagRenameTagModal.jsx
@@ -1,0 +1,69 @@
+import React, { useState, useReducer } from 'react'
+import PropTypes from 'prop-types'
+
+import { useClient } from 'cozy-client'
+
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
+import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+
+const TagRenameTagModal = ({ tag, onClose }) => {
+  const client = useClient()
+  const { t } = useI18n()
+  const [label, setLabel] = useState(tag.label)
+  const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
+
+  const handleClick = async () => {
+    toggleBusy()
+    await client.save({
+      ...tag,
+      label
+    })
+    onClose()
+  }
+
+  return (
+    <ConfirmDialog
+      open
+      onClose={onClose}
+      title={t('Tag.renameModal.title')}
+      content={
+        <>
+          <TextField
+            fullWidth
+            margin="normal"
+            label={t('Tag.renameModal.label')}
+            defaultValue={tag.label}
+            autoFocus
+            variant="outlined"
+            inputProps={{ maxLength: 30 }}
+            onChange={event => setLabel(event.target.value)}
+          />
+        </>
+      }
+      actions={
+        <>
+          <Button
+            variant="secondary"
+            label={t('Tag.renameModal.actions.cancel')}
+            onClick={onClose}
+          />
+          <Button
+            label={t('Tag.renameModal.actions.submit')}
+            busy={isBusy}
+            disabled={label.length === 0}
+            onClick={handleClick}
+          />
+        </>
+      }
+    />
+  )
+}
+
+TagRenameTagModal.propTypes = {
+  tag: PropTypes.object.isRequired,
+  onClose: PropTypes.func.isRequired
+}
+
+export default TagRenameTagModal

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -110,51 +110,51 @@ export class HasManyReimbursements extends HasManyInPlace {
 
 // Add transactions relationships on tags
 export class HasManyTags extends HasMany {
-  add(docsArg) {
+  async add(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
     const targets = Array.isArray(this.target) ? this.target : [this.target]
 
     for (const tag of docs) {
-      tag.transactions?.add(targets)
+      await tag.transactions?.add(targets)
     }
 
-    super.add(docs)
+    return super.add(docs)
   }
 
-  remove(docsArg) {
+  async remove(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
     const targets = Array.isArray(this.target) ? this.target : [this.target]
 
     for (const tag of docs) {
-      tag.transactions?.remove(targets)
+      await tag.transactions?.remove(targets)
     }
 
-    super.remove(docs)
+    return super.remove(docs)
   }
 }
 
 // Add tags relationships on transactions
 export class HasManyTransactions extends HasMany {
-  add(docsArg) {
+  async add(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
     const targets = Array.isArray(this.target) ? this.target : [this.target]
 
     for (const transaction of docs) {
-      transaction.tags?.add(targets)
+      await transaction.tags?.add(targets)
     }
 
-    super.add(docs)
+    return super.add(docs)
   }
 
-  remove(docsArg) {
+  async remove(docsArg) {
     const docs = Array.isArray(docsArg) ? docsArg : [docsArg]
     const targets = Array.isArray(this.target) ? this.target : [this.target]
 
     for (const transaction of docs) {
-      transaction.tags?.remove(targets)
+      await transaction.tags?.remove(targets)
     }
 
-    super.remove(docs)
+    return super.remove(docs)
   }
 }
 
@@ -374,11 +374,21 @@ export const tagsConn = {
   fetchPolicy: older30s
 }
 
-export const buildTagsQueryByIds = ids => {
+export const buildTagsQueryWithTransactionsByIds = ids => {
   return {
     definition: Q(TAGS_DOCTYPE).getByIds(ids).include(['transactions']),
     options: {
       as: `${TAGS_DOCTYPE}/${JSON.stringify(ids)}/withTransactions`,
+      fetchPolicy: older30s
+    }
+  }
+}
+
+export const buildTransactionsWithTagsQueryByIds = ids => {
+  return {
+    definition: Q(TRANSACTION_DOCTYPE).getByIds(ids).include(['tags']),
+    options: {
+      as: `${TRANSACTION_DOCTYPE}/${JSON.stringify(ids)}/withTags`,
       fetchPolicy: older30s
     }
   }

--- a/src/ducks/settings/TagListItem.jsx
+++ b/src/ducks/settings/TagListItem.jsx
@@ -11,6 +11,7 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import RightIcon from 'cozy-ui/transpiled/react/Icons/Right'
 import TagIcon from 'cozy-ui/transpiled/react/Icons/Tag'
 
+import { useHistory } from 'components/RouterContext'
 import { countTransactions } from 'components/Tag/helpers'
 
 const useStyles = makeStyles({
@@ -24,10 +25,10 @@ const TagListItem = ({ tag }) => {
   const { isMobile } = useBreakpoints()
   const styles = useStyles()
   const { t } = useI18n()
+  const history = useHistory()
 
   const handleListItemClick = () => {
-    // TODO: this should open a dialog to manage the tag
-    alert('Not implemented')
+    history.push(`tag/${tag._id}`)
   }
 
   return (

--- a/src/ducks/tags/TagDialog.jsx
+++ b/src/ducks/tags/TagDialog.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react'
+import PropTypes from 'prop-types'
+
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { Dialog } from 'cozy-ui/transpiled/react/CozyDialogs'
+
+import { useHistory } from 'components/RouterContext'
+import TagDialogTitle from 'ducks/tags/TagDialogTitle'
+import TagDialogContent from 'ducks/tags/TagDialogContent'
+
+const TagDialog = ({ tag }) => {
+  const { isMobile } = useBreakpoints()
+  const history = useHistory()
+  const [isRenameModalOpened, setIsRenameModalOpened] = useState(false)
+  const [isDeleteModalOpened, setIsDeleteModalOpened] = useState(false)
+
+  const amount = tag.transactions.data.reduce((amount, transaction) => {
+    return amount + transaction.amount
+  }, 0)
+  const currency = 'EUR'
+
+  const handleDialogBack = () => {
+    history.goBack()
+  }
+
+  const title = (
+    <TagDialogTitle
+      tag={tag}
+      amount={amount}
+      currency={currency}
+      setIsRenameModalOpened={setIsRenameModalOpened}
+      setIsDeleteModalOpened={setIsDeleteModalOpened}
+    />
+  )
+
+  const content = (
+    <TagDialogContent
+      tag={tag}
+      isRenameModalOpened={isRenameModalOpened}
+      setIsRenameModalOpened={setIsRenameModalOpened}
+      isDeleteModalOpened={isDeleteModalOpened}
+      setIsDeleteModalOpened={setIsDeleteModalOpened}
+    />
+  )
+
+  if (isMobile) {
+    return (
+      <>
+        <Dialog
+          open
+          size="large"
+          disableTitleAutoPadding
+          disableGutters
+          onBack={handleDialogBack}
+          title={title}
+          content={content}
+        />
+      </>
+    )
+  }
+
+  return (
+    <>
+      {title}
+      {content}
+    </>
+  )
+}
+
+TagDialog.propTypes = {
+  tag: PropTypes.object.required
+}
+
+export default TagDialog

--- a/src/ducks/tags/TagDialogContent.jsx
+++ b/src/ducks/tags/TagDialogContent.jsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import { isMobileApp } from 'cozy-device-helper'
+import { buildTransactionsWithTagsQueryByIds } from 'doctypes'
+import { hasQueryBeenLoaded, isQueryLoading, useQueryAll } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+
+import Loading from 'components/Loading'
+import Padded from 'components/Padded'
+import TagDeleteTagModal from 'components/Tag/TagDeleteTagModal'
+import TagRenameTagModal from 'components/Tag/TagRenameTagModal'
+import { TransactionList } from 'ducks/transactions/Transactions'
+import { DESKTOP_SCROLLING_ELEMENT_CLASSNAME } from 'ducks/transactions/scroll/getScrollingElement'
+
+const TagDialogContent = ({
+  tag,
+  isRenameModalOpened,
+  setIsRenameModalOpened,
+  isDeleteModalOpened,
+  setIsDeleteModalOpened
+}) => {
+  const { t } = useI18n()
+  const transactionsQueryByIds = buildTransactionsWithTagsQueryByIds(
+    tag.transactions.data.map(transaction => transaction._id)
+  )
+  const response = useQueryAll(
+    transactionsQueryByIds.definition,
+    transactionsQueryByIds.options
+  )
+  const isFetching = isQueryLoading(response) && !hasQueryBeenLoaded(response)
+
+  let content = null
+
+  if (isFetching) {
+    content = <Loading loadingType="movements" />
+  } else if (response.data.length === 0) {
+    content = (
+      <Padded className="u-pt-0">
+        <Typography variant="body1">
+          {t('Transactions.no-movements')}
+        </Typography>
+      </Padded>
+    )
+  } else {
+    content = (
+      <div className={DESKTOP_SCROLLING_ELEMENT_CLASSNAME}>
+        <TransactionList
+          transactions={response.data}
+          canFetchMore={response.hasMore}
+          filteringOnAccount={false}
+          manualLoadMore={isMobileApp()}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {content}
+      {isRenameModalOpened && (
+        <TagRenameTagModal
+          tag={tag}
+          onClose={() => setIsRenameModalOpened(false)}
+        />
+      )}
+      {isDeleteModalOpened && (
+        <TagDeleteTagModal
+          tag={tag}
+          transactions={response.data}
+          onClose={() => setIsDeleteModalOpened(false)}
+        />
+      )}
+    </>
+  )
+}
+
+TagDialogContent.propTypes = {
+  tag: PropTypes.object.isRequired,
+  isRenameModalOpened: PropTypes.bool.isRequired,
+  setIsRenameModalOpened: PropTypes.func.isRequired,
+  isDeleteModalOpened: PropTypes.bool.isRequired,
+  setIsDeleteModalOpened: PropTypes.func.isRequired
+}
+
+export default TagDialogContent

--- a/src/ducks/tags/TagDialogTitle.jsx
+++ b/src/ducks/tags/TagDialogTitle.jsx
@@ -1,0 +1,111 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import makeStyles from 'cozy-ui/transpiled/react/helpers/makeStyles'
+import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Button from 'cozy-ui/transpiled/react/Buttons'
+import Figure from 'cozy-ui/transpiled/react/Figure'
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import PenIcon from 'cozy-ui/transpiled/react/Icons/Pen'
+import TrashIcon from 'cozy-ui/transpiled/react/Icons/Trash'
+
+import { getCurrencySymbol } from 'utils/currencySymbol'
+import { countTransactions } from 'components/Tag/helpers'
+
+const useStyles = makeStyles({
+  box: {
+    padding: '1.75rem 2rem 1.25rem'
+  },
+  mobileTopBox: {
+    display: 'flex',
+    flexDirection: 'row',
+    margin: '-.5rem 0 -.5rem 2rem',
+    gap: '.5rem'
+  },
+  desktopTopBox: {
+    display: 'flex',
+    flexDirection: 'row',
+    margin: '-.5rem 0',
+    gap: '.5rem'
+  },
+  subBox: {
+    flex: '1'
+  },
+  bottomBox: {
+    display: 'flex',
+    margin: '1.25rem 0 .25rem 0',
+    gap: '.5rem'
+  },
+  mobileButton: {
+    flex: '1'
+  },
+  desktopButton: {
+    flex: '0 auto'
+  },
+  typography: {
+    placeSelf: 'center'
+  }
+})
+
+const TagDialogTitle = ({
+  tag,
+  amount,
+  currency,
+  setIsRenameModalOpened,
+  setIsDeleteModalOpened
+}) => {
+  const { isMobile } = useBreakpoints()
+  const styles = useStyles()
+  const { t } = useI18n()
+  return (
+    <div className={isMobile ? null : styles.box}>
+      <div className={isMobile ? styles.mobileTopBox : styles.desktopTopBox}>
+        <div className={styles.subBox}>
+          <Typography variant="h4">{tag.label}</Typography>
+          <Typography variant="caption">
+            {t('Tag.transactions', {
+              smart_count: countTransactions(tag)
+            })}
+          </Typography>
+        </div>
+        <Typography variant="h6" className={styles.typography}>
+          <Figure
+            total={amount}
+            symbol={getCurrencySymbol(currency)}
+            coloredPositive
+            signed
+          />
+        </Typography>
+      </div>
+      <div className={styles.bottomBox}>
+        <Button
+          className={isMobile ? styles.mobileButton : styles.desktopButton}
+          variant="secondary"
+          startIcon={<Icon icon={PenIcon} />}
+          label={t('Tag.renameModal.title')}
+          onClick={() => setIsRenameModalOpened(true)}
+        />
+        <Button
+          className={isMobile ? styles.mobileButton : styles.desktopButton}
+          color="error"
+          variant="secondary"
+          startIcon={<Icon icon={TrashIcon} />}
+          label={t('Tag.deleteModal.title')}
+          onClick={() => setIsDeleteModalOpened(true)}
+        />
+      </div>
+    </div>
+  )
+}
+
+TagDialogTitle.propTypes = {
+  tag: PropTypes.object.isRequired,
+  amount: PropTypes.number.isRequired,
+  currency: PropTypes.string.isRequired,
+  setIsRenameModalOpened: PropTypes.func.isRequired,
+  setIsDeleteModalOpened: PropTypes.func.isRequired
+}
+
+export default TagDialogTitle

--- a/src/ducks/tags/TagPage.jsx
+++ b/src/ducks/tags/TagPage.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+
+import { buildTagsQueryWithTransactionsByIds } from 'doctypes'
+import { useQueryAll, isQueryLoading } from 'cozy-client'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
+import Spinner from 'cozy-ui/transpiled/react/Spinner'
+
+import { useLocation } from 'components/RouterContext'
+import TagDialog from 'ducks/tags/TagDialog'
+
+const TagPage = () => {
+  const { pathname } = useLocation()
+  const tagId = pathname.split('/').pop()
+  const { t } = useI18n()
+
+  const tagsQueryByIds = buildTagsQueryWithTransactionsByIds([tagId])
+  const response = useQueryAll(
+    tagsQueryByIds.definition,
+    tagsQueryByIds.options
+  )
+  const hasFailed = response.fetchStatus === 'failed'
+
+  if (hasFailed) {
+    return (
+      <>
+        <p>{t('Loading.error')}</p>
+        <p>{response.lastError?.message}</p>
+      </>
+    )
+  }
+
+  const isLoading = isQueryLoading(response) || response.hasMore
+
+  if (isLoading) {
+    return (
+      <Spinner
+        size="xxlarge"
+        className="u-flex u-flex-justify-center u-mt-2 u-h-5"
+      />
+    )
+  }
+
+  if (response.data.length === 0) {
+    return null
+  }
+
+  return <TagDialog tag={response.data[0]} />
+}
+
+export default TagPage

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -329,11 +329,16 @@ export const getTransactionTagsIds = transaction =>
 export const hasAtLeastFiveTags = transaction =>
   getTransactionTags(transaction)?.length >= 5
 
-export const addTag = (transaction, tag) => transaction.tags?.add(tag)
+export const addTag = async (transaction, tag) =>
+  await transaction.tags?.add(tag)
 
-export const removeTag = (transaction, tag) => transaction.tags?.remove(tag)
+export const removeTag = async (transaction, tag) =>
+  await transaction.tags?.remove(tag)
 
 export const hasTag = (transaction, tag) =>
   getTransactionTags(transaction)?.some(
     transactionTag => transactionTag._id === tag._id
   )
+
+export const removeTransaction = async (tag, transaction) =>
+  await tag.transactions?.remove(transaction)

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -959,6 +959,14 @@
     "sortCountAsc": "Least used first",
     "sortCountDesc": "Most used first",
     "sortDateAsc": "Least common first",
-    "sortDateDesc": "Most common first"
+    "sortDateDesc": "Most common first",
+    "renameModal": {
+      "title": "Rename",
+      "label": "Name of the tag",
+      "actions": {
+        "cancel": "Annuler",
+        "submit": "Rename"
+      }
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -967,6 +967,14 @@
         "cancel": "Annuler",
         "submit": "Rename"
       }
+    },
+    "deleteModal": {
+      "title": "Delete",
+      "content": "Deleting this tag will prevent it to be applied on your transactions and it will be removed from %{smart_count} transaction that has it. |||| Deleting this tag will prevent it to be applied on your transactions and it will be removed from %{smart_count} transactions that have it",
+      "actions": {
+        "cancel": "Cancel",
+        "submit": "Delete"
+      }
     }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -969,5 +969,14 @@
         "cancel": "Annuler",
         "submit": "Renommer"
       }
+    },
+    "deleteModal": {
+      "title": "Supprimer",
+      "content": "En supprimant ce label, il ne sera plus applicable à vos opérations et il sera effacé de %{smart_count} opération le portant. |||| En supprimant ce label, il ne sera plus applicable à vos opérations et il sera effacé des %{smart_count} opérations le portant.",
+      "actions": {
+        "cancel": "Annuler",
+        "submit": "Supprimer"
+      }
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -961,6 +961,13 @@
     "sortCountAsc": "Les moins utilisés en premier",
     "sortCountDesc": "Les plus utilisés en premier",
     "sortDateAsc": "Les moins fréquents en premier",
-    "sortDateDesc": "Les plus fréquents en premier"
+    "sortDateDesc": "Les plus fréquents en premier",
+    "renameModal": {
+      "title": "Renommer",
+      "label": "Nom du label",
+      "actions": {
+        "cancel": "Annuler",
+        "submit": "Renommer"
+      }
   }
 }


### PR DESCRIPTION
This PR adds a new route leading to page that:

- list all the transactions linked to a given tag
- allow to rename and delete that tag

Clicking on a tag list item in the settings or on a tag chip on a transaction leads to this page.