### PR TITLE
fix: Expose isBankTrigger from BanksContext

### DIFF
--- a/src/ducks/context/BanksContext.jsx
+++ b/src/ducks/context/BanksContext.jsx
@@ -31,7 +31,7 @@ const EMPTY_ARRAY = []
 const BanksProvider = ({ children, client }) => {
   const { jobsInProgress = [] } = useJobsContext()
   const [banksJobsInProgress, setBanksJobsInProgress] = useState([])
-  const { isFetchingBankSlugs, isBankKonnector, bankingSlugs } =
+  const { isFetchingBankSlugs, isBankKonnector, bankingSlugs, isBankTrigger } =
     useBankingSlugs()
 
   const onlyBanksInProgress = useMemo(
@@ -76,7 +76,8 @@ const BanksProvider = ({ children, client }) => {
         hasJobsInProgress: banksJobsInProgress.length > 0,
         isFetchingBankSlugs,
         isBankKonnector,
-        bankingSlugs
+        bankingSlugs,
+        isBankTrigger
       }}
     >
       {children}


### PR DESCRIPTION
The previous refactoring forgot to expose isBankTrigger from BanksContext. The result was an error displayed when the user didn't have any account. 


```
### 🐛 Bug Fixes

* Empty Home page, aka with <NoAccount> component displayed is now working
```
