### PR TITLE
fix: Remove 404 call to manifest.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## ✨ Features
 * Optimization of the Mango query to get first / last date for an account 
+* No more 404 call to manifest.json
 
 ## 🐛 Bug Fixes
 * Revert cozy-script to deduplicate CSS files

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -7,7 +7,6 @@
   {{.ThemeCSS}}
   <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
   <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-  <link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
   <link rel="mask-icon" href="/public/safari-pinned-tab.svg" color="#16B52D">
   <% } %>
   <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
There is no manifest.json at the moment,
so let's remove the call.

We should certainly add it one day.