### PR TITLE
fix: Make in progress item in setting not clickable

### DIFF
--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -123,6 +123,9 @@ const AccountsListSettings = ({
               account={accounts[0]}
               secondary={secondary(connection, isLoading)}
               onClick={() => {
+                if (accounts?.[0]?.inProgress === true) {
+                  return
+                }
                 return setEditionModalOptions({
                   connection: connection,
                   connectionId: connectionId


### PR DESCRIPTION
Or else, this will display a meaningless overlay for such items
