### PR TITLE
fix: Don't register the flag plugin twice

### DIFF
--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -7,9 +7,10 @@ import { createScheduledTrigger } from './konnectorAlerts/createTriggerAt'
 import { setIgnoredErrorsFlag } from './konnectorAlerts/setIgnoredErrorsFlag'
 
 const main = async ({ client }) => {
-  client.registerPlugin(flag.plugin)
-  await client.plugins.flags.refresh()
-
+  if (require.main !== module && process.env.NODE_ENV !== 'production') {
+    client.registerPlugin(flag.plugin)
+    await client.plugins.flags.refresh()
+  }
   if (!flag('banks.konnector-alerts')) {
     logger(
       'info',

--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -5,9 +5,6 @@ import runRecurrenceService from 'ducks/recurrence/service'
 import { runService } from './service'
 
 runService(async ({ client }) => {
-  client.registerPlugin(flag.plugin)
-  await client.plugins.flags.refresh()
-
   if (!flag('banks.services.recurrence.enabled')) {
     logger(
       'info',


### PR DESCRIPTION
Since https://github.com/cozy/cozy-banks/commit/643ece93c383d5050ee245fb37ce9abad5e3d254 , runService init
cozy-flags.

But we can only init a cozy-client plugin once. So we have to remove
other place where the flags were initialize when not passing by
runService().

I don't konw why konnectorAlerts does a check on require.main & node_env,
but I have created the opposed check in order to be sure.

It should fix the errors we had:
> The service catched an error: Error: Cannot register plugin flags.
 A plugin with the same name has already been registered.