### PR TITLE
chore: Run recurrence service only if flag is set

### DIFF
--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -1,6 +1,20 @@
-import { runService } from './service'
+import flag from 'cozy-flags'
+
+import { logger } from 'ducks/konnectorAlerts'
 import runRecurrenceService from 'ducks/recurrence/service'
+import { runService } from './service'
 
 runService(async ({ client }) => {
+  client.registerPlugin(flag.plugin)
+  await client.plugins.flags.refresh()
+
+  if (!flag('banks.services.recurrence.enabled')) {
+    logger(
+      'info',
+      'Bailing out of recurrence service since flag "banks.services.recurrence.enabled" is not set'
+    )
+    return
+  }
+
   await runRecurrenceService({ client })
 })


### PR DESCRIPTION
Although the recurrence service should be fixed and thus not enter an
infinite calls loop, we have tested it yet.
We put the service call behind the `banks.services.recurrence.enabled`
flag so we can release Banks with the included fix not running.