### PR TITLE
fix: Add realtime on accounts in settings screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 * Harvest 9.25.0:
   * Remove an BI webview reconnection step
   * Remove an unused request to BI api to be faster
+* Display the resulting account in the Settings screen after an account creation (with realtime)
 
 
 

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -7,14 +7,14 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
-import { hasQueryBeenLoaded, isQueryLoading, useQuery } from 'cozy-client'
+import { hasQueryBeenLoaded, isQueryLoading, useQuery, RealTimeQueries } from 'cozy-client'
 
 import Loading from 'components/Loading'
 
 import AddAccountLink from 'ducks/settings/AddAccountLink'
 import { useTrackPage } from 'ducks/tracking/browser'
 
-import { accountsConn } from 'doctypes'
+import { accountsConn, ACCOUNT_DOCTYPE } from 'doctypes'
 import { useBanksContext } from 'ducks/context/BanksContext'
 import AccountsListSettings from 'ducks/settings/AccountsListSettings'
 
@@ -53,6 +53,7 @@ const AccountsSettings = () => {
       ) : (
         <p>{t('Accounts.no-accounts')}</p>
       )}
+      <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
       <AddAccountLink>
         <Button color="primary">
           <Icon icon={PlusIcon} className="u-mr-half" />{' '}

--- a/src/ducks/settings/AccountsSettings.spec.jsx
+++ b/src/ducks/settings/AccountsSettings.spec.jsx
@@ -161,6 +161,14 @@ describe('AccountsSettings', () => {
       getRedirectionURL: () => ''
     }
 
+    client.plugins = {
+      realtime: {
+        subscribe: jest.fn(),
+        unsubscribe: jest.fn()
+      }
+    }
+    client.dispatch = jest.fn()
+
     const root = render(
       <AppLike client={client}>
         <AccountsSettings />


### PR DESCRIPTION
This allows to show the resulting account in settings screen after
account creation