### PR TITLE
Backport recent changes to beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "cozy-device-helper": "^2.1.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",
-    "cozy-harvest-lib": "^9.31.1",
+    "cozy-harvest-lib": "^9.32.1",
     "cozy-intent": "^1.17.1",
     "cozy-interapp": "0.6.2",
     "cozy-keys-lib": "3.8.0",

--- a/src/AppContainer.jsx
+++ b/src/AppContainer.jsx
@@ -84,16 +84,16 @@ const AppContainer = ({ store, lang, history, client }) => {
                     <BanksProvider client={client}>
                       <SelectionProvider>
                         <StoreURLProvider>
-                          <CozyConfirmDialogProvider>
-                            <MuiCozyTheme>
+                          <MuiCozyTheme>
+                            <CozyConfirmDialogProvider>
                               <RealTimeQueries doctype={TRIGGER_DOCTYPE} />
                               <RealTimeQueries doctype={ACCOUNT_DOCTYPE} />
                               <RealTimeQueries doctype={COZY_ACCOUNT_DOCTYPE} />
                               <RealTimeQueries doctype={TRANSACTION_DOCTYPE} />
                               <RealTimeQueries doctype={GROUP_DOCTYPE} />
                               <Router history={history} routes={AppRoute()} />
-                            </MuiCozyTheme>
-                          </CozyConfirmDialogProvider>
+                            </CozyConfirmDialogProvider>
+                          </MuiCozyTheme>
                         </StoreURLProvider>
                       </SelectionProvider>
                     </BanksProvider>

--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -74,7 +74,11 @@ const JobsProvider = ({ children, client, options = {} }) => {
     const isConnectionSynced = msg?.event === 'CONNECTION_SYNCED'
     const isBiWebhook = Boolean(msg?.bi_webhook)
     let arr = [...currJobsInProgress]
-    if (worker === 'konnector' && hasAccount && (!isBiWebhook || isConnectionSynced)) {
+    if (
+      worker === 'konnector' &&
+      hasAccount &&
+      (!isBiWebhook || isConnectionSynced)
+    ) {
       if (state === 'running' && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })
         arr.push(msg)

--- a/src/ducks/notifications/HealthBillLinked/index.js
+++ b/src/ducks/notifications/HealthBillLinked/index.js
@@ -3,7 +3,6 @@ import merge from 'lodash/merge'
 
 import log from 'cozy-logger'
 import { toText } from 'cozy-notifications'
-import { BankTransaction } from 'cozy-doctypes'
 
 import { Bill } from 'models'
 import {
@@ -134,7 +133,7 @@ class HealthBillLinked extends NotificationView {
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, HealthBillLinked)
     })
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -199,7 +199,7 @@ class LateHealthReimbursement extends NotificationView {
       'info',
       `Marking ${this.toNotify.length} transactions as already notified:`
     )
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -138,7 +138,10 @@ class LateHealthReimbursement extends NotificationView {
       return
     }
 
-    log('info', `${transactions.length} late health reimbursements`)
+    log(
+      'info',
+      `${transactions.length} late health reimbursements never notified`
+    )
 
     this.toNotify = transactions
 
@@ -188,9 +191,14 @@ class LateHealthReimbursement extends NotificationView {
    * See `Notification::sendNotification`
    */
   async onSuccess() {
+    log('info', 'LateHealthReimbursement notification successfuly sent')
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, LateHealthReimbursement)
     })
+    log(
+      'info',
+      `Marking ${this.toNotify.length} transactions as already notified:`
+    )
     await BankTransaction.updateAll(this.toNotify)
   }
 }

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -7,7 +7,6 @@ import groupBy from 'lodash/groupBy'
 import fromPairs from 'lodash/fromPairs'
 
 import log from 'cozy-logger'
-import { BankTransaction } from 'cozy-doctypes'
 
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE } from 'doctypes'
 import NotificationView from 'ducks/notifications/BaseNotificationView'
@@ -267,7 +266,7 @@ class TransactionGreater extends NotificationView {
     this.toNotify.forEach(transaction => {
       setAlreadyNotified(transaction, TransactionGreater)
     })
-    await BankTransaction.updateAll(this.toNotify)
+    await this.client.saveAll(this.toNotify)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5345,10 +5345,10 @@ cozy-flags@^2.8.7:
   dependencies:
     microee "^0.0.6"
 
-cozy-harvest-lib@^9.31.1:
-  version "9.31.1"
-  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.31.1.tgz#603790ddaf92e760d0de0675bdc9884630963ce3"
-  integrity sha512-jRGgjGnrpBhYmuAiegPMNtCGSGb6QDtvnltsT3AowLcr2fk0HZmUfoYHa6N/WrN7tG1pzv5XJZ5Ehc1d/3Ia6g==
+cozy-harvest-lib@^9.32.1:
+  version "9.32.1"
+  resolved "https://registry.yarnpkg.com/cozy-harvest-lib/-/cozy-harvest-lib-9.32.1.tgz#c14f06ae95b6330ef378c1809761af45ce35894f"
+  integrity sha512-tIc2Pj+AQW1dYcLuVMp49OtjIuGui6b8TVhBsS+Isd4kEGw20mtu4uvyfd+DAmm/Q3LcVTE6d3LO4SmQqMMl4g==
   dependencies:
     "@cozy/minilog" "^1.0.0"
     "@sentry/browser" "^6.0.1"


### PR DESCRIPTION
This PR backports #2547, #2552 and #2553 to 1.47.1
```
### ✨ Features

* Upgrade cozy-harvest-lib to 9.32.1 :
  * Use OAuthService in KonnectorAccountTabs
  * Use OAuthService in OAuthForm
  * Update wording for Bank disconnect dialog close button

### 🐛 Bug Fixes

* Use `CozyClient.saveAll()` instead of `Document.updateAll()` from deprecated `cozy-doctypes` to avoid CouchDB errors with attributes starting with an underscore (#2547)
* Swap providers to make some Harvest dialogs match the theme

### 🔧 Tech

* Add more logs around LateHealthReimbursement onSuccess method (#2547)
```
