### PR TITLE
feat: Upgrade cozy-harvest-lib to 9.31.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.30.1",
+    "cozy-harvest-lib": "^9.31.0",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5338,10 +5338,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.30.1:
-  version "9.30.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.30.1.tgz#35c4298d1ff3dc631965d31481b212595afc2a37"
-  integrity sha512-4DvMzTNqbgNR2TFyp27VhfOQwPpmGM06daUt+PUO8jeGwhDnHm7qUQN46Z+3phuhdAb8uJmFbxBclii7vAWVnQ==
+cozy-harvest-lib@^9.31.0:
+  version "9.31.0"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.31.0.tgz#a7e41ad407a074c43c3146c21320a53451056d8d"
+  integrity sha512-Xs7M0y7vE3SlfuW/yFfR8R8aRDlMHdNq7LcPX95h/s0Go31MmHK9bgwkO3f85APPgQ123z7/uCWLh8Si0fhB+A==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
To :
 - Prevent createTemporaryToken to updateCache twice at the same time
 - Follow current trigger jobs even after the first load


```
### ✨ Features

* Follow current trigger jobs even after the first load

### 🐛 Bug Fixes

* Prevent createTemporaryToken to updateCache twice at the same time

```
