### PR TITLE
fix: Duplicate CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## ✨ Features
 * Optimization of the Mango query to get first / last date for an account 
+
+## 🐛 Bug Fixes
+* Revert cozy-script to deduplicate CSS files
+  
 # 1.45.0
 
 ## ✨ Features

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "cozy-notifications": "0.12.0",
     "cozy-pouch-link": "^29.1.1",
     "cozy-realtime": "3.11.0",
-    "cozy-scripts": "^6.3.1",
+    "cozy-scripts": "6.3.0",
     "cozy-sharing": "3.12.2",
     "cozy-stack-client": "^29.1.0",
     "cozy-ui": "^70.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,10 +5530,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.1.tgz#1a711a43a4fef67224039f623640731dc7ef5ec6"
-  integrity sha512-RNJVGmHzZfNy5i0CFR+UKIPySiTLffkVPVrxPnc0i7RiQtusiNetwhdLmMCT6/JSJ1ZVwIL+f09yWGziBxyTlQ==
+cozy-scripts@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.0.tgz#7365f1af997ec18a907df0ce7f9c51f5c64e332e"
+  integrity sha512-ChHOGJS9XKRSw/t1deTfPbNAYk4GkJBgDS618z0n3MNcvDy8430EUnhRt10R6+FXLRSu3js8paMDd9UBT6ZluQ==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"


### PR DESCRIPTION
Since https://github.com/cozy/create-cozy-app/commit/fa07a257c90e4b359097b56761d929755b4b5f17
we duplicate the generated CSS. It's bad since we load twice the
same CSS, so in fact we load at least 4 CSS files for Banks.

These CSS are pretty heavy, so let's revert to only get the ones
we really need without duplication.

We'll fix the issue in cozy-scripts later.