### PR TITLE
feat: Ignore account delete and account disabled jobs

### DIFF
--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -73,11 +73,12 @@ const JobsProvider = ({ children, client, options = {} }) => {
     const hasAccount = msg.account
     const isConnectionSynced = msg?.event === 'CONNECTION_SYNCED'
     const isBiWebhook = Boolean(msg?.bi_webhook)
+    const isAccountDeleted = msg?.account_deleted === true
     let arr = [...currJobsInProgress]
     if (
       worker === 'konnector' &&
       hasAccount &&
-      (!isBiWebhook || isConnectionSynced)
+      (!isBiWebhook || isConnectionSynced) && !isAccountDeleted
     ) {
       if (state === 'running' && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })

--- a/src/ducks/context/JobsContext.spec.jsx
+++ b/src/ducks/context/JobsContext.spec.jsx
@@ -1,79 +1,38 @@
 import React from 'react'
+import MicroEE from 'microee'
 
 import JobsProvider, { JobsContext } from '../context/JobsContext'
 import { render, act } from '@testing-library/react'
 import CozyClient from 'cozy-client'
 
-export const createKonnectorMsg = (
-  state,
-  konnector,
-  account,
-  event,
-  bi_webhook
-) => ({
-  worker: 'konnector',
-  state,
-  message: {
-    konnector,
-    account,
-    bi_webhook,
-    event
-  }
-})
+const onSuccess = jest.fn()
 
-const RUNNING = 'running'
-const KONNECTORS = [
-  { konnector: 'caissedepargne1', account: '1234' },
-  { konnector: 'boursorama83', account: '5678' },
-  {
-    konnector: 'caissedepargne1',
-    account: '1234',
-    bi_webhook: true,
-    event: 'CONNECTION_SYNCED'
-  },
-  {
-    konnector: 'caissedepargne1',
-    account: '1234',
-    bi_webhook: true,
-    event: 'CONNECTION_DELETED'
+function CozyRealtimeMock() {
+  this.subscribe = jest
+    .fn()
+    .mockImplementation((eventType, doctype, fn) => {
+      this.on(eventType + doctype, fn)
+    })
+  this.unsubscribe = jest.fn().mockImplementation(() => {
+    this.removeAllListeners()
+  })
+
+  this.emitRealtimeEvent = (eventType, doctype, event) => {
+    this.emit(eventType + doctype, event)
   }
-]
+
+  this.clear = () => {
+    this.removeAllListeners()
+    this.subscribe.mockClear()
+    this.unsubscribe.mockClear()
+  }
+}
+MicroEE.mixin(CozyRealtimeMock)
 
 describe('Jobs Context', () => {
-  const setup = ({ konnectors, waitKonnectors = [] }) => {
+  const setup = () => {
     const client = new CozyClient({})
-    client.plugins.realtime = {
-      subscribe: (eventName, doctype, handleRealtime) => {
-        // There are 4 subscribers (created, updated, deleted, notified)
-        // To simulate handle realtime we check if there are
-        // at least the first event and we call handleRealtime callbacks
-        if (eventName === 'created') {
-          for (const konn of konnectors) {
-            setTimeout(
-              () =>
-                handleRealtime(
-                  createKonnectorMsg(
-                    RUNNING,
-                    konn.konnector,
-                    konn.account,
-                    konn.event,
-                    konn.bi_webhook
-                  )
-                ),
-              konn.timeout || 1
-            )
-          }
-        } else if (eventName === 'notified') {
-          for (const konn of waitKonnectors) {
-            setTimeout(
-              () => handleRealtime({ data: { slug: konn.slug } }),
-              konn.timeout || 1
-            )
-          }
-        }
-      },
-      unsubscribe: () => {}
-    }
+    client.plugins.realtime = new CozyRealtimeMock()
 
     const children = (
       <JobsContext.Consumer>
@@ -88,11 +47,11 @@ describe('Jobs Context', () => {
       </JobsContext.Consumer>
     )
     const root = render(
-      <JobsProvider client={client} options={{}}>
+      <JobsProvider client={client} options={{ onSuccess }}>
         {children}
       </JobsProvider>
     )
-    return root
+    return { root, client }
   }
 
   afterEach(() => {
@@ -100,7 +59,26 @@ describe('Jobs Context', () => {
     jest.clearAllTimers()
   })
   it('should display job in progress', async () => {
-    const root = setup({ konnectors: [KONNECTORS[0], KONNECTORS[1]] })
+    const { root, client } = setup()
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('created', 'io.cozy.jobs', {
+        worker: 'konnector',
+        state: 'running',
+        message: {
+          konnector: 'caissedepargne1',
+          account: '1234'
+        }
+      })
+      client.plugins.realtime.emitRealtimeEvent('created', 'io.cozy.jobs', {
+        worker: 'konnector',
+        state: 'running',
+        message: {
+          konnector: 'boursorama83',
+          account: '5678'
+        }
+      })
+    })
+
     expect(await root.findByText('caissedepargne1')).toBeTruthy()
     expect(await root.findByText('1234')).toBeTruthy()
     expect(await root.findByText('boursorama83')).toBeTruthy()
@@ -108,7 +86,20 @@ describe('Jobs Context', () => {
   })
 
   it('should not display job in progress for a CONNECTION_DELETED job', () => {
-    const root = setup({ konnectors: [KONNECTORS[3]] })
+    const { root, client } = setup()
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('created', 'io.cozy.jobs', {
+        worker: 'konnector',
+        state: 'running',
+        message: {
+          konnector: 'caissedepargne1',
+          account: '1234',
+          event: 'CONNECTION_DELETED',
+          bi_webhook: true
+        }
+      })
+    })
+
     expect(root.queryByText('caissedepargne1')).toBeNull()
     expect(root.queryByText('1234')).toBeNull()
     expect(root.queryByText('boursorama83')).toBeNull()
@@ -116,28 +107,59 @@ describe('Jobs Context', () => {
   })
 
   it('should display wait job in progress', async () => {
-    const root = setup({
-      konnectors: [],
-      waitKonnectors: [{ slug: 'caissedepargne1' }]
+    const { root, client } = setup()
+
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('notified', 'io.cozy.jobs', {
+        data: {
+          slug: 'caissedepargne1'
+        }
+      })
     })
+
     expect(await root.findByText('caissedepargne1')).toBeTruthy()
     expect(root.queryByText('boursorama83')).toBeNull()
   })
+
   it('should still display job in progress when real job is running', async () => {
-    const root = setup({
-      konnectors: [KONNECTORS[2]],
-      waitKonnectors: [{ slug: 'caissedepargne1', timeout: 10 }]
+    const { root, client } = setup()
+
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('notified', 'io.cozy.jobs', {
+        data: {
+          slug: 'caissedepargne1'
+        }
+      })
     })
+
+    expect(await root.findByText('caissedepargne1')).toBeTruthy()
+
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('created', 'io.cozy.jobs', {
+        worker: 'konnector',
+        state: 'running',
+        message: {
+          konnector: 'caissedepargne1',
+          account: '1234',
+        }
+      })
+    })
+
     expect(await root.findByText('caissedepargne1')).toBeTruthy()
     expect(await root.findByText('1234')).toBeTruthy()
-    expect(root.queryByText('boursorama83')).toBeNull()
-    expect(root.queryByText('5678')).toBeNull()
   })
+
   it('should should hide wait job in progress after around 5 minutes if no real job was created', async () => {
-    const root = setup({
-      konnectors: [],
-      waitKonnectors: [{ slug: 'boursorama83' }]
+    const { root, client } = setup()
+
+    act(() => {
+      client.plugins.realtime.emitRealtimeEvent('notified', 'io.cozy.jobs', {
+        data: {
+          slug: 'boursorama83'
+        }
+      })
     })
+
     expect(await root.findByText('boursorama83')).toBeTruthy()
 
     jest.spyOn(Date, 'now').mockImplementation(() => 0)


### PR DESCRIPTION
When a konnector job is successful, we display an "Import success"
message.

We do not want to display this "Import success" message for job
triggered when an account (io.cozy.account) is deleted and for job
triggered by "ACCOUNT_DISABLED" webhooks.



```
### ✨ Fix

* Ignore account delete and account disabled jobs for import success message
```
