### PR TITLE
fix: Handle account without ".auth.identifier" attribute without error

### DIFF
--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -93,7 +93,7 @@ const AccountsListSettings = ({
         if (isInMaintenance) {
           return t('Settings.accounts-tab.in-maintenance')
         }
-        return connection.auth.identifier
+        return connection?.auth?.identifier
       } else {
         return (
           <>


### PR DESCRIPTION
This case may happen when accounts have been created via a webhook's
payload and the connector has not been run yet to fetch the identifier

In this case, the account identifier is just not displayed



```
### 🐛 Bug Fixes
* Handle account without ".auth.identifier" attribute without error
```
