### PR TITLE
fix: Remove import in progress in the end of the connector job

### DIFF
--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -79,7 +79,8 @@ const JobsProvider = ({ children, client, options = {} }) => {
     if (
       worker === 'konnector' &&
       hasAccount &&
-      (!isBiWebhook || isConnectionSynced) && !isAccountDeleted
+      (!isBiWebhook || isConnectionSynced) &&
+      !isAccountDeleted
     ) {
       if ((state === 'running' || state === 'done') && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })

--- a/src/ducks/context/JobsContext.jsx
+++ b/src/ducks/context/JobsContext.jsx
@@ -48,7 +48,8 @@ const JobsProvider = ({ children, client, options = {} }) => {
     // and we want to display it to the user
     const { slug } = data
     if (slug) {
-      const currentJobWithSameSlug = jobsInProgress.findIndex(
+      const { current: currJobsInProgress } = jobsInProgressRef
+      const currentJobWithSameSlug = currJobsInProgress.findIndex(
         j => j.konnector === slug
       )
       if (currentJobWithSameSlug === -1) {
@@ -80,9 +81,11 @@ const JobsProvider = ({ children, client, options = {} }) => {
       hasAccount &&
       (!isBiWebhook || isConnectionSynced) && !isAccountDeleted
     ) {
-      if (state === 'running' && !exist) {
+      if ((state === 'running' || state === 'done') && !exist) {
         waitJobQueue.removeWaitJob({ slug: msg.konnector })
-        arr.push(msg)
+        if (state !== 'done') {
+          arr.push(msg)
+        }
       } else if (state === 'done' && exist) {
         arr.splice(index, 1)
 

--- a/src/ducks/context/JobsContext.spec.jsx
+++ b/src/ducks/context/JobsContext.spec.jsx
@@ -8,11 +8,9 @@ import CozyClient from 'cozy-client'
 const onSuccess = jest.fn()
 
 function CozyRealtimeMock() {
-  this.subscribe = jest
-    .fn()
-    .mockImplementation((eventType, doctype, fn) => {
-      this.on(eventType + doctype, fn)
-    })
+  this.subscribe = jest.fn().mockImplementation((eventType, doctype, fn) => {
+    this.on(eventType + doctype, fn)
+  })
   this.unsubscribe = jest.fn().mockImplementation(() => {
     this.removeAllListeners()
   })
@@ -231,7 +229,7 @@ describe('Jobs Context', () => {
         state: 'running',
         message: {
           konnector: 'caissedepargne1',
-          account: '1234',
+          account: '1234'
         }
       })
     })


### PR DESCRIPTION
When detecting the end of the CONNECTION_SYNCED banking connector job,
use an updated jobsInProgress reference to decide if there is still a
job in progress to display.

We use the same hack as already used here https://github.com/cozy/cozy-banks/blob/58d1a6a0438db16addeed2d8ccca6d642545b56d/src/ducks/context/JobsContext.jsx#L65-L67
because the state doesn't have the right value, but the ref yes. 



```
### 🐛 Bug Fixes

* Remove import in progress in the end of the connector job
```
