### PR TITLE
fix: Search Input Size

### DIFF
--- a/src/components/BarSearchInput/index.jsx
+++ b/src/components/BarSearchInput/index.jsx
@@ -37,6 +37,7 @@ const BarSearchInput = ({
         </IconButton>
       </BarSearchIcon>
       <Input
+        fullwidth
         ref={inputRef}
         type="text"
         onChange={onChange}


### PR DESCRIPTION
Since a894b8c913d083664327684056c716c50e903b37,
the size of the input was not the good one.

Let's use the fullwidth props to fix the issue.

(no changelog update since the refacto was not added) 