### PR TITLE
fix: Remove call to getTagsRelationshipByTransaction if tags not activated

### DIFF
--- a/src/ducks/transactions/TransactionModal/DeleteTransactionRow.jsx
+++ b/src/ducks/transactions/TransactionModal/DeleteTransactionRow.jsx
@@ -25,7 +25,9 @@ const DeleteTransactionRow = ({ transaction }) => {
   const [showingDeleteConfirmation, setShowDeleteConfirmation] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
-  const tagsRelationship = getTagsRelationshipByTransaction(transaction)
+  const tagsRelationship = flag('banks.tags.enabled')
+    ? getTagsRelationshipByTransaction(transaction)
+    : []
   const transactionTagsIds = tagsRelationship
     ? tagsRelationship.map(t => t._id)
     : []


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* On the transaction detail, remove call to 
getTagsRelationshipByTransaction if 
tags not activated

```