### PR TITLE
fix: Swap providers to make some Harvest dialogs match the theme

### DIFF
--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -84,16 +84,16 @@ const AppContainer = ({ store, lang, history, client }) => {
                     <BanksProvider client={client}>
                       <SelectionProvider>
                         <StoreURLProvider>
-                          <CozyConfirmDialogProvider>
-                            <MuiCozyTheme>
+                          <MuiCozyTheme>
+                            <CozyConfirmDialogProvider>
                               <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
                               <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
                               <RealTimeQueries doctype={COZY_ACCOUNT_DOCTYPE} />
                               <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
                               <RealTimeQueries doctype={GROUP_DOCTYPE} />
                               <Router history={history} routes={AppRoute()} />
-                            </MuiCozyTheme>
-                          </CozyConfirmDialogProvider>
+                            </CozyConfirmDialogProvider>
+                          </MuiCozyTheme>
                         </StoreURLProvider>
                       </SelectionProvider>
                     </BanksProvider>


### PR DESCRIPTION
This is an (untested) fix following #2545, that should make sure Bank disconnect dialogs match Cozy UI theme (and also its override variation).
```
### 🐛 Bug Fixes

* Swap providers to make some Harvest dialogs match the theme
```
