### PR TITLE
Backport notifications fixes to v1.42.1

### DIFF
--- a/src/targets/services/konnectorAlerts/helpers.js
+++ b/src/targets/services/konnectorAlerts/helpers.js
@@ -1,6 +1,10 @@
 import memoize from 'lodash/memoize'
 import keyBy from 'lodash/keyBy'
 import get from 'lodash/get'
+import addDays from 'date-fns/add_days'
+import addHours from 'date-fns/add_hours'
+import addMinutes from 'date-fns/add_minutes'
+import addSeconds from 'date-fns/add_seconds'
 import parse from 'date-fns/parse'
 import subDays from 'date-fns/sub_days'
 import subHours from 'date-fns/sub_hours'
@@ -120,6 +124,9 @@ export const fetchRelatedFuturAtTriggers = async (client, id) => {
 
   return data
 }
+
+export const add = (base, { days = 0, hours = 0, minutes = 0, seconds = 0 }) =>
+  addDays(addHours(addMinutes(addSeconds(base, seconds), minutes), hours), days)
 
 export const sub = (base, { days = 0, hours = 0, minutes = 0, seconds = 0 }) =>
   subDays(subHours(subMinutes(subSeconds(base, seconds), minutes), hours), days)

--- a/src/targets/services/konnectorAlerts/helpers.js
+++ b/src/targets/services/konnectorAlerts/helpers.js
@@ -1,6 +1,11 @@
 import memoize from 'lodash/memoize'
 import keyBy from 'lodash/keyBy'
 import get from 'lodash/get'
+import parse from 'date-fns/parse'
+import subDays from 'date-fns/sub_days'
+import subHours from 'date-fns/sub_hours'
+import subMinutes from 'date-fns/sub_minutes'
+import subSeconds from 'date-fns/sub_seconds'
 
 import { Q } from 'cozy-client'
 
@@ -115,3 +120,9 @@ export const fetchRelatedFuturAtTriggers = async (client, id) => {
 
   return data
 }
+
+export const sub = (base, { days = 0, hours = 0, minutes = 0, seconds = 0 }) =>
+  subDays(subHours(subMinutes(subSeconds(base, seconds), minutes), hours), days)
+
+export const isOlderThan = (referenceDate, { days, hours, minutes, seconds }) =>
+  parse(referenceDate) < sub(Date.now(), { days, hours, minutes, seconds })

--- a/src/targets/services/konnectorAlerts/helpers.spec.js
+++ b/src/targets/services/konnectorAlerts/helpers.spec.js
@@ -1,7 +1,7 @@
 import { createMockClient } from 'cozy-client'
 import MockDate from 'mockdate'
 
-import { storeTriggerStates, isOlderThan, sub } from './helpers'
+import { add, storeTriggerStates, isOlderThan, sub } from './helpers'
 
 const triggerStatesWithNotifsInfo = [
   {
@@ -78,6 +78,44 @@ describe('sub', () => {
     expect(past.getUTCHours()).toBe(9)
     expect(past.getUTCMinutes()).toBe(11)
     expect(past.getUTCSeconds()).toBe(33)
+  })
+})
+
+describe('add', () => {
+  it('returns a Date object', () => {
+    expect(
+      add(Date.now(), {
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4
+      })
+    ).toBeInstanceOf(Date)
+    expect(
+      add(new Date(), {
+        days: 1,
+        hours: 2,
+        minutes: 3,
+        seconds: 4
+      })
+    ).toBeInstanceOf(Date)
+  })
+
+  it('returns the expected future date', () => {
+    const base = Date.parse('28 Sep 2022 11:14:37 GMT')
+
+    const future = add(base, {
+      days: 1,
+      hours: 2,
+      minutes: 3,
+      seconds: 4
+    })
+    expect(future.getUTCFullYear()).toBe(2022)
+    expect(future.getUTCMonth()).toBe(8) // Months are 0 indexed
+    expect(future.getUTCDate()).toBe(29)
+    expect(future.getUTCHours()).toBe(13)
+    expect(future.getUTCMinutes()).toBe(17)
+    expect(future.getUTCSeconds()).toBe(41)
   })
 })
 

--- a/src/targets/services/konnectorAlerts/helpers.spec.js
+++ b/src/targets/services/konnectorAlerts/helpers.spec.js
@@ -1,5 +1,7 @@
 import { createMockClient } from 'cozy-client'
-import { storeTriggerStates } from './helpers'
+import MockDate from 'mockdate'
+
+import { storeTriggerStates, isOlderThan, sub } from './helpers'
 
 const triggerStatesWithNotifsInfo = [
   {
@@ -53,5 +55,46 @@ describe('storeTriggerStates', () => {
         }
       }
     })
+  })
+})
+
+describe('sub', () => {
+  it('returns a Date object', () => {
+    expect(
+      sub(Date.now(), { days: 1, hours: 2, minutes: 3, seconds: 4 })
+    ).toBeInstanceOf(Date)
+    expect(
+      sub(new Date(), { days: 1, hours: 2, minutes: 3, seconds: 4 })
+    ).toBeInstanceOf(Date)
+  })
+
+  it('returns the expected past date', () => {
+    const base = Date.parse('28 Sep 2022 11:14:37 GMT')
+
+    const past = sub(base, { days: 1, hours: 2, minutes: 3, seconds: 4 })
+    expect(past.getUTCFullYear()).toBe(2022)
+    expect(past.getUTCMonth()).toBe(8) // Months are 0 indexed
+    expect(past.getUTCDate()).toBe(27)
+    expect(past.getUTCHours()).toBe(9)
+    expect(past.getUTCMinutes()).toBe(11)
+    expect(past.getUTCSeconds()).toBe(33)
+  })
+})
+
+describe('isOlderThan', () => {
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  it('returns true if given date is older than given time parameters', () => {
+    MockDate.set(Date.parse('28 Sep 2022 11:14:37 GMT'))
+
+    expect(isOlderThan('2022-09-28T11:14:33Z', { seconds: 3 })).toBe(true)
+  })
+
+  it('returns false if given date is not older than given time parameters', () => {
+    MockDate.set(Date.parse('28 Sep 2022 11:14:37 GMT'))
+
+    expect(isOlderThan('2022-09-28T11:14:33Z', { seconds: 4 })).toBe(false)
   })
 })

--- a/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
+++ b/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
@@ -1,5 +1,6 @@
 import CozyClient from 'cozy-client'
 import { sendNotification } from 'cozy-notifications'
+import MockDate from 'mockdate'
 
 import matchAll from 'utils/matchAll'
 import { sendTriggerNotifications } from './sendTriggerNotifications'
@@ -222,6 +223,11 @@ describe('sendTriggerNotifications', () => {
 
   beforeEach(() => {
     sendNotification.mockClear()
+    MockDate.set('2020-01-02')
+  })
+
+  afterEach(() => {
+    MockDate.reset()
   })
 
   const expectTriggerStatesToHaveBeenSaved = client => {

--- a/src/targets/services/konnectorAlerts/shouldNotify.spec.js
+++ b/src/targets/services/konnectorAlerts/shouldNotify.spec.js
@@ -1,0 +1,73 @@
+import { createMockClient } from 'cozy-client'
+import MockDate from 'mockdate'
+
+import { shouldNotify } from './shouldNotify'
+import { sub } from './helpers'
+
+describe('shouldNotify', () => {
+  const setup = ({ last_failure } = {}) => {
+    const client = createMockClient({})
+    client.query.mockResolvedValue({ data: {} })
+    client.stackClient.fetchJSON.mockResolvedValue({
+      latest_version: { manifest: { categories: ['banking'] } }
+    }) // connector's registry info
+
+    const previousStates = {
+      fakeTrigger: {}
+    }
+
+    const trigger = {
+      _id: 'fakeTrigger',
+      message: {
+        konnector: 'fakeBankingConnector'
+      },
+      current_state: {
+        status: 'errored',
+        last_error: 'LOGIN_FAILED', // actionable error
+        last_success: sub(Date.now(), { days: 15 }).toISOString(), // has succeeded in the past
+        last_executed_job_id: 'fakeJob',
+        last_failure
+      }
+    }
+
+    return { client, previousStates, trigger }
+  }
+
+  beforeEach(() => {
+    MockDate.set(Date.now())
+  })
+
+  afterEach(() => {
+    MockDate.reset()
+  })
+
+  describe('last failure date', () => {
+    it('returns a truthy result if given trigger failed less than 7 days and 15 minutes ago', async () => {
+      const { client, previousStates, trigger } = setup({
+        last_failure: sub(Date.now(), {
+          days: 7,
+          minutes: 15
+        }).toISOString()
+      })
+
+      expect(await shouldNotify({ client, trigger, previousStates })).toEqual({
+        ok: true
+      })
+    })
+
+    it('returns a falsy result if given trigger failed more than 7 days and 15 minutes ago', async () => {
+      const { client, previousStates, trigger } = setup({
+        last_failure: sub(Date.now(), {
+          days: 7,
+          minutes: 15,
+          seconds: 1
+        }).toISOString()
+      })
+
+      expect(await shouldNotify({ client, trigger, previousStates })).toEqual({
+        ok: false,
+        reason: 'last-failure-too-old'
+      })
+    })
+  })
+})

--- a/src/targets/services/recurrence.js
+++ b/src/targets/services/recurrence.js
@@ -1,6 +1,20 @@
-import { runService } from './service'
+import flag from 'cozy-flags'
+
+import { logger } from 'ducks/konnectorAlerts'
 import runRecurrenceService from 'ducks/recurrence/service'
+import { runService } from './service'
 
 runService(async ({ client }) => {
+  client.registerPlugin(flag.plugin)
+  await client.plugins.flags.refresh()
+
+  if (!flag('banks.services.recurrence.enabled')) {
+    logger(
+      'info',
+      'Bailing out of recurrence service since flag "banks.services.recurrence.enabled" is not set'
+    )
+    return
+  }
+
   await runRecurrenceService({ client })
 })


### PR DESCRIPTION
```
### ✨ Features

* Don't notify users about very old konnector run failures (i.e. older than 7 days and 15 minutes which is the maximum delay between the last failure and the scheduled 7 days reminder). (#2516)

### 🐛 Bug Fixes

* Prevent scheduling `konnectorAlerts` triggers in the past which would be executed right away by `cozy-stack` ending up sending multiple notifications to the user about the failed konnector run. (#2516)
* Prevent service call loops by only updating transactions for which we've updated the associated recurrence. (#2429)

### 🔧 Tech

* Run recurrence service only if flag is set (#2451)
```
