### PR TITLE
fix: Log event only when hiding incomes and not when unhiding them

### DIFF
--- a/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
+++ b/src/ducks/categories/AdvancedFilterModal/AdvancedFilterModal.jsx
@@ -32,8 +32,12 @@ const AdvancedFilterModal = ({
   useTrackPage('analyse:filtres-avances-saisie')
 
   const toogleIncome = () => {
-    trackEvent({ name: 'masquer-revenus' })
-    setIsWithIncomeChecked(prev => !prev)
+    setIsWithIncomeChecked(prev => {
+      if (prev) {
+        trackEvent({ name: 'masquer-revenus' })
+      }
+      return !prev
+    })
   }
 
   const handleConfirm = () => {


### PR DESCRIPTION
It used to be logged for both.
```
### 🐛 Bug Fixes

* Log event only when hiding incomes and not when unhiding them
```
