### PR TITLE
feat: Upgrade Harvest to get OAuthWrapperCompProps in TriggerManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.26.13",
+    "cozy-harvest-lib": "^9.27.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5306,10 +5306,10 @@ cozy-doctypes@^1.82.3:
     lodash "^4.17.19"
     prop-types "^15.7.2"
 
-cozy-doctypes@^1.85.3:
-  version "1.85.3"
-  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.3.tgz#9a59856161a4e54af248bec8ed6b1e8752bbbcff"
-  integrity sha512-ISHGpC4tlzcN4P8MzKV3vbsWmx6AfPIZjO60KSHNfHuD1TFfOaAWKQXpg2Eo4KWExImzRXmrs1uMTuYFEdYZTA==
+cozy-doctypes@^1.85.4:
+  version "1.85.4"
+  resolved "https://registry.yarnpkg.com/cozy-doctypes/-/cozy-doctypes-1.85.4.tgz#4c1f42d5bab1f15cc7da6431f820c676f21ba036"
+  integrity sha512-Ofk7PMio5lJ+NM0A0B0G7IBU29AYjP6pzct/3nh1ZJ3/DGmWNWDgnaYKYOkiLYIBcO+nC21Vnn95f02gEl+CUA==
   dependencies:
     cozy-logger "^1.9.1"
     date-fns "^1.30.1"
@@ -5331,15 +5331,15 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.26.13:
-  version "9.26.13"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.26.13.tgz#dcede50b1f35c671aea7cef48b49f0d8b68764b1"
-  integrity sha512-zBOVxxYH8cw/Y8FXQvUyEIHpsry+K9cVG9oKlQhWfgGZQSB7PdRgSD3KQc1EY5iLLZl7INyKAJ/GA0gIjXrSNQ==
+cozy-harvest-lib@^9.27.0:
+  version "9.27.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.27.0.tgz#7e9d269bed43c6fdda193e05ea128026c2cd936a"
+  integrity sha512-pisl0vcVfO7wma8X84GwQC7ED5h+eL/nFmFM5tN9z6YLixG2466/rxdUUqI9i1wajoON/tuT+J9QK6OHDIJ/Ug==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"
     cozy-bi-auth "0.0.25"
-    cozy-doctypes "^1.85.3"
+    cozy-doctypes "^1.85.4"
     cozy-logger "^1.9.1"
     date-fns "^1.30.1"
     final-form "^4.18.5"


### PR DESCRIPTION
This property allows to pass custom Properties to OAuthForm wrapper
without unmounting/remounting OAuthForm on each rerender

This avoids the disparition of the BI webview in banks when a new job is
expected

See https://github.com/cozy/cozy-libs/commit/c2461a312fd75dff29452fc99ac968d40e040c83



```
### ✨ Features

* New OAuthWrapperCompProps in TriggerManager

```
