### PR TITLE
Hide deprecated recurrence bundles behind a button

### DIFF
--- a/src/ducks/future/selectors.js
+++ b/src/ducks/future/selectors.js
@@ -9,6 +9,7 @@ import orderBy from 'lodash/orderBy'
 import { getRecurrences } from 'selectors'
 import { getFilteredAccountIds } from 'ducks/filters'
 import { nextDate, STATUS_FINISHED } from 'ducks/recurrence'
+import { isFinished } from 'ducks/recurrence/api'
 import getClient from 'selectors/getClient'
 import { TRANSACTION_DOCTYPE } from 'doctypes'
 
@@ -24,6 +25,9 @@ const MIN_MEDIAN_FOR_PLANNING = 15
  * Returns whether a recurrence should generate planned transactions
  */
 export const isDeprecatedBundle = recurrence => {
+  if (isFinished(recurrence)) {
+    return true
+  }
   const now = Date.now()
   const latestDate = parse(recurrence.latestDate)
   const deltaToNow = differenceInDays(now, latestDate)

--- a/src/ducks/future/selectors.spec.js
+++ b/src/ducks/future/selectors.spec.js
@@ -1,3 +1,4 @@
+import { STATUS_ONGOING, STATUS_FINISHED } from 'ducks/recurrence/api'
 import { isDeprecatedBundle } from './selectors.js'
 
 const now = Date.now()
@@ -7,16 +8,28 @@ const fiveMonthsAgo = new Date(now)
 fiveMonthsAgo.setMonth(fiveMonthsAgo.getMonth() - 5)
 
 describe('isDeprecatedBundle', () => {
-  it('should consider inactive recurrences as deprecated', () => {
+  it('should consider inactive or finished recurrences as deprecated', () => {
     const recurrences = [
       {
-        latestDate: threeMonthsAgo.toISOString()
+        latestDate: threeMonthsAgo.toISOString(),
+        status: STATUS_ONGOING
       },
       {
-        latestDate: fiveMonthsAgo.toISOString()
+        latestDate: fiveMonthsAgo.toISOString(),
+        status: STATUS_ONGOING
+      },
+      {
+        latestDate: threeMonthsAgo.toISOString(),
+        status: STATUS_FINISHED
+      },
+      {
+        latestDate: fiveMonthsAgo.toISOString(),
+        status: STATUS_FINISHED
       }
     ]
     expect(isDeprecatedBundle(recurrences[0])).toBe(false)
     expect(isDeprecatedBundle(recurrences[1])).toBe(true)
+    expect(isDeprecatedBundle(recurrences[2])).toBe(true)
+    expect(isDeprecatedBundle(recurrences[3])).toBe(true)
   })
 })

--- a/src/ducks/future/selectors.spec.js
+++ b/src/ducks/future/selectors.spec.js
@@ -1,0 +1,22 @@
+import { isDeprecatedBundle } from './selectors.js'
+
+const now = Date.now()
+const threeMonthsAgo = new Date(now)
+threeMonthsAgo.setMonth(threeMonthsAgo.getMonth() - 3)
+const fiveMonthsAgo = new Date(now)
+fiveMonthsAgo.setMonth(fiveMonthsAgo.getMonth() - 5)
+
+describe('isDeprecatedBundle', () => {
+  it('should consider inactive recurrences as deprecated', () => {
+    const recurrences = [
+      {
+        latestDate: threeMonthsAgo.toISOString()
+      },
+      {
+        latestDate: fiveMonthsAgo.toISOString()
+      }
+    ]
+    expect(isDeprecatedBundle(recurrences[0])).toBe(false)
+    expect(isDeprecatedBundle(recurrences[1])).toBe(true)
+  })
+})

--- a/src/ducks/recurrence/Bundles.jsx
+++ b/src/ducks/recurrence/Bundles.jsx
@@ -137,7 +137,7 @@ const BundlesTableHead = () => {
 }
 
 const BundleMobileWrapper = ({ children }) => {
-  return <div className={styles.RecurrencesMobileContent}>{children}</div>
+  return <div className="u-pt-3">{children}</div>
 }
 
 const BundlesTable = ({ children }) => {

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Link } from 'react-router'
 import orderBy from 'lodash/orderBy'
 import groupBy from 'lodash/groupBy'
@@ -12,6 +12,7 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Breadcrumbs from 'cozy-ui/transpiled/react/Breadcrumbs'
 import ListSubheader from 'cozy-ui/transpiled/react/MuiCozyTheme/ListSubheader'
 import { withStyles } from 'cozy-ui/transpiled/react/styles'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 
 import Loading from 'components/Loading'
 import { recurrenceConn } from 'doctypes'
@@ -60,6 +61,8 @@ const DeprecatedNotice = withStyles(theme => ({
 export const RecurrencesPage = ({ emptyIcon, showTitle }) => {
   const history = useHistory()
   const { isMobile } = useBreakpoints()
+  const [areDeprecatedBundleShown, setAreDeprecatedBundleShown] =
+    useState(false)
   const bundleCol = useQuery(recurrenceConn.query, recurrenceConn)
   const { data: rawBundles } = bundleCol
   const { live: liveBundles, deprecated: deprecatedBundles } = useMemo(() => {
@@ -117,15 +120,30 @@ export const RecurrencesPage = ({ emptyIcon, showTitle }) => {
             ))}
           {typeof deprecatedBundles !== 'undefined' &&
             deprecatedBundles.length && (
-            <>
-              <DeprecatedNotice>
-                {t('Recurrence.deprecated-bundles-help')}
-              </DeprecatedNotice>
-              {deprecatedBundles.map(bundle => (
-                <BundleRow key={bundle._id} bundle={bundle} />
-              ))}
-            </>
-          )}
+              <>
+                {!areDeprecatedBundleShown && (
+                  <Button
+                    className="u-mh-1 u-mv-half"
+                    variant="text"
+                    label={t('Recurrence.show-deprecated-bundles', {
+                      number: deprecatedBundles.length
+                    })}
+                    size="small"
+                    onClick={() => setAreDeprecatedBundleShown(true)}
+                  />
+                )}
+                {areDeprecatedBundleShown && (
+                  <>
+                    <DeprecatedNotice>
+                      {t('Recurrence.deprecated-bundles-help')}
+                    </DeprecatedNotice>
+                    {deprecatedBundles.map(bundle => (
+                      <BundleRow key={bundle._id} bundle={bundle} />
+                    ))}
+                  </>
+                )}
+              </>
+            )}
         </BundlesWrapper>
       ) : (
         <Padded>

--- a/src/ducks/recurrence/RecurrencesPage.jsx
+++ b/src/ducks/recurrence/RecurrencesPage.jsx
@@ -115,7 +115,8 @@ export const RecurrencesPage = ({ emptyIcon, showTitle }) => {
             liveBundles.map(bundle => (
               <BundleRow key={bundle._id} bundle={bundle} />
             ))}
-          {typeof deprecatedBundles !== 'undefined' && (
+          {typeof deprecatedBundles !== 'undefined' &&
+            deprecatedBundles.length && (
             <>
               <DeprecatedNotice>
                 {t('Recurrence.deprecated-bundles-help')}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -928,6 +928,7 @@
         "yearly": "every year"
     },
     "freq-info": "every %{frequency} days",
+    "show-deprecated-bundles": "Show inactive recurrences (%{number})",
     "deprecated-bundles-help": "Payments below will not be considered for 30-day balance since their last occurence happened more than  4 months ago."
   },
 

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -930,6 +930,7 @@
       "yearly": "tous les ans"
     },
     "freq-info": "tous les %{frequency} jours",
+    "show-deprecated-bundles": "Voir les récurrences inactives (%{number})",
     "deprecated-bundles-help": "Les paiements ci-dessous ne sont pas comptés dans le solde à venir car leur dernière occurrence date de plus de 4 mois."
   },
 


### PR DESCRIPTION
Instead of always showing every recurrence bundle in the recurrence tab, this hides deprecated (a.k.a. inactive or marked as finished) ones by default.
They can still be revealed by pressing a "Show inactive recurrences" button.

```
### ✨ Features

* Hide deprecated recurrence bundles behind a new "Show inactive recurrences" button
```
