### PR TITLE
fix: Add realtime on io.cozy.account

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -24,6 +24,7 @@ import cozyBar from 'utils/cozyBar'
 import {
   TRIGGER_DOCTYPE,
   ACCOUNT_DOCTYPE,
+  COZY_ACCOUNT_DOCTYPE,
   TRANSACTION_DOCTYPE,
   GROUP_DOCTYPE
 } from 'doctypes'
@@ -85,6 +86,7 @@ const AppContainer = ({ store, lang, history, client }) => {
                           <MuiCozyTheme>
                             <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
                             <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
+                            <RealTimeQueries doctype={COZY_ACCOUNT_DOCTYPE} />
                             <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
                             <RealTimeQueries doctype={GROUP_DOCTYPE} />
                             <Router history={history} routes={AppRoute()} />


### PR DESCRIPTION
This realtime is needed to have an account to display as disconnected
when it is removed by cozy-stack after a CONNECTION_DELETED bi webhook
when the user removes the connection from the BI manage webview



```
### ✨ Features

*

### 🐛 Bug Fixes

* Update cozy accounts when removed from cozy-stack after BI connection removal from BI webview

### 🔧 Tech

*
```
