### PR TITLE
fix: RunService will always wait for flag to be initialized

### DIFF
--- a/src/targets/services/service.js
+++ b/src/targets/services/service.js
@@ -18,7 +18,8 @@ export const runService = async service => {
     appMetadata
   })
   Document.registerClient(client)
-
+  client.registerPlugin(flag.plugin)
+  await client.plugins.flags.initializing
   const settings = await fetchSettings(client)
   const localModelOverrideValue = settings.community.localModelOverride.enabled
   log('info', 'Setting local model override flag to ' + localModelOverrideValue)


### PR DESCRIPTION
Banks' services can be called by the outside world and mainly by the banking konnector.

We had an issue with our override when the banking konnector was calling the categorization service (by creating the associated job) and then this categorization service called the `onOperationOrBillCreate` by creating by itself the associated job:
https://github.com/cozy/cozy-banks/blob/3412c9389584e6c1b8120feb644fb459e42171ac/src/targets/services/categorization.js#L60

`startService` was creating the job by reading the value of the flag: https://github.com/cozy/cozy-banks/blob/3412c9389584e6c1b8120feb644fb459e42171ac/src/ducks/categorization/services.js#L124-L130

But since when the `categorization` service is called it doesn't init the flag, we call startService, flag is empty and then it fallbacks to `banks`. It works well by default, but not in our override.

Since it seems that all bank's services are launched by the `runService` command, let's add the flag initialization in it in order to do not have to worry about it anymore.

It should fix our notification issue.



```

### 🐛 Bug Fixes

* Fix notifications issues on the b2c app

```
