### PR TITLE
Correctly retrieve the setting that hides amounts in notifications

### DIFF
--- a/src/ducks/notifications/services.js
+++ b/src/ducks/notifications/services.js
@@ -107,10 +107,7 @@ export const sendNotificationForClass = async (
   { config, client, data, lang }
 ) => {
   const klassRules = getClassRules(Klass, config)
-  const amountCensoring = getClassRules(
-    { settingKey: 'amountCensoring' },
-    config
-  )
+  const amountCensoring = config.notifications.amountCensoring?.enabled
   const klassOptions = {
     client,
     t,


### PR DESCRIPTION
This is a fix for #2493 which is not yet in beta so the changelog is omitted.

Amounts used to be hidden even with the setting disabled.
Basically the variable `amountCensoring` was an object and not a boolean and thus was always truthy.