### PR TITLE
fix: Recipe 1.45.0 beta.6

### DIFF
--- a/src/components/Tag/TagAddNewTagModal.jsx
+++ b/src/components/Tag/TagAddNewTagModal.jsx
@@ -16,7 +16,7 @@ const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
 
   const handleChange = ev => {
-    setLabel(ev.target.value)
+    setLabel(ev.target.value.trim())
   }
 
   const handleClick = async () => {


### PR DESCRIPTION
Problème : *Il est possible de créer un label vide*

L'Input étant un champ "non controlé", `trim` les la saisie utilisateur suffit à solutionner le problème