### PR TITLE
Always show the action column since tags are always enabled

### DIFF
--- a/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
+++ b/src/ducks/categories/CategoriesHeader/MobileFragment.jsx
@@ -55,10 +55,6 @@ const MobileFragment = React.memo(props => {
           <HeaderLoadingProgress
             isFetching={!!isFetchingNewData && !isFetching}
           />
-          <LegalMention className="u-flex u-flex-items-center u-flex-justify-around u-mr-1">
-            {incomeToggle}
-          </LegalMention>
-
           {!hasData && !isFetching && !isFetchingNewData && (
             <Empty
               className={cx('u-mt-3', styles.NoAccount_empty)}

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -184,14 +184,12 @@ const TransactionRowDesktop = ({
             signed
           />
         </TdSecondary>
-        {showTransactionActions && (
-          <TdSecondary className={styles.ColumnSizeAction}>
-            {showTransactionActions && (
-              <TransactionActions transaction={transaction} onlyDefault />
-            )}
-            <TagChips transaction={transaction} clickable />
-          </TdSecondary>
-        )}
+        <TdSecondary className={styles.ColumnSizeAction}>
+          {showTransactionActions && (
+            <TransactionActions transaction={transaction} onlyDefault />
+          )}
+          <TagChips transaction={transaction} clickable />
+        </TdSecondary>
       </tr>
       {categoryModal}
       {transactionModal}

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -130,24 +130,22 @@ const TransactionRowMobile = ({
                   ) : null}
                 </Img>
               </Media>
-              {showTransactionActions && (
-                <div
-                  className={cx(
-                    'u-mb-half',
-                    styles.TransactionRowMobile__actions
-                  )}
-                >
-                  {showTransactionActions && (
-                    <TransactionActions
-                      transaction={transaction}
-                      onlyDefault
-                      compact
-                      menuPosition="right"
-                    />
-                  )}
-                  <TagChips transaction={transaction} clickable />
-                </div>
-              )}
+              <div
+                className={cx(
+                  'u-mb-half',
+                  styles.TransactionRowMobile__actions
+                )}
+              >
+                {showTransactionActions && (
+                  <TransactionActions
+                    transaction={transaction}
+                    onlyDefault
+                    compact
+                    menuPosition="right"
+                  />
+                )}
+                <TagChips transaction={transaction} clickable />
+              </div>
             </Bd>
           </Media>
         </ListItem>

--- a/src/ducks/transactions/header/TableHead.jsx
+++ b/src/ducks/transactions/header/TableHead.jsx
@@ -7,7 +7,6 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import { Table } from 'components/Table'
 
 import transactionsStyles from 'ducks/transactions/Transactions.styl'
-import { showTransactionActions } from 'ducks/transactions/TransactionRow'
 
 const TableHead = ({ isSubcategory }) => {
   const { t } = useI18n()
@@ -33,11 +32,9 @@ const TableHead = ({ isSubcategory }) => {
           <td className={transactionsStyles.ColumnSizeAmount}>
             {t('Transactions.header.amount')}
           </td>
-          {showTransactionActions && (
-            <td className={transactionsStyles.ColumnSizeAction}>
-              {t('Transactions.header.action')}
-            </td>
-          )}
+          <td className={transactionsStyles.ColumnSizeAction}>
+            {t('Transactions.header.action')}
+          </td>
         </tr>
       </thead>
     </Table>


### PR DESCRIPTION
#2526 removed the `banks.tags.enabled` flag, effectively enabling tags everywhere.
However, it also introduced some regression in environnements that have the `banks.transaction-actions.deactivated` flag set to `true`, where tags in transaction lists were completely hidden.

This PR makes sure the behavior is the same as it used to be before #2526, when the `banks.tags.enabled` flag was set to `true`.

```
### 🐛 Bug Fixes

* Always show the action column since tags are always enabled
```
