### PR TITLE
feat: Upgrade cozy-harvest-lib to 9.29.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.29.1",
+    "cozy-harvest-lib": "^9.29.4",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,10 +5338,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.29.1:
-  version "9.29.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.1.tgz#2c979c1a183fe7568e392c76457660e33349ef7d"
-  integrity sha512-5gvkD9EEmUCKaGOcfe/O5pJhkPj4Ecr6QklCB3Dxd4mTOoS4GwagKDr/ukBNqUMkh6QVkIjcbX4O1zyuwyEECg==
+cozy-harvest-lib@^9.29.4:
+  version "9.29.4"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.4.tgz#9fa8d137331a30cb5ffd61718f2c47b38a6094b9"
+  integrity sha512-uWeqs3k95yLFeEAbPYUo172w9QNYokSdHH8dFN2WQohHLkPxX28APgGRLYwNsOvh6OFCMpzKvSoVhb2ch9O75A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To get a proper display of BI connection deletion popup and with account
status update



```
### 🐛 Bug Fixes

* Update account connection status after BI connection deletion in BI webview

```
