### PR TITLE
fix: Add missing intentsApi property

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.26.10",
+    "cozy-harvest-lib": "^9.26.13",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,10 +5355,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.26.10:
-  version "9.26.10"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.10.tgz#4fd4427d3d7abf8f2706bf8ddb3e60dfee0733ff"
-  integrity sha512-+8uN7Ht+pthgsXVm4FZ3qzVEonYZcoEUdV69zMK4gZnPSVmOFTY60aCAIlmvuGQvIQkWl9yuQI8yxhbu3c1M9Q==
+cozy-harvest-lib@^9.26.13:
+  version "9.26.13"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.13.tgz#dcede50b1f35c671aea7cef48b49f0d8b68764b1"
+  integrity sha512-zBOVxxYH8cw/Y8FXQvUyEIHpsry+K9cVG9oKlQhWfgGZQSB7PdRgSD3KQc1EY5iLLZl7INyKAJ/GA0gIjXrSNQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
with an upgrade of Harvest

To open InAppBrowser properly when clicking "reconnect" button in error
message

```
### 🐛 Bug Fixes

* Harvest 9.26.13 : Add missing intentsApi property

```
