### PR TITLE
feat: Upgrade Harvest to 9.29.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.29.0",
+    "cozy-harvest-lib": "^9.29.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,10 +5338,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.29.0:
-  version "9.29.0"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.0.tgz#6ef667e204a355a9c9f5cb7d908c634899aff8bf"
-  integrity sha512-oCQUjFozXoEUTJQ0wqnm7s+mj2802a1kStm/xVm82F/OnnYiN/+4bVqRSjFpkwyMWcJzue0amtGcsZMpL7TTxw==
+cozy-harvest-lib@^9.29.1:
+  version "9.29.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.1.tgz#2c979c1a183fe7568e392c76457660e33349ef7d"
+  integrity sha512-5gvkD9EEmUCKaGOcfe/O5pJhkPj4Ecr6QklCB3Dxd4mTOoS4GwagKDr/ukBNqUMkh6QVkIjcbX4O1zyuwyEECg==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get a fixed locale on popin after BI connection removal from BI webview

https://github.com/cozy/cozy-libs/commit/ed2f352467da5f36ef1753de5578f156bb2a1ffb



```
### 🐛 Bug Fixes

* Upgrade harvest to 9.29.1: Wrong locale on BI connection removal https://github.com/cozy/cozy-libs/commit/ed2f352467da5f36ef1753de5578f156bb2a1ffb
```
