### PR TITLE
feat: Upgrade cozy-realtime to 4.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "cozy-logger": "^1.9.0",
     "cozy-notifications": "0.12.0",
     "cozy-pouch-link": "33.2.0",
-    "cozy-realtime": "3.11.0",
+    "cozy-realtime": "4.2.9",
     "cozy-scripts": "6.3.0",
     "cozy-sharing": "3.12.2",
     "cozy-stack-client": "33.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5255,7 +5255,7 @@ cozy-client@^6.58.0:
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
 
-cozy-device-helper@^1.10.0, cozy-device-helper@^1.10.3, cozy-device-helper@^1.12.0, cozy-device-helper@^1.7.3, cozy-device-helper@^1.7.5:
+cozy-device-helper@^1.10.0, cozy-device-helper@^1.12.0, cozy-device-helper@^1.7.3, cozy-device-helper@^1.7.5:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-1.12.0.tgz#619a24b0d3caf2d3f616a1524daef7c7b71eab7a"
   integrity sha512-7pFbltgkD8rSO0PEf8pd6aBB37RUnNYH7fb3pkbcvo5rk4quCfSLREV94gZwXxowzP4vjZcAumTM09DfI42mJA==
@@ -5266,6 +5266,13 @@ cozy-device-helper@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.1.0.tgz#6e94215ecf7831093eeb6b260923262cb7331f81"
   integrity sha512-FhiplXS7R4kY7FobGDbmR6GSWMcgrZMnjDz2DcHVyX2sSNewVKk71zRh0vWeWuJRraoXpd32n8B327SjERkEXw==
+  dependencies:
+    lodash "^4.17.19"
+
+cozy-device-helper@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-device-helper/-/cozy-device-helper-2.6.0.tgz#07d83e6e412244f92bba30a0e04560bf3e1abb79"
+  integrity sha512-9loS2xUnA1szP8z8rBu8ni69zZj95eZKH8OqPTspWeRgUtzCAMlJoXusqEUTgVbj37JrvbYkifyxf3IkCZDXAg==
   dependencies:
     lodash "^4.17.19"
 
@@ -5531,13 +5538,13 @@ cozy-pouch-link@33.2.0:
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
-cozy-realtime@3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-3.11.0.tgz#6d68137653aac0d815de30af038adf240b5ada2e"
-  integrity sha512-8YmP/pipVZwkLtkXrG2aSaAHxZNEc36bj3cuFAAGeuE3pw8c0+c/ClD/598+NXzBgtQ6cSExiDGMxVqynRnA3w==
+cozy-realtime@4.2.9:
+  version "4.2.9"
+  resolved "https://registry.yarnpkg.com/cozy-realtime/-/cozy-realtime-4.2.9.tgz#3b8823a1c0e894e3160102d797c238cc85f57bd5"
+  integrity sha512-LMaCNI98W1KCb0DoaqEujbLomS9Nvypn3Drft0b9nq0SZhy5XYktqNT6qyiRe+mEhWyDG0AQA7b0C/lMLYIGYA==
   dependencies:
     "@cozy/minilog" "^1.0.0"
-    cozy-device-helper "^1.10.3"
+    cozy-device-helper "^2.6.0"
 
 cozy-release@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
To get the sendNotification method, needed by harvest


```
### 🔧 Tech

* upgrade cozy-realtime to 4.2.9 to get the sendNotification method
```
