### PR TITLE
feat: Activate realtime on cozy accounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.29.5",
+    "cozy-harvest-lib": "^9.30.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -17,6 +17,7 @@ import flag from 'cozy-flags'
 
 import { TrackerProvider } from 'ducks/tracking/browser'
 import JobsProvider from 'ducks/context/JobsContext'
+import { CozyConfirmDialogProvider } from 'cozy-harvest-lib'
 import BanksProvider from 'ducks/context/BanksContext'
 import SelectionProvider from 'ducks/context/SelectionContext'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
@@ -82,6 +83,7 @@ const AppContainer = ({ store, lang, history, client }) => {
                     <BanksProvider client={client}>
                       <SelectionProvider>
                         <StoreURLProvider>
+                          <CozyConfirmDialogProvider>
                           <MuiCozyTheme>
                             <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
                             <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
@@ -89,6 +91,7 @@ const AppContainer = ({ store, lang, history, client }) => {
                             <RealTimeQueries doctype={GROUP_DOCTYPE} />
                             <Router history={history} routes={AppRoute()} />
                           </MuiCozyTheme>
+                          </CozyConfirmDialogProvider>
                         </StoreURLProvider>
                       </SelectionProvider>
                     </BanksProvider>

--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -25,6 +25,7 @@ import cozyBar from 'utils/cozyBar'
 import {
   TRIGGER_DOCTYPE,
   ACCOUNT_DOCTYPE,
+  COZY_ACCOUNT_DOCTYPE,
   TRANSACTION_DOCTYPE,
   GROUP_DOCTYPE
 } from 'doctypes'
@@ -84,13 +85,14 @@ const AppContainer = ({ store, lang, history, client }) => {
                       <SelectionProvider>
                         <StoreURLProvider>
                           <CozyConfirmDialogProvider>
-                          <MuiCozyTheme>
-                            <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
-                            <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
-                            <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
-                            <RealTimeQueries doctype={GROUP_DOCTYPE} />
-                            <Router history={history} routes={AppRoute()} />
-                          </MuiCozyTheme>
+                            <MuiCozyTheme>
+                              <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
+                              <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
+                              <RealTimeQueries doctype={COZY_ACCOUNT_DOCTYPE} />
+                              <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
+                              <RealTimeQueries doctype={GROUP_DOCTYPE} />
+                              <Router history={history} routes={AppRoute()} />
+                            </MuiCozyTheme>
                           </CozyConfirmDialogProvider>
                         </StoreURLProvider>
                       </SelectionProvider>

--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -74,7 +74,11 @@ const JobsProvider = ({ children, client, options = {} }) => {
     const isConnectionSynced = msg?.event === 'CONNECTION_SYNCED'
     const isBiWebhook = Boolean(msg?.bi_webhook)
     let arr = [...currJobsInProgress]
-    if (worker === 'konnector' && hasAccount && (!isBiWebhook || isConnectionSynced)) {
+    if (
+      worker === 'konnector' &&
+      hasAccount &&
+      (!isBiWebhook || isConnectionSynced)
+    ) {
       if (state === 'running' && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })
         arr.push(msg)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,10 +5338,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.29.5:
-  version "9.29.5"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.29.5.tgz#82b485b9191510023e9d975f32f3391b62280076"
-  integrity sha512-RMF7UBfDr3Sla9zXngJbjvfFuJZIL0Xk6Hk9u9cc0CuiQzHAkFr0a0ZDf4NH3gQ2gXJ4WaqYjiAhVFvegJkeiA==
+cozy-harvest-lib@^9.30.1:
+  version "9.30.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.30.1.tgz#35c4298d1ff3dc631965d31481b212595afc2a37"
+  integrity sha512-4DvMzTNqbgNR2TFyp27VhfOQwPpmGM06daUt+PUO8jeGwhDnHm7qUQN46Z+3phuhdAb8uJmFbxBclii7vAWVnQ==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
Harvest is also upgraded to support the update of the current account
even when it is displaying a popup or an InAppBrowser- feat: Activate realtime on cozy accounts


```
### ✨ Features

* Add realtime update of cozy accounts
* Harvest upgrade to 9.30.1 : 
    * Add independent confirm dialog
    * Use independant OAuth window
    * Better locale for delete BI connection confirmation button
```
