### PR TITLE
Add event and page loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Optimization of the Mango query to get first / last date for an account
 * No more 404 call to manifest.json
+* Add new event and page loggers for tags
 
 ## 🐛 Bug Fixes
 * Revert cozy-script to deduplicate CSS files

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -8,6 +8,8 @@ import Icon from 'cozy-ui/transpiled/react/Icon'
 import { makeStyles } from 'cozy-ui/transpiled/react/styles'
 import MagnifierIcon from 'cozy-ui/transpiled/react/Icons/Magnifier'
 
+import { trackPage } from 'ducks/tracking/browser'
+
 const useStyles = makeStyles(theme => ({
   input: {
     borderRadius: '1.25rem',
@@ -36,6 +38,10 @@ const SearchInput = ({ placeholder, setValue }) => {
     [setValue]
   )
 
+  const handleFocus = () => {
+    trackPage('parametres:labels:recherche-saisie')
+  }
+
   return (
     <>
       <InputGroup
@@ -51,6 +57,7 @@ const SearchInput = ({ placeholder, setValue }) => {
         <Input
           placeholder={placeholder}
           onChange={event => delayedSetValue(event.target.value)}
+          onFocus={handleFocus}
         />
       </InputGroup>
     </>

--- a/src/components/SelectInput.jsx
+++ b/src/components/SelectInput.jsx
@@ -10,6 +10,8 @@ import ActionMenu, {
 import DropdownText from 'cozy-ui/transpiled/react/DropdownText'
 import InputGroup from 'cozy-ui/transpiled/react/InputGroup'
 
+import { trackEvent } from 'ducks/tracking/browser'
+
 const useStyles = makeStyles({
   mobileInput: {
     width: '100%',
@@ -53,12 +55,17 @@ const SelectInput = ({ options, name, value, setValue }) => {
 
   const anchorRef = useRef()
 
+  const handleClick = () => {
+    trackEvent({ name: 'tri' })
+    setIsOpened(true)
+  }
+
   return (
     <InputGroup className={isMobile ? styles.mobileInput : styles.desktopInput}>
       <DropdownText
         className={isMobile ? styles.mobileButton : styles.desktopButton}
         variant="caption"
-        onClick={() => setIsOpened(true)}
+        onClick={handleClick}
         ref={anchorRef}
       >
         {options[value]}

--- a/src/components/Tag/TagAddModalOrBottomSheet.jsx
+++ b/src/components/Tag/TagAddModalOrBottomSheet.jsx
@@ -15,6 +15,7 @@ import {
   getTransactionTagsIds
 } from 'ducks/transactions/helpers'
 import { makeTagsToRemove, makeTagsToAdd } from 'components/Tag/helpers'
+import { trackPage, useTrackPage } from 'ducks/tracking/browser'
 
 const TagAddModalOrBottomSheet = ({ transaction, onClose }) => {
   const { isMobile } = useBreakpoints()
@@ -25,6 +26,8 @@ const TagAddModalOrBottomSheet = ({ transaction, onClose }) => {
     getTransactionTagsIds(transaction)
   )
   const [hasTagsBeenModified, setHasTagsBeenModified] = useState(false)
+
+  useTrackPage('mon_compte:depense:ajout-label-saisie')
 
   const toggleAddNewTagModal = () => setShowAddNewTagModal(prev => !prev)
 
@@ -45,6 +48,7 @@ const TagAddModalOrBottomSheet = ({ transaction, onClose }) => {
   }
 
   const handleConfirm = async () => {
+    trackPage('mon_compte:depense:ajout-label-confirmation')
     if (hasTagsBeenModified) {
       setIsSaving(true)
       const tagsToRemove = makeTagsToRemove({

--- a/src/components/Tag/TagAddNewTagModal.jsx
+++ b/src/components/Tag/TagAddNewTagModal.jsx
@@ -8,14 +8,24 @@ import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import { TAGS_DOCTYPE } from 'doctypes'
+import { trackPage, useTrackPage } from 'ducks/tracking/browser'
+import { useLocation } from 'components/RouterContext'
 
 const labelMaxLength = 30
 
 const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
   const client = useClient()
   const { t } = useI18n()
+  const location = useLocation()
   const [label, setLabel] = useState('')
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
+  const inSettings = location.pathname.startsWith('/settings')
+
+  useTrackPage(
+    inSettings
+      ? 'parametres:labels:creation-label-saisie'
+      : 'mon_compte:depense:creation-label-saisie'
+  )
 
   const handleChange = ev => {
     const currentValue = ev.target.value
@@ -25,6 +35,11 @@ const TagAddNewTagModal = ({ onClick, onClose, withLabel }) => {
   }
 
   const handleClick = async () => {
+    trackPage(
+      inSettings
+        ? 'parametres:labels:creation-label-confirmation'
+        : 'mon_compte:depense:creation-label-confirmation'
+    )
     toggleBusy()
 
     const { data: tag } = await client.save({

--- a/src/components/Tag/TagAddNewTagModal.spec.jsx
+++ b/src/components/Tag/TagAddNewTagModal.spec.jsx
@@ -14,9 +14,17 @@ const setup = ({
   const client = getClient()
   const defautlMockSave = mockSave.mockResolvedValue({ data: [] })
   client.save = defautlMockSave
-
+  const location = {
+    pathname: '/settings'
+  }
+  const router = {
+    getCurrentLocation: () => {
+      return location
+    },
+    location
+  }
   return render(
-    <AppLike client={client}>
+    <AppLike client={client} router={router}>
       <TagAddNewTagModal onClose={onClose} onClick={onClick} />
     </AppLike>
   )

--- a/src/components/Tag/TagChip.jsx
+++ b/src/components/Tag/TagChip.jsx
@@ -8,6 +8,7 @@ import { TAGS_DOCTYPE } from 'doctypes'
 import useDocument from 'components/useDocument'
 import { useHistory } from 'components/RouterContext'
 import { removeTagRelationshipFromTransaction } from 'ducks/transactions/helpers'
+import { trackEvent } from 'ducks/tracking/browser'
 
 const TagChip = ({
   className,
@@ -21,7 +22,10 @@ const TagChip = ({
   const history = useHistory()
 
   const handleDelete = deletable
-    ? () => removeTagRelationshipFromTransaction(transaction, tagFromDoctype)
+    ? () => {
+        trackEvent({ name: 'retrait-label' })
+        removeTagRelationshipFromTransaction(transaction, tagFromDoctype)
+      }
     : undefined
 
   const handleClick = ev => {

--- a/src/components/Tag/TagDeleteTagModal.jsx
+++ b/src/components/Tag/TagDeleteTagModal.jsx
@@ -10,6 +10,7 @@ import { useHistory } from 'components/RouterContext'
 
 import { countTransactions } from 'components/Tag/helpers'
 import { removeTag } from 'ducks/transactions/helpers'
+import { trackPage, useTrackPage } from 'ducks/tracking/browser'
 
 const TagDeleteTagModal = ({ tag, transactions, onClose }) => {
   const client = useClient()
@@ -17,7 +18,10 @@ const TagDeleteTagModal = ({ tag, transactions, onClose }) => {
   const history = useHistory()
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
 
+  useTrackPage('parametres:labels:supprimer-label-popin')
+
   const handleClick = async () => {
+    trackPage('parametres:labels:supprimer-label-confirmation')
     toggleBusy()
     await removeTag(client, tag, transactions)
     history.goBack()

--- a/src/components/Tag/TagRenameTagModal.jsx
+++ b/src/components/Tag/TagRenameTagModal.jsx
@@ -8,13 +8,18 @@ import TextField from 'cozy-ui/transpiled/react/MuiCozyTheme/TextField'
 import { ConfirmDialog } from 'cozy-ui/transpiled/react/CozyDialogs'
 import Button from 'cozy-ui/transpiled/react/Buttons'
 
+import { trackPage, useTrackPage } from 'ducks/tracking/browser'
+
 const TagRenameTagModal = ({ tag, onClose, withLabel }) => {
   const client = useClient()
   const { t } = useI18n()
   const [label, setLabel] = useState(tag.label)
   const [isBusy, toggleBusy] = useReducer(prev => !prev, false)
 
+  useTrackPage('parametres:labels:renommer-label-saisie')
+
   const handleClick = async () => {
+    trackPage('parametres:labels:renommer-label-confirmation')
     toggleBusy()
     await client.save({
       ...tag,

--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
@@ -14,6 +14,7 @@ import { tagsConn } from 'doctypes'
 import IncomeListItem from 'ducks/categories/AdvancedFilterModal/IncomeListItem'
 import style from 'ducks/categories/AdvancedFilterModal/AdvancedFilterModal.styl'
 import TagListItem from 'ducks/categories/CategoriesTags/TagListItem'
+import { trackEvent, trackPage, useTrackPage } from 'ducks/tracking/browser'
 
 const AdvancedFilterModal = ({
   onClose,
@@ -28,11 +29,15 @@ const AdvancedFilterModal = ({
   const { data: tags, ...tagsQueryRest } = useQueryAll(tagsConn.query, tagsConn)
   const isLoading = isQueryLoading(tagsQueryRest) || tagsQueryRest.hasMore
 
+  useTrackPage('analyse:filtres-avances-saisie')
+
   const toogleIncome = () => {
+    trackEvent({ name: 'masquer-revenus' })
     setIsWithIncomeChecked(prev => !prev)
   }
 
   const handleConfirm = () => {
+    trackPage('analyse:filtres-avances-confirmation')
     onConfirm(isWithIncomeChecked)
     setSelectedTags(tagListSelected)
     onClose()

--- a/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
+++ b/src/ducks/categories/CategoriesTags/TagAddModalOrBottomSheet.jsx
@@ -5,6 +5,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import TagAddModal from 'components/Tag/TagAddModal'
 import TagBottomSheet from 'components/Tag/TagBottomSheet'
+import { trackPage, useTrackPage } from 'ducks/tracking/browser'
 
 const isAlreadyChecked = (selectedTagIds, tag) =>
   selectedTagIds.some(tagId => tagId === tag._id)
@@ -21,6 +22,8 @@ const TagAddModalOrBottomSheet = ({
     tagListSelected.map(tagSelected => tagSelected._id)
   )
 
+  useTrackPage('analyse:filtres:labels-saisie')
+
   const handleClick = tag => {
     if (isAlreadyChecked(selectedTagIds, tag)) {
       setSelectedTagIds(prev => prev.filter(id => id !== tag._id))
@@ -30,6 +33,7 @@ const TagAddModalOrBottomSheet = ({
   }
 
   const handleConfirm = () => {
+    trackPage('analyse:filtres:labels-confirmation')
     const selectedTagList = tags.filter(tag =>
       selectedTagIds.some(selectedTagId => selectedTagId === tag._id)
     )

--- a/src/ducks/settings/TagsSettings.jsx
+++ b/src/ducks/settings/TagsSettings.jsx
@@ -6,11 +6,14 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import TagsListSettings from 'ducks/settings/TagsListSettings'
+import { useTrackPage } from 'ducks/tracking/browser'
 
 const TagsSettings = () => {
   const { t } = useI18n()
   const response = useQueryAll(tagsConn.query, tagsConn)
   const hasFailed = response.fetchStatus === 'failed'
+
+  useTrackPage('parametres:labels')
 
   if (hasFailed) {
     return (

--- a/src/ducks/tags/TagPage.jsx
+++ b/src/ducks/tags/TagPage.jsx
@@ -7,11 +7,14 @@ import Spinner from 'cozy-ui/transpiled/react/Spinner'
 
 import { useLocation } from 'components/RouterContext'
 import TagDialog from 'ducks/tags/TagDialog'
+import { useTrackPage } from 'ducks/tracking/browser'
 
 const TagPage = () => {
   const { pathname } = useLocation()
   const tagId = pathname.split('/').pop()
   const { t } = useI18n()
+
+  useTrackPage('parametres:labels:labels-detail-operations')
 
   const tagsQueryByIds = buildTagsQueryWithTransactionsByIds([tagId])
   const response = useQueryAll(


### PR DESCRIPTION
This PR adds logs for some navigation and interaction events related to tags.
This does not include the batch event bindings which will only be part of the override.

The easiest way to test the changes is adding some `console.log()` calls in the `trackerShim` in `tracker.js`.