### PR TITLE
feat: Ignore some webhooks for some events

### DIFF
--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -71,8 +71,10 @@ const JobsProvider = ({ children, client, options = {} }) => {
     const onSuccess = options.onSuccess
     const onError = options.onError
     const hasAccount = msg.account
+    const isConnectionSynced = msg?.event === 'CONNECTION_SYNCED'
+    const isBiWebhook = Boolean(msg?.bi_webhook)
     let arr = [...currJobsInProgress]
-    if (worker === 'konnector' && hasAccount) {
+    if (worker === 'konnector' && hasAccount && (!isBiWebhook || isConnectionSynced)) {
       if (state === 'running' && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })
         arr.push(msg)


### PR DESCRIPTION
At the moment, banks display an import success toast when any bank job
related to a banking connector successed.

Since it is now possible to have multiple konnector job successes for
the creation of one connection ore even on the deletetion of a
connection, we need to filter out some jobs.

Here are the rules to consider a job :

- The job is not a webhook (still possible run manually by the user)
- The job is a webhook of type CONNECTION_SYNCED

ACCOUNT_ENABLED, ACCOUNT_DISABLED and CONNECTION_DELETED jobs are
ignored for the detection of running jobs and for the display of success
or error toasts



```
### ✨ Features

* Do not display success or error toast for webhooks other than CONNECTION_SYNCED

```
