### PR TITLE
Fix(trigger-konnector): prevent multiple requests + synchronize error message on Harvest Modal

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux'
 import { WebviewIntentProvider } from 'cozy-intent'
 import I18n from 'cozy-ui/transpiled/react/I18n'
 import MuiCozyTheme from 'cozy-ui/transpiled/react/MuiCozyTheme'
-import { CozyProvider } from 'cozy-client'
+import { CozyProvider, RealTimeQueries } from 'cozy-client'
 import { BreakpointsProvider } from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
 import {
   StylesProvider,
@@ -22,6 +22,7 @@ import SelectionProvider from 'ducks/context/SelectionContext'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { initTranslation } from 'cozy-ui/transpiled/react/I18n'
 import cozyBar from 'utils/cozyBar'
+import { TRIGGER_DOCTYPE } from 'doctypes'
 
 const jobsProviderOptions = t => ({
   onSuccess: () => Alerter.success(t('JobsContext.alerter-success')),
@@ -77,6 +78,7 @@ const AppContainer = ({ store, lang, history, client }) => {
                     <BanksProvider client={client}>
                       <SelectionProvider>
                         <MuiCozyTheme>
+                          <RealTimeQueries doctype={TRIGGER_DOCTYPE}></RealTimeQueries>
                           <Router history={history} routes={AppRoute()} />
                         </MuiCozyTheme>
                       </SelectionProvider>

--- a/src/doctypes.js
+++ b/src/doctypes.js
@@ -277,7 +277,8 @@ export const cronKonnectorTriggersConn = {
       worker: 'konnector',
       type: '@cron'
     }),
-  as: 'triggers'
+  as: 'triggers',
+  fetchPolicy: older30s
 }
 
 export const transactionsConn = {


### PR DESCRIPTION
Read each commit description:

## Multiple Requests

Previously:
![Capture d’écran 2022-08-26 à 11 58 21](https://user-images.githubusercontent.com/8363334/186924162-358cbc82-b2bf-45c2-89d0-f19d2e736f4e.png)

Now:
Only one fetch for this call

## Error message on Harvest modal reconnection

![2022-08-26 16 07 19](https://user-images.githubusercontent.com/8363334/186924092-2782a6ad-4fb9-4e51-860d-be0cf3d576d3.gif)

