### PR TITLE
Use warn log instead of info for konnectorAlerts service

### DIFF
--- a/src/ducks/konnectorAlerts/notification.js
+++ b/src/ducks/konnectorAlerts/notification.js
@@ -143,8 +143,8 @@ class KonnectorAlertNotification extends NotificationView {
     })
   }
 
-  onSuccess() {
-    logger('warn', 'Notification sent')
+  async onSuccess() {
+    logger('warn', 'KonnectorAlerts notification successfully sent')
   }
 }
 

--- a/src/ducks/konnectorAlerts/notification.js
+++ b/src/ducks/konnectorAlerts/notification.js
@@ -58,7 +58,7 @@ class KonnectorAlertNotification extends NotificationView {
     if (flagPreferredChannel) {
       KonnectorAlertNotification.preferredChannels = [flagPreferredChannel]
       logger(
-        'info',
+        'warn',
         `Set KonnectorAlertNotification preferredChannel to ${flagPreferredChannel} because of flag`
       )
     }
@@ -68,7 +68,7 @@ class KonnectorAlertNotification extends NotificationView {
     const willSend =
       !!templateData.konnectorAlerts && templateData.konnectorAlerts.length > 0
     if (!willSend) {
-      logger('info', 'Nothing to send, bailing out')
+      logger('warn', 'Nothing to send, bailing out')
     }
     return willSend
   }
@@ -132,7 +132,7 @@ class KonnectorAlertNotification extends NotificationView {
       const date = getScheduleDate()
       const flagAt = flag('banks.konnector-alerts.schedule-date')
       const at = flagAt || date.toISOString()
-      logger('info', `Scheduling notification at ${at}`)
+      logger('warn', `Scheduling notification at ${at}`)
       attributes.at = at
     }
 
@@ -144,7 +144,7 @@ class KonnectorAlertNotification extends NotificationView {
   }
 
   onSuccess() {
-    logger('info', 'Notification sent')
+    logger('warn', 'Notification sent')
   }
 }
 

--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -13,7 +13,7 @@ const main = async ({ client }) => {
   }
   if (!flag('banks.konnector-alerts')) {
     logger(
-      'info',
+      'warn',
       'Bailing out of job notifications service since flag "banks.konnector-alerts" is not set'
     )
     return

--- a/src/targets/services/konnectorAlerts/createTriggerAt.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.js
@@ -12,7 +12,7 @@ const createTriggerAt = async ({ client, date, konnectorTriggerId }) => {
       // If the date is in the past or too close to the current execution of the
       // service, we don't create a trigger.
       logger(
-        'info',
+        'warn',
         '@at trigger not created: this konnector trigger would be too close to this execution (less than 2 days)'
       )
       return
@@ -31,7 +31,7 @@ const createTriggerAt = async ({ client, date, konnectorTriggerId }) => {
       }
     })
     logger(
-      'info',
+      'warn',
       `⭐ Created: new @at trigger at ${date.toISOString().split('T')[0]}`
     )
   } catch (error) {
@@ -48,13 +48,13 @@ export const createScheduledTrigger = async client => {
 
   for (const [id, triggerStates] of Object.entries(settingTriggerStates)) {
     logger(
-      'info',
+      'warn',
       `⌛ Try to create @at triggers for konnectorTriggerId: ${id}...`
     )
 
     if (triggerStates?.shouldNotify?.ok !== true) {
       logger(
-        'info',
+        'warn',
         `@at triggers not created: this konnector trigger doesn't sent any notification`
       )
       continue
@@ -64,7 +64,7 @@ export const createScheduledTrigger = async client => {
 
     if (relatedFuturAtTriggers.length > 0) {
       logger(
-        'info',
+        'warn',
         `@at triggers not created: @at triggers already existing in the future for this konnector trigger`
       )
       continue

--- a/src/targets/services/konnectorAlerts/sendTriggerNotifications.js
+++ b/src/targets/services/konnectorAlerts/sendTriggerNotifications.js
@@ -30,7 +30,7 @@ export const sendTriggerNotifications = async client => {
       worker: 'konnector'
     })
   )
-  logger('info', `${cronKonnectorTriggers.length} konnector triggers`)
+  logger('warn', `${cronKonnectorTriggers.length} konnector triggers`)
 
   const triggerStatesDoc = await fetchTriggerStates(client)
   const previousStates = get(triggerStatesDoc, 'triggerStates', {})
@@ -56,11 +56,11 @@ export const sendTriggerNotifications = async client => {
   const willBeNotifiedTriggers = cronKonnectorTriggersAndNotifsInfo.filter(
     ({ trigger, shouldNotify }) => {
       if (shouldNotify.ok || ignoredErrors.has(shouldNotify.reason)) {
-        logger('info', `Will notify trigger for ${getKonnectorSlug(trigger)}`)
+        logger('warn', `Will notify trigger for ${getKonnectorSlug(trigger)}`)
         return true
       } else {
         logger(
-          'info',
+          'warn',
           `Will not notify trigger for ${getKonnectorSlug(trigger)} because ${
             shouldNotify.reason
           }`
@@ -88,7 +88,7 @@ export const sendTriggerNotifications = async client => {
   )
 
   logger(
-    'info',
+    'warn',
     `${willBeNotifiedTriggers.length} konnector triggers to notify`
   )
 
@@ -105,7 +105,7 @@ export const sendTriggerNotifications = async client => {
     const notification = buildNotification(client, { konnectorAlerts })
     if (flag('banks.konnector-alerts.notification.disable')) {
       logger(
-        'info',
+        'warn',
         'Abort sending notification because of flag "banks.konnector-alerts.notification.disable"'
       )
     } else {

--- a/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
+++ b/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
@@ -295,7 +295,7 @@ describe('sendTriggerNotifications', () => {
       }
 
       expect(logger).toHaveBeenCalledWith(
-        'info',
+        'warn',
         `Will not notify trigger for ${result.konnectorSlug} because ${result.state}`
       )
     }

--- a/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
+++ b/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
@@ -9,7 +9,7 @@ export const setIgnoredErrorsFlag = async client => {
   const jobId = process.env.COZY_JOB_ID?.split('/').pop()
 
   logger(
-    'info',
+    'warn',
     `Executing job notifications service by trigger: ${triggerId}, job: ${jobId}...`
   )
 
@@ -22,11 +22,11 @@ export const setIgnoredErrorsFlag = async client => {
     if (forcedIgnoredErrors) {
       flag('banks.konnector-alerts.ignored-errors', forcedIgnoredErrors)
       logger(
-        'info',
+        'warn',
         `Forced flag banks.konnector-alerts.ignored-errors to: ${forcedIgnoredErrors}`
       )
     } else {
-      logger('info', 'Flag banks.konnector-alerts.ignored-errors not forced')
+      logger('warn', 'Flag banks.konnector-alerts.ignored-errors not forced')
     }
   } catch (e) {
     logger(


### PR DESCRIPTION
Car on souhaite avoir ces logs même si l'instance n'est pas en debug

backport de https://github.com/cozy/cozy-banks/pull/2570

```
### 🔧 Tech

* Force log for konnectorAlerts service even if instance is not in debug mode
```