### PR TITLE
feat: Add wait jobs

### DIFF
--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -255,9 +255,9 @@ class Balance extends PureComponent {
       checkedAccounts.length === accounts.length
         ? undefined
         : {
-          nbCheckedAccounts: checkedAccounts.length,
-          nbAccounts: accounts.length
-        }
+            nbCheckedAccounts: checkedAccounts.length,
+            nbAccounts: accounts.length
+          }
 
     return (
       <Fragment>
@@ -304,8 +304,9 @@ const addTransactions = Component => {
     const transactions = useFullyLoadedQuery(conn.query, conn)
     return <Component {...props} transactions={transactions} />
   }
-  Wrapped.displayName = `withTransactions(${Component.displayName || Component.name
-    })`
+  Wrapped.displayName = `withTransactions(${
+    Component.displayName || Component.name
+  })`
   return Wrapped
 }
 

--- a/src/ducks/balance/Balance.jsx
+++ b/src/ducks/balance/Balance.jsx
@@ -226,6 +226,7 @@ class Balance extends PureComponent {
   }
 
   render() {
+    const { hasJobsInProgress } = this.props
     if (isLoading(this.props)) {
       return (
         <Fragment>
@@ -241,7 +242,7 @@ class Balance extends PureComponent {
     const hasNoAccount = accounts.filter(a => !isVirtualAccount(a)).length === 0
 
     if (
-      hasNoAccount ||
+      (hasNoAccount && !hasJobsInProgress) ||
       flag('balance.no-account') ||
       flag('banks.balance.account-loading')
     ) {

--- a/src/ducks/balance/BalanceWithBanksJobs.jsx
+++ b/src/ducks/balance/BalanceWithBanksJobs.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { useBanksContext } from 'ducks/context/BanksContext'
+import Balance from 'ducks/balance/Balance'
+
+const BalanceWithBanksJobs = () => {
+  const { hasJobsInProgress } = useBanksContext()
+  return <Balance hasJobsInProgress={hasJobsInProgress} />
+}
+
+export default BalanceWithBanksJobs

--- a/src/ducks/balance/index.js
+++ b/src/ducks/balance/index.js
@@ -1,4 +1,4 @@
-import Balance from 'ducks/balance/Balance.jsx'
+import Balance from 'ducks/balance/BalanceWithBanksJobs'
 
 // components
 export { Balance }

--- a/src/ducks/context/BanksContext.jsx
+++ b/src/ducks/context/BanksContext.jsx
@@ -46,9 +46,14 @@ const BanksProvider = ({ children, client }) => {
           const slug = jobsInProgress.konnector
           return `${KONNECTOR_DOCTYPE}/${slug}`
         })
-        const resp = await client.query(Q(KONNECTOR_DOCTYPE).getByIds(ids), {
-          as: 'io.cozy.konnectors/in-progress',
-          fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+        // use client.fetchQueryAndGetFromState to avoid a null response on second call. see
+        // https://github.com/cozy/cozy-client/issues/931#issuecomment-1065010796
+        const resp = await client.fetchQueryAndGetFromState({
+          definition: Q(KONNECTOR_DOCTYPE).getByIds(ids),
+          options: {
+            as: 'io.cozy.konnectors/in-progress',
+            fetchPolicy: CozyClient.fetchPolicies.olderThan(30 * 1000)
+          }
         })
         const newJobInProgress = resp.data.map(konnector => {
           const slug = konnector.slug

--- a/src/ducks/context/BanksContext.spec.jsx
+++ b/src/ducks/context/BanksContext.spec.jsx
@@ -31,7 +31,7 @@ describe('Banks Context', () => {
       where: jest.fn().mockImplementation(() => ({ indexFields: jest.fn() })),
       getByIds: jest.fn()
     }))
-    client.query.mockResolvedValue({
+    client.fetchQueryAndGetFromState = jest.fn().mockResolvedValue({
       data: [
         { slug: 'caissedepargne1', name: 'Caisse Epargne' },
         { slug: 'boursorama83', name: 'Boursorama' }

--- a/src/ducks/context/BanksContext.spec.jsx
+++ b/src/ducks/context/BanksContext.spec.jsx
@@ -41,21 +41,23 @@ describe('Banks Context', () => {
       { slug: 'caissedepargne1' },
       { slug: 'boursorama83' }
     ])
-    client.plugins = {}
-    client.plugins.realtime = {
-      subscribe: (eventName, doctype, handleRealtime) => {
-        // There are 3 subscribers (created, updated, deleted)
-        // To simulate handle realtime we check if there are
-        // at least the first event and we call handleRealtime callbacks
-        if (eventName === 'created') {
-          for (const konn of konnectors) {
-            handleRealtime(
-              createKonnectorMsg(RUNNING, konn.konnector, konn.account)
-            )
+
+    client.plugins = {
+      realtime: {
+        subscribe: (eventName, doctype, handleRealtime) => {
+          // There are 4 subscribers (created, updated, deleted, notified)
+          // To simulate handle realtime we check if there are
+          // at least the first event and we call handleRealtime callbacks
+          if (eventName === 'created') {
+            for (const konn of konnectors) {
+              handleRealtime(
+                createKonnectorMsg(RUNNING, konn.konnector, konn.account)
+              )
+            }
           }
-        }
-      },
-      unsubscribe: () => {}
+        },
+        unsubscribe: () => {}
+      }
     }
 
     const children = (

--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -82,9 +82,9 @@ const AccountsListSettings = ({
   const [editionModalOptions, setEditionModalOptions] = useState(null)
 
   const secondary = useCallback(
-    (connection, isLoading) => {
-      if (connection) {
-        if (isLoading) {
+    (connection, isAnyJobLoading, isCurrentJobInProgress) => {
+      if (connection || isCurrentJobInProgress) {
+        if (isAnyJobLoading) {
           return t('Settings.accounts-tab.import-in-progress')
         }
         const isInMaintenance = slugInMaintenance.includes(
@@ -113,17 +113,22 @@ const AccountsListSettings = ({
       {/* Bank accounts still connected to io.cozy.accounts */}
       <List>
         {connectionGroups.map(({ accounts, connection, connectionId }) => {
-          const isLoading =
+          const isAnyJobLoading =
             jobsInProgress.some(j => j.account === connectionId) ||
             accounts[0].inProgress
+          const isCurrentJobInProgress = accounts?.[0]?.inProgress
 
           return (
             <AccountListItem
               key={accounts[0]._id}
               account={accounts[0]}
-              secondary={secondary(connection, isLoading)}
+              secondary={secondary(
+                connection,
+                isAnyJobLoading,
+                isCurrentJobInProgress
+              )}
               onClick={() => {
-                if (accounts?.[0]?.inProgress === true) {
+                if (isCurrentJobInProgress === true) {
                   return
                 }
                 return setEditionModalOptions({
@@ -131,7 +136,7 @@ const AccountsListSettings = ({
                   connectionId: connectionId
                 })
               }}
-              isLoading={isLoading}
+              isAnyJobLoading={isAnyJobLoading}
               hasError={hasError(connection)}
             />
           )

--- a/src/ducks/settings/WaitJobQueue.js
+++ b/src/ducks/settings/WaitJobQueue.js
@@ -1,0 +1,97 @@
+const DEFAULT_DURATION = 1000 * 60 * 5 // 5 minutes
+const INTERVAL = 10 * 1000 // 10 seconds
+
+/**
+ * Implement a wait queue of virtual jobs which have sense when harvest told banks a new banking job will come.
+ */
+export class WaitJobQueue {
+  /**
+   * @constructor
+   * @param {Object} options
+   * @param {Function} options.setter - setter function called when the internal queue has changed
+   * @param {Number} options.duration - time to wait for the real job to come (in ms). default: 5 minutes
+   */
+  constructor({ setter, duration = DEFAULT_DURATION }) {
+    this.setter = setter
+    this.queue = []
+    this.duration = duration
+    this.setIntervalId = null
+  }
+
+  /**
+   * Check if timeout is exceeded for each job and removes them when needed
+   */
+  checkWaitJobQueue() {
+    const currentTime = Date.now()
+    for (const job of this.queue) {
+      if (currentTime > job.timeout) {
+        this.removeWaitJob({ slug: job.konnector })
+      }
+    }
+  }
+
+  /**
+   * Add a job to the queue
+   *
+   * @param {Object} options
+   * @param {String} options.slug - slug of the job
+   */
+  addWaitJob({ slug }) {
+    const queue = [...this.queue]
+    const jobWithSameSlugIndex = queue.findIndex(job => job.konnector === slug)
+    const timeout = Date.now() + DEFAULT_DURATION
+    if (jobWithSameSlugIndex !== -1) {
+      queue[jobWithSameSlugIndex].timeout = timeout
+    } else {
+      queue.push({ konnector: slug, timeout, wait: true })
+      this.setter(queue)
+    }
+    this.queue = queue
+
+    if (this.setIntervalId === null) {
+      this.initInterval()
+    }
+  }
+
+  /**
+   * Remove a job from the queue, identified by its slug.
+   * This will also clear interval if there no more wait job in the queue
+   *
+   * @param {Object} options
+   * @param {String} options.slug - slug of the job
+   */
+  removeWaitJob({ slug }) {
+    const queue = [...this.queue]
+    const jobWithSameSlugIndex = queue.findIndex(job => job.konnector === slug)
+    if (jobWithSameSlugIndex !== -1) {
+      queue.splice(jobWithSameSlugIndex, 1)
+      this.queue = queue
+    }
+
+    this.setter(this.queue)
+
+    if (this.queue.length === 0) {
+      this.clearInterval()
+    }
+  }
+
+  /**
+   * Set the interval of INTERVAL ms to check the queue
+   */
+  initInterval() {
+    this.setIntervalId = setInterval(
+      this.checkWaitJobQueue.bind(this),
+      INTERVAL
+    )
+  }
+
+  /**
+   * Clear the interval
+   */
+  clearInterval() {
+    if (this.setIntervalId !== null) {
+      clearInterval(this.setIntervalId)
+      this.setIntervalId = null
+    }
+  }
+}


### PR DESCRIPTION
Wait jobs allow harvest to tell to banks it is waiting for a job to be
triggered by a BI webhook.

This wait job will displayed like a real job in progress but will be
replaced and removed by the real job with the same slug or after 5
minutes.

Harvest can trigger this wait jobs by sending a realtime notify on
io.cozy.jobs with the slug of the expected job.

Since these wait jobs are triggered before any account or trigger
creation, they don't have any associated account and will be replaced by
any job with the same expected slug