### PR TITLE
fix: Check if we get relationships or not before maping

### DIFF
--- a/src/ducks/transactions/TransactionModal/DeleteTransactionRow.jsx
+++ b/src/ducks/transactions/TransactionModal/DeleteTransactionRow.jsx
@@ -25,9 +25,10 @@ const DeleteTransactionRow = ({ transaction }) => {
   const [showingDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
-  const transactionTagsIds = getTagsRelationshipByTransaction(transaction).map(
-    t => t._id
-  )
+  const tagsRelationship = getTagsRelationshipByTransaction(transaction)
+  const transactionTagsIds = tagsRelationship
+    ? tagsRelationship.map(t => t._id)
+    : []
   const transactionTagsWithTransactions = useDocuments(
     TAGS_DOCTYPE,
     transactionTagsIds


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Since `tags` are behind a flag, it can appears that we don't have the `tags` relationships at all. Let's be defensive about that case in order to not throw an error. Fix an error when the user can not open a specific transaction 

```
