### PR TITLE
fix: Stop using cozy-doctypes' Document.updateAll

### DIFF
--- a/src/ducks/notifications/HealthBillLinked/index.js
+++ b/src/ducks/notifications/HealthBillLinked/index.js
@@ -3,7 +3,6 @@ import merge from 'lodash/merge'
 
 import log from 'cozy-logger'
 import { toText } from 'cozy-notifications'
-import { BankTransaction } from 'cozy-doctypes'
 
 import { Bill } from 'models'
 import {
@@ -134,7 +133,7 @@ class HealthBillLinked extends NotificationView {
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, HealthBillLinked)
     })
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -199,7 +199,7 @@ class LateHealthReimbursement extends NotificationView {
       'info',
       `Marking ${this.toNotify.length} transactions as already notified:`
     )
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -138,7 +138,10 @@ class LateHealthReimbursement extends NotificationView {
       return
     }
 
-    log('info', `${transactions.length} late health reimbursements`)
+    log(
+      'info',
+      `${transactions.length} late health reimbursements never notified`
+    )
 
     this.toNotify = transactions
 
@@ -188,9 +191,14 @@ class LateHealthReimbursement extends NotificationView {
    * See `Notification::sendNotification`
    */
   async onSuccess() {
+    log('info', 'LateHealthReimbursement notification successfuly sent')
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, LateHealthReimbursement)
     })
+    log(
+      'info',
+      `Marking ${this.toNotify.length} transactions as already notified:`
+    )
     await BankTransaction.updateAll(this.toNotify)
   }
 }

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -7,7 +7,6 @@ import groupBy from 'lodash/groupBy'
 import fromPairs from 'lodash/fromPairs'
 
 import log from 'cozy-logger'
-import { BankTransaction } from 'cozy-doctypes'
 
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import NotificationView from 'ducks/notifications/BaseNotificationView'
@@ -267,7 +266,7 @@ class TransactionGreater extends NotificationView {
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, TransactionGreater)
     })
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 


### PR DESCRIPTION
Use cozy-client's `saveAll` instead as it is up-to-date and will
cleanup data before sending it to cozy-stack.
This avoids having CouchDB errors because documents have attributes
starting with an underscore (`_type` in this case).


```
### 🐛 Bug Fixes

* Use `CozyClient.saveAll()` instead of `Document.updateAll()` from deprecated `cozy-doctypes` to avoid CouchDB errors with attributes starting with an underscore (#2547)

### 🔧 Tech

* Add more logs around LateHealthReimbursement onSuccess method (#2547)
```
