### PR TITLE
fix: Remove realtime on accounts

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -24,7 +24,6 @@ import cozyBar from 'utils/cozyBar'
 import {
   TRIGGER_DOCTYPE,
   ACCOUNT_DOCTYPE,
-  COZY_ACCOUNT_DOCTYPE,
   TRANSACTION_DOCTYPE,
   GROUP_DOCTYPE
 } from 'doctypes'
@@ -86,7 +85,6 @@ const AppContainer = ({ store, lang, history, client }) => {
                           <MuiCozyTheme>
                             <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
                             <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
-                            <RealTimeQueries doctype={COZY_ACCOUNT_DOCTYPE} />
                             <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
                             <RealTimeQueries doctype={GROUP_DOCTYPE} />
                             <Router history={history} routes={AppRoute()} />


### PR DESCRIPTION
This causes rendering issues on Harvest at the moment.
Another [temporary fix](https://github.com/cozy/cozy-libs/pull/1878) has been
found to update account from harvest waiting for a better fix which will
make OAuthWindow in harvest independent from Harvest components tree.



```
### 🐛 Bug Fixes

* Remove realtime on accounts

```
