### PR TITLE
fix: Mango request optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # 1.46.0
 
+## ✨ Features
+* Optimization of the Mango query to get first / last date for an account 
 # 1.45.0
 
 ## ✨ Features

--- a/src/ducks/transactions/queries.js
+++ b/src/ducks/transactions/queries.js
@@ -100,16 +100,25 @@ export const makeFilteredTransactionsConn = options => {
  * @return {[QueryDefinition, QueryDefinition]} - Earliest and latest queries
  */
 export const makeEarliestLatestQueries = baseQuery => {
+  const indexedFields = Object.keys(baseQuery.selector)
+  indexedFields.push('date')
+
+  const sortByDesc = []
+  const sortByAsc = []
+  indexedFields.map(field => {
+    sortByDesc.push({ [field]: 'desc' })
+    sortByAsc.push({ [field]: 'asc' })
+  })
   const latestQuery = Q('io.cozy.bank.operations')
     .limitBy(1)
     .where({ ...baseQuery.selector, date: { $gt: null } }) // must reset the date
-    .indexFields(['date'])
-    .sortBy([{ date: 'desc' }])
+    .indexFields(indexedFields)
+    .sortBy(sortByDesc)
   const earliestQuery = Q('io.cozy.bank.operations')
     .limitBy(1)
     .where({ ...baseQuery.selector, date: { $gt: null } }) // must reset the date
-    .indexFields(['date'])
-    .sortBy([{ date: 'asc' }])
+    .indexFields(indexedFields)
+    .sortBy(sortByAsc)
   return [earliestQuery, latestQuery]
 }
 

--- a/src/ducks/transactions/queries.spec.js
+++ b/src/ducks/transactions/queries.spec.js
@@ -132,8 +132,8 @@ describe('makeEarliestLatestQueries', () => {
           account: 'comptelou1',
           date: { $gt: null }
         },
-        indexedFields: ['date'],
-        sort: [{ date: 'asc' }],
+        indexedFields: ['account', 'date'],
+        sort: [{ account: 'asc' }, { date: 'asc' }],
         limit: 1
       }),
       expect.objectContaining({
@@ -141,8 +141,8 @@ describe('makeEarliestLatestQueries', () => {
           account: 'comptelou1',
           date: { $gt: null }
         },
-        indexedFields: ['date'],
-        sort: [{ date: 'desc' }],
+        indexedFields: ['account', 'date'],
+        sort: [{ account: 'desc' }, { date: 'desc' }],
         limit: 1
       })
     ])
@@ -159,8 +159,8 @@ describe('makeEarliestLatestQueries', () => {
           account: { $in: ['comptelou1', 'compteisa2'] },
           date: { $gt: null }
         },
-        indexedFields: ['date'],
-        sort: [{ date: 'asc' }],
+        indexedFields: ['account', 'date'],
+        sort: [{ account: 'asc' }, { date: 'asc' }],
         limit: 1
       }),
       expect.objectContaining({
@@ -168,8 +168,8 @@ describe('makeEarliestLatestQueries', () => {
           account: { $in: ['comptelou1', 'compteisa2'] },
           date: { $gt: null }
         },
-        indexedFields: ['date'],
-        sort: [{ date: 'desc' }],
+        indexedFields: ['account', 'date'],
+        sort: [{ account: 'desc' }, { date: 'desc' }],
         limit: 1
       })
     ])


### PR DESCRIPTION
Since the "baseQuery" can have a selector, we need to add this
selector to the indexField in order to have a performant index.

To be able to sort correctly, we need to add the selector to the
sort. So here it is.

