### PR TITLE
Add virtual accounts to the account switch

### DIFF
--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -53,7 +53,7 @@ const filteringDocPropType = PropTypes.oneOfType([
 
 const getFilteringDocLabel = (filteringDoc, t) => {
   if (filteringDoc._type === ACCOUNT_DOCTYPE) {
-    return getAccountLabel(filteringDoc)
+    return getAccountLabel(filteringDoc, t)
   } else if (filteringDoc._type === GROUP_DOCTYPE) {
     return getGroupLabel(filteringDoc, t)
   }
@@ -156,8 +156,8 @@ const AccountSwitchMenu = ({
   }, [groups, t])
 
   const sortedAccounts = useMemo(() => {
-    return sortBy(accounts, ['institutionLabel', getAccountLabel])
-  }, [accounts])
+    return sortBy(accounts, ['institutionLabel', a => getAccountLabel(a, t)])
+  }, [accounts, t])
 
   return (
     <CozyTheme theme="normal">
@@ -231,7 +231,7 @@ const AccountSwitchMenu = ({
               <AccountIcon account={account} />
             </ListItemIcon>
             <AccountListItemText
-              primary={account.shortLabel || account.label}
+              primary={getAccountLabel(account, t)}
               secondary={getAccountInstitutionLabel(account)}
             />
             <ListItemSecondaryAction>

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -134,6 +134,7 @@ const AccountSwitchListItem = props => {
 const AccountSwitchMenu = ({
   accounts,
   groups,
+  virtualGroups,
   filteringDoc,
   filterByDoc,
   resetFilterByDoc
@@ -152,8 +153,10 @@ const AccountSwitchMenu = ({
   )
 
   const sortedGroups = useMemo(() => {
-    return sortBy(groups, g => getGroupLabel(g, t))
-  }, [groups, t])
+    return sortBy([...groups, ...virtualGroups], g =>
+      getGroupLabel(g, t).toLowerCase()
+    )
+  }, [groups, virtualGroups, t])
 
   const sortedAccounts = useMemo(() => {
     return sortBy(accounts, ['institutionLabel', a => getAccountLabel(a, t)])
@@ -335,17 +338,8 @@ const AccountSwitch = props => {
     handleClose()
   }, [dispatch, handleClose])
 
-  const accounts = accountsCollection.data
-
-  const orderedGroups = useMemo(() => {
-    const groups = [...(groupsCollection.data || []), ...virtualGroups].map(
-      group => ({
-        ...group,
-        label: getGroupLabel(group, t)
-      })
-    )
-    return sortBy(groups, x => x.label.toLowerCase())
-  }, [groupsCollection.data, t, virtualGroups])
+  const accounts = accountsCollection.data || []
+  const groups = groupsCollection.data || []
 
   const selectProps = selectPropsBySize[size]
   const select = (
@@ -379,7 +373,8 @@ const AccountSwitch = props => {
                 filterByDoc={handleFilterByDoc}
                 resetFilterByDoc={handleResetFilterByDoc}
                 close={handleClose}
-                groups={orderedGroups}
+                groups={groups}
+                virtualGroups={virtualGroups}
                 accounts={accounts}
               />
             }

--- a/src/ducks/account/AccountSwitch.jsx
+++ b/src/ducks/account/AccountSwitch.jsx
@@ -18,9 +18,9 @@ import Radio from 'cozy-ui/transpiled/react/Radios'
 import CozyTheme from 'cozy-ui/transpiled/react/CozyTheme'
 import DropdownText from 'cozy-ui/transpiled/react/DropdownText'
 
+import { AccountRowIcon } from 'ducks/balance/AccountRow'
 import RawContentDialog from 'components/RawContentDialog'
 import AccountSharingStatus from 'components/AccountSharingStatus'
-import AccountIcon from 'components/AccountIcon'
 import BarItem from 'components/BarItem'
 import { BarCenter } from 'components/Bar'
 
@@ -40,7 +40,7 @@ import {
 } from 'doctypes'
 import { getGroupLabel } from 'ducks/groups/helpers'
 
-import { getVirtualGroups } from 'selectors'
+import { getVirtualAccounts, getVirtualGroups } from 'selectors'
 import {
   getAccountInstitutionLabel,
   getAccountLabel
@@ -133,6 +133,7 @@ const AccountSwitchListItem = props => {
 
 const AccountSwitchMenu = ({
   accounts,
+  virtualAccounts,
   groups,
   virtualGroups,
   filteringDoc,
@@ -159,8 +160,11 @@ const AccountSwitchMenu = ({
   }, [groups, virtualGroups, t])
 
   const sortedAccounts = useMemo(() => {
-    return sortBy(accounts, ['institutionLabel', a => getAccountLabel(a, t)])
-  }, [accounts, t])
+    return sortBy(
+      [...accounts, ...virtualAccounts],
+      ['institutionLabel', a => getAccountLabel(a, t).toLowerCase()]
+    )
+  }, [accounts, virtualAccounts, t])
 
   return (
     <CozyTheme theme="normal">
@@ -231,7 +235,7 @@ const AccountSwitchMenu = ({
             selected={filteringDoc && account._id === filteringDoc._id}
           >
             <ListItemIcon>
-              <AccountIcon account={account} />
+              <AccountRowIcon account={account} />
             </ListItemIcon>
             <AccountListItemText
               primary={getAccountLabel(account, t)}
@@ -305,6 +309,7 @@ const AccountSwitch = props => {
   const { isMobile } = useBreakpoints()
   const filteringDoc = useSelector(getFilteringDoc)
   const filteredAccounts = useSelector(getFilteredAccounts)
+  const virtualAccounts = useSelector(getVirtualAccounts)
   const virtualGroups = useSelector(getVirtualGroups)
 
   const handleToggle = useCallback(
@@ -376,6 +381,7 @@ const AccountSwitch = props => {
                 groups={groups}
                 virtualGroups={virtualGroups}
                 accounts={accounts}
+                virtualAccounts={virtualAccounts}
               />
             }
           />

--- a/src/ducks/account/helpers.js
+++ b/src/ducks/account/helpers.js
@@ -42,8 +42,13 @@ export const getAccountInstitutionLabel = account => {
   return label
 }
 
-export const getAccountLabel = account =>
-  account ? account.shortLabel || account.label : ''
+export const getAccountLabel = (account, t) => {
+  if (account == null) {
+    return ''
+  }
+  const accountLabel = account.shortLabel || account.label
+  return account.virtual ? t(accountLabel) : accountLabel
+}
 
 export const distanceInWords = distance => {
   if (!Number.isFinite(distance)) {

--- a/src/ducks/account/helpers.spec.js
+++ b/src/ducks/account/helpers.spec.js
@@ -1,4 +1,5 @@
 import {
+  getAccountLabel,
   getAccountUpdatedAt,
   distanceInWords,
   getAccountType,
@@ -17,6 +18,33 @@ import triggersFixtures from 'test/fixtures/triggers.json'
 import flag from 'cozy-flags'
 
 jest.mock('cozy-flags')
+
+describe('translateGroup', () => {
+  const translate = jest.fn(key => key)
+
+  afterEach(() => {
+    translate.mockReset()
+  })
+
+  it("should translate the account label only if it's a virtual account", () => {
+    const virtualAccount = {
+      virtual: true,
+      label: 'Data.virtualAccounts.othersReimbursements'
+    }
+
+    const normalAccount = {
+      virtual: false,
+      label: 'Isabelle checkings'
+    }
+
+    expect(getAccountLabel(virtualAccount, translate)).toEqual(
+      'Data.virtualAccounts.othersReimbursements'
+    )
+    expect(getAccountLabel(normalAccount, translate)).toEqual(
+      normalAccount.label
+    )
+  })
+})
 
 describe('getAccountUpdatedAt', () => {
   beforeEach(() => {

--- a/src/ducks/balance/AccountRow.jsx
+++ b/src/ducks/balance/AccountRow.jsx
@@ -46,7 +46,7 @@ const Owners = React.memo(function Owners(props) {
   )
 })
 
-const AccountRowIcon = ({ account }) => {
+export const AccountRowIcon = ({ account }) => {
   return isReimbursementsAccount(account) ? (
     <ReimbursementsIcon account={account} />
   ) : (

--- a/src/ducks/balance/AccountRow.jsx
+++ b/src/ducks/balance/AccountRow.jsx
@@ -130,7 +130,7 @@ const AccountRow = props => {
   const owners = account.owners.data.filter(Boolean).filter(owner => !owner.me)
   const hasOwners = owners.length > 0
   const hasAlert = account.balance < 0
-  const accountLabel = getAccountLabel(account)
+  const accountLabel = getAccountLabel(account, t)
   const handleSwitchClick = useCallback(ev => {
     ev.stopPropagation()
   }, [])
@@ -168,7 +168,7 @@ const AccountRow = props => {
           variant="body1"
           color={disabled ? 'textSecondary' : 'textPrimary'}
         >
-          {account.virtual ? t(accountLabel) : accountLabel}
+          {accountLabel}
         </EllipseTypography>
         <AccountCaption
           gutterBottom={isMobile && hasOwners}

--- a/src/ducks/notifications/CategoryBudget/index.js
+++ b/src/ducks/notifications/CategoryBudget/index.js
@@ -44,7 +44,7 @@ const getAccountOrGroupLabelFromAlert = (
     const doc = col[_id]
     if (doc) {
       return _type === ACCOUNT_DOCTYPE
-        ? getAccountLabel(doc)
+        ? getAccountLabel(doc, t)
         : getGroupLabel(doc, t)
     } else {
       return ''

--- a/src/ducks/notifications/DelayedDebit/index.js
+++ b/src/ducks/notifications/DelayedDebit/index.js
@@ -159,7 +159,7 @@ class DelayedDebit extends NotificationView {
         this.amountCensoring
       ),
       currency: '€',
-      label: getAccountLabel(account.checkingsAccount.data)
+      label: getAccountLabel(account.checkingsAccount.data, this.t)
     })
   }
 

--- a/src/ducks/reimbursements/ReimbursementsPage.jsx
+++ b/src/ducks/reimbursements/ReimbursementsPage.jsx
@@ -1,46 +1,16 @@
 import React, { useMemo } from 'react'
-import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import useBreakpoints from 'cozy-ui/transpiled/react/hooks/useBreakpoints'
-import Header from 'components/Header'
 import Padded from 'components/Padded'
-import { PageTitle } from 'components/Title'
 import cx from 'classnames'
-import BackButton from 'components/BackButton'
 import { ConnectedSelectDates } from 'components/SelectDates'
 import Reimbursements from 'ducks/reimbursements/Reimbursements'
-import styles from 'ducks/reimbursements/ReimbursementsPage.styl'
-import useFilteringDoc from 'ducks/filters/useFilteringDoc'
-import { getCategoryName } from 'ducks/categories/categoriesMap'
-import { GROUP_DOCTYPE } from 'doctypes'
+import { BalanceDetailsHeader } from 'ducks/balance'
 import {
   subMonths,
   format,
   endOfDay,
   differenceInCalendarMonths
 } from 'date-fns'
-
-const getTitleTranslationKey = doc => {
-  const base = 'Reimbursements.title'
-  let lastPart
-
-  if (doc._type === GROUP_DOCTYPE) {
-    lastPart = 'group'
-  } else if (doc.categoryId) {
-    lastPart = getCategoryName(doc.categoryId)
-  } else {
-    lastPart = 'othersExpenses'
-  }
-
-  const key = [base, lastPart].join('.')
-
-  return key
-}
-
-const Title = ({ doc }) => {
-  const { t } = useI18n()
-  const translationKey = getTitleTranslationKey(doc)
-  return <PageTitle>{t(translationKey)}</PageTitle>
-}
 
 const start2016 = new Date(2015, 11, 31)
 
@@ -60,30 +30,26 @@ const getDefaultOptions = () => {
 
 const ReimbursementsPage = () => {
   const { isMobile } = useBreakpoints()
-  const filteringDoc = useFilteringDoc()
   const options = useMemo(() => getDefaultOptions(), [])
 
   return (
     <>
-      <Header theme="inverted" fixed>
+      <BalanceDetailsHeader showBalance>
         <Padded
           className={cx({
             'u-ph-half': isMobile,
             'u-pv-0': isMobile,
-            'u-pb-half': isMobile
+            'u-pb-half': isMobile,
+            'u-pt-half': !isMobile
           })}
         >
-          <div className={styles.ReimbursementsPage__title}>
-            <BackButton theme="primary" arrow />
-            <Title doc={filteringDoc} />
-          </div>
           <ConnectedSelectDates
             showFullYear
             color="primary"
             options={options}
           />
         </Padded>
-      </Header>
+      </BalanceDetailsHeader>
       <Reimbursements />
     </>
   )

--- a/src/ducks/settings/CategoryAlerts/AccountGroupChoice.jsx
+++ b/src/ducks/settings/CategoryAlerts/AccountGroupChoice.jsx
@@ -61,7 +61,7 @@ export const AccountGroupChoice = ({
                 key={account._id}
                 isSelected={current && current._id === account._id}
                 hasRadio
-                label={getAccountLabel(account)}
+                label={getAccountLabel(account, t)}
                 onClick={() => onSelect(account)}
               />
             ))}

--- a/src/ducks/settings/DelayedDebitAlert.jsx
+++ b/src/ducks/settings/DelayedDebitAlert.jsx
@@ -126,10 +126,10 @@ class DumbDelayedDebitCard extends React.Component {
     }
 
     const creditCardLabel = creditCardAccount
-      ? getAccountLabel(creditCardAccount)
+      ? getAccountLabel(creditCardAccount, t)
       : '...'
     const checkingsLabel = checkingsAccount
-      ? getAccountLabel(checkingsAccount)
+      ? getAccountLabel(checkingsAccount, t)
       : '...'
 
     return (

--- a/src/ducks/settings/DelayedDebitAlertRules.jsx
+++ b/src/ducks/settings/DelayedDebitAlertRules.jsx
@@ -52,10 +52,10 @@ const getDescriptionProps = props => {
   const { docCreditCardAccount, docCheckingsAccount } =
     getRelevantAccounts(props)
   const creditCardLabel = docCreditCardAccount
-    ? getAccountLabel(docCreditCardAccount)
+    ? getAccountLabel(docCreditCardAccount, props.t)
     : '...'
   const checkingsLabel = docCheckingsAccount
-    ? getAccountLabel(docCheckingsAccount)
+    ? getAccountLabel(docCheckingsAccount, props.t)
     : '...'
 
   return {

--- a/src/ducks/settings/helpers.js
+++ b/src/ducks/settings/helpers.js
@@ -147,7 +147,7 @@ export const getAccountOrGroupLabel = (accountOrGroup, t) => {
   }
   switch (accountOrGroup._type) {
     case ACCOUNT_DOCTYPE:
-      return getAccountLabel(accountOrGroup)
+      return getAccountLabel(accountOrGroup, t)
     case GROUP_DOCTYPE:
       return getGroupLabel(accountOrGroup, t)
     default:

--- a/src/ducks/transactions/TransactionModal/TransactionModalInfoContent.jsx
+++ b/src/ducks/transactions/TransactionModal/TransactionModalInfoContent.jsx
@@ -122,7 +122,7 @@ const TransactionModalInfoContent = props => {
             infos={[
               {
                 label: t('Transactions.infos.account'),
-                value: getAccountLabel(account)
+                value: getAccountLabel(account, t)
               },
               {
                 label: t('Transactions.infos.institution'),

--- a/src/ducks/transactions/TransactionRow/AccountCaption.jsx
+++ b/src/ducks/transactions/TransactionRow/AccountCaption.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
@@ -8,11 +9,13 @@ import {
 } from 'ducks/account/helpers'
 
 const AccountCaption = ({ account }) => {
+  const { t } = useI18n()
+
   const accountInstitutionLabel = getAccountInstitutionLabel(account)
 
   return (
     <Typography className="u-ellipsis" variant="caption" color="textSecondary">
-      {getAccountLabel(account)}
+      {getAccountLabel(account, t)}
       {accountInstitutionLabel && ` - ${accountInstitutionLabel}`}
     </Typography>
   )

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -688,12 +688,6 @@
   },
 
   "Reimbursements": {
-    "title": {
-      "healthExpenses": "Health reimbursements",
-      "professionalExpenses": "Professional reimbursements",
-      "othersExpenses": "Others reimbursements",
-      "group": "All awaiting reimbursements"
-    },
     "pending": "Pending reimbursements: ",
     "alreadyReimbursed": "Already reimbursed",
     "noPending": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -689,12 +689,6 @@
   },
 
   "Reimbursements": {
-    "title": {
-      "healthExpenses": "Rembours. santé",
-      "professionalExpenses": "Rembours. notes de frais",
-      "othersExpenses": "Autres remboursements",
-      "group": "Tous les remb. en attente"
-    },
     "pending": "Remboursements en attente : ",
     "alreadyReimbursed": "Déjà remboursés",
     "noPending": {

--- a/test/e2e/alerts-existing-cozy.js
+++ b/test/e2e/alerts-existing-cozy.js
@@ -41,8 +41,10 @@ const accountOrGroupFormatter = (accountsById, groupsById) => {
     if (!accountOrGroup) {
       return 'all accounts'
     } else if (accountOrGroup._type === ACCOUNT_DOCTYPE) {
+      const fakeT = x => x
       return (
-        getAccountLabel(accountsById[accountOrGroup._id]) || 'Unknown account'
+        getAccountLabel(accountsById[accountOrGroup._id], fakeT) ||
+        'Unknown account'
       )
     } else if (accountOrGroup._type === GROUP_DOCTYPE) {
       const fakeT = x => x


### PR DESCRIPTION
This should improve the navigation by:

- adding the virtual accounts to the account switch
- adding the account switch to virtual accounts and virtual groups

This way, the user can go from any account to another without having to go back to the balance page.

```
### ✨ Features

* Add the virtual reimbursement accounts to the account switch
* Add the account switch to the reimbursement page
```
