### PR TITLE
Preserve selected tags when navigating in categories

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -14,6 +14,7 @@ import { useTheme } from 'cozy-ui/transpiled/react/styles'
 
 import { settingsConn } from 'doctypes'
 import Nav from 'ducks/commons/Nav'
+import SelectedTagsProvider from 'ducks/context/SelectedTagsContext'
 import { Warnings } from 'ducks/warnings'
 import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 import { pinGuarded } from 'ducks/pin'
@@ -81,27 +82,29 @@ const App = props => {
 
   return (
     <RouterContext.Provider value={props.router}>
-      <AppSearchBar />
-      <Layout>
-        {showBottomNav && (
-          <KeyboardAwareSidebar>
-            <Nav />
-          </KeyboardAwareSidebar>
-        )}
+      <SelectedTagsProvider>
+        <AppSearchBar />
+        <Layout>
+          {showBottomNav && (
+            <KeyboardAwareSidebar>
+              <Nav />
+            </KeyboardAwareSidebar>
+          )}
 
-        <Main>
-          <Content className={styles.Main}>
-            <ErrorBoundary>{props.children}</ErrorBoundary>
-          </Content>
-        </Main>
+          <Main>
+            <Content className={styles.Main}>
+              <ErrorBoundary>{props.children}</ErrorBoundary>
+            </Content>
+          </Main>
 
-        {/* Outside every other component to bypass overflow:hidden */}
-        <ReactHint />
+          {/* Outside every other component to bypass overflow:hidden */}
+          <ReactHint />
 
-        <Warnings />
-        <Alerter />
-      </Layout>
-      {flag('debug') ? <CozyDevTools panels={banksPanels} /> : null}
+          <Warnings />
+          <Alerter />
+        </Layout>
+        {flag('debug') ? <CozyDevTools panels={banksPanels} /> : null}
+      </SelectedTagsProvider>
     </RouterContext.Provider>
   )
 }

--- a/src/components/App.spec.jsx
+++ b/src/components/App.spec.jsx
@@ -39,9 +39,14 @@ describe('App', () => {
   const setup = () => {
     const client = new CozyClient({ links: [link] })
     jest.spyOn(client, 'queryAll').mockResolvedValue([])
+    const router = {
+      location: {
+        pathname: '/'
+      }
+    }
     const root = render(
       <AppLike client={client}>
-        <App>
+        <App router={router}>
           <DumbComponent client={client} />
         </App>
       </AppLike>

--- a/src/ducks/categories/CategoriesPage/enhanceCategoriesPage.jsx
+++ b/src/ducks/categories/CategoriesPage/enhanceCategoriesPage.jsx
@@ -1,7 +1,8 @@
-import React, { useMemo, useState } from 'react'
+import React, { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 
 import { APPLICATION_DATE } from 'ducks/transactions/constants'
+import { useSelectedTags } from 'ducks/context/SelectedTagsContext'
 import useLast from 'hooks/useLast'
 import useFullyLoadedQuery from 'hooks/useFullyLoadedQuery'
 import {
@@ -31,7 +32,7 @@ const enhanceCategoriesPage = Component => props => {
   const accounts = useQuery(accountsConn.query, accountsConn)
   const groups = useQuery(groupsConn.query, groupsConn)
   const settings = useQuery(settingsConn.query, settingsConn)
-  const [selectedTags, setSelectedTags] = useState([])
+  const [selectedTags, setSelectedTags] = useSelectedTags()
 
   const filteringDoc = useSelector(getFilteringDoc)
   const period = useSelector(getPeriod)

--- a/src/ducks/context/SelectedTagsContext.jsx
+++ b/src/ducks/context/SelectedTagsContext.jsx
@@ -1,0 +1,44 @@
+import React, {
+  createContext,
+  useEffect,
+  useState,
+  useContext,
+  useMemo
+} from 'react'
+import { useLocation } from 'components/RouterContext'
+
+export const SelectedTagsContext = createContext()
+
+export const useSelectedTags = () => {
+  const context = useContext(SelectedTagsContext)
+  if (!context) {
+    throw new Error(
+      'useSelectedTagsContext must be used within a SelectedTagsProvider'
+    )
+  }
+  return context
+}
+
+const SelectedTagsProvider = ({ children }) => {
+  const [selectedTags, setSelectedTags] = useState([])
+  const location = useLocation()
+
+  useEffect(() => {
+    // We want to keep the list of selected tags when navigating from one
+    // categories page to another, but unload it when exiting this set of
+    // routes
+    if (!location.pathname.startsWith('/analysis/categories')) {
+      setSelectedTags([])
+    }
+  }, [location])
+
+  const value = useMemo(() => [selectedTags, setSelectedTags], [selectedTags])
+
+  return (
+    <SelectedTagsContext.Provider value={value}>
+      {children}
+    </SelectedTagsContext.Provider>
+  )
+}
+
+export default SelectedTagsProvider


### PR DESCRIPTION
This stores the selected tags in a context, and provide them in the parent route of category pages.
This allows to persist the selection when navigating between category pages, while clearing it when exiting this group of pages.

```
### ✨ Features

* Preserve selected tags when navigating in categories
```
