### PR TITLE
fix: The label entry must be limited directly

### DIFF
--- a/src/components/Tag/TagAddNewTagModal.jsx
+++ b/src/components/Tag/TagAddNewTagModal.jsx
@@ -9,6 +9,8 @@ import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import { TAGS_DOCTYPE } from 'doctypes'
 
+const labelMaxLength = 30
+
 const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
   const client = useClient()
   const { t } = useI18n()
@@ -16,7 +18,10 @@ const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
 
   const handleChange = ev => {
-    setLabel(ev.target.value.trim())
+    const currentValue = ev.target.value
+    if (currentValue.match(/^\S.*/)) {
+      setLabel(currentValue.substring(0, labelMaxLength))
+    } else setLabel('')
   }
 
   const handleClick = async () => {
@@ -24,7 +29,7 @@ const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
 
     const { data: tag } = await client.save({
       _type: TAGS_DOCTYPE,
-      label
+      label: label.trim()
     })
 
     if (onClick) onClick(tag)
@@ -39,11 +44,12 @@ const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
       content={
         <TextField
           fullWidth
+          value={label}
           margin="normal"
           {...(withLabel && { label: t('Tag.tag-name') })}
           variant="outlined"
           inputProps={{
-            maxLength: 30,
+            maxLength: labelMaxLength,
             'data-testid': 'TagAddNewTagModal-TextField'
           }}
           autoFocus

--- a/src/components/Tag/TagAddNewTagModal.spec.jsx
+++ b/src/components/Tag/TagAddNewTagModal.spec.jsx
@@ -31,8 +31,25 @@ describe('TagAddNewTagModal', () => {
     const submitButton = getByTestId('TagAddNewTagModal-Button-submit')
 
     fireEvent.change(newTagInput, { target: { value: '   ' } })
-    fireEvent.click(submitButton)
+    expect(submitButton).toHaveProperty('disabled', true)
+    expect(newTagInput).toHaveProperty('value', '')
 
+    fireEvent.click(submitButton)
+    expect(mockSave).toBeCalledTimes(0)
+  })
+
+  it('should not set value if start with a space', () => {
+    const mockSave = jest.fn()
+    const { getByTestId } = setup({ mockSave })
+
+    const newTagInput = getByTestId('TagAddNewTagModal-TextField')
+    const submitButton = getByTestId('TagAddNewTagModal-Button-submit')
+
+    fireEvent.change(newTagInput, { target: { value: ' abc' } })
+    expect(submitButton).toHaveProperty('disabled', true)
+    expect(newTagInput).toHaveProperty('value', '')
+
+    fireEvent.click(submitButton)
     expect(mockSave).toBeCalledTimes(0)
   })
 
@@ -44,21 +61,24 @@ describe('TagAddNewTagModal', () => {
     const submitButton = getByTestId('TagAddNewTagModal-Button-submit')
 
     fireEvent.change(newTagInput, { target: { value: '' } })
-    fireEvent.click(submitButton)
+    expect(submitButton).toHaveProperty('disabled', true)
+    expect(newTagInput).toHaveProperty('value', '')
 
+    fireEvent.click(submitButton)
     expect(mockSave).toBeCalledTimes(0)
   })
 
-  it('should trim spaces before saving them', () => {
+  it('should remove spaces after label before saving them', () => {
     const mockSave = jest.fn()
     const { getByTestId } = setup({ mockSave })
 
     const newTagInput = getByTestId('TagAddNewTagModal-TextField')
     const submitButton = getByTestId('TagAddNewTagModal-Button-submit')
 
-    fireEvent.change(newTagInput, { target: { value: '    text value    ' } })
-    fireEvent.click(submitButton)
+    fireEvent.change(newTagInput, { target: { value: 'text value    ' } })
+    expect(newTagInput).toHaveProperty('value', 'text value    ')
 
+    fireEvent.click(submitButton)
     expect(mockSave).toBeCalledWith({
       _type: 'io.cozy.tags',
       label: 'text value'


### PR DESCRIPTION
~~The `maxLength` property is not supported on Android.
This problem is probably caused by the predictive text feature.~~

It's better to make the field controlled
and adapt the previous fix on spaces (0b7cfc9)