### PR TITLE
fix: Do not display an error icon for all accounts with the same slug

### DIFF
--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -71,7 +71,7 @@ const AccountsListSettings = ({
     const errors =
       triggers?.data
         ?.filter(trigger => get(trigger, 'current_state.status') === 'errored')
-        .map(trigger => get(trigger, 'message.konnector')) || []
+        .map(trigger => get(trigger, 'message.account')) || []
     setKonnInError(errors)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [triggers.lastUpdate])
@@ -106,7 +106,7 @@ const AccountsListSettings = ({
     [slugInMaintenance, t]
   )
 
-  const hasError = connection => konnInError.includes(connection?.account_type)
+  const hasError = connection => konnInError.includes(connection?._id)
 
   return (
     <Unpadded horizontal className={LegalMention.active ? 'u-mv-1' : 'u-mb-1'}>


### PR DESCRIPTION
Now, trigger error are indexed by their corresponding account id
(io.cozy.account).

This way, when a trigger with account_type "slug1" is in error, not all
accounts related to this account_type are displayed as in error but only
the account related to the trigger in error.



```
### 🐛 Bug Fixes

* Do not display an error icon for all accounts with the same slug
```
