### PR TITLE
Use info log instead of warn for konnectorAlerts service

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,6 +1,6 @@
 {
   "name": "Banks",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "name_prefix": "Cozy",
   "slug": "banks",
   "registry_namespace": "banks",

--- a/src/ducks/konnectorAlerts/notification.js
+++ b/src/ducks/konnectorAlerts/notification.js
@@ -58,7 +58,7 @@ class KonnectorAlertNotification extends NotificationView {
     if (flagPreferredChannel) {
       KonnectorAlertNotification.preferredChannels = [flagPreferredChannel]
       logger(
-        'warn',
+        'info',
         `Set KonnectorAlertNotification preferredChannel to ${flagPreferredChannel} because of flag`
       )
     }
@@ -68,7 +68,7 @@ class KonnectorAlertNotification extends NotificationView {
     const willSend =
       !!templateData.konnectorAlerts && templateData.konnectorAlerts.length > 0
     if (!willSend) {
-      logger('warn', 'Nothing to send, bailing out')
+      logger('info', 'Nothing to send, bailing out')
     }
     return willSend
   }
@@ -132,7 +132,7 @@ class KonnectorAlertNotification extends NotificationView {
       const date = getScheduleDate()
       const flagAt = flag('banks.konnector-alerts.schedule-date')
       const at = flagAt || date.toISOString()
-      logger('warn', `Scheduling notification at ${at}`)
+      logger('info', `Scheduling notification at ${at}`)
       attributes.at = at
     }
 

--- a/src/targets/mobile/config.xml
+++ b/src/targets/mobile/config.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-packageName="io.cozy.banks.mobile" android-versionCode="1480000" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.48.0.0" version="1.48.0" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-packageName="io.cozy.banks.mobile" android-versionCode="1481000" ios-CFBundleIdentifier="io.cozy.banks" ios-CFBundleVersion="1.48.1.0" version="1.48.1" xmlns="http://www.w3.org/ns/widgets" xmlns:android="http://schemas.android.com/apk/res/android" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Cozy Banks</name>
     <description>The banking application for Cozy</description>
     <author email="contact@cozycloud.cc" href="https://cozy.io">Cozy Cloud</author>
-    <preference name="AppendUserAgent" value="io.cozy.banks.mobile-1.48.0" />
+    <preference name="AppendUserAgent" value="io.cozy.banks.mobile-1.48.1" />
     <content src="index.html" />
     <access origin="*" />
     <allow-intent href="http://*/*" />

--- a/src/targets/services/konnectorAlerts.js
+++ b/src/targets/services/konnectorAlerts.js
@@ -13,7 +13,7 @@ const main = async ({ client }) => {
   }
   if (!flag('banks.konnector-alerts')) {
     logger(
-      'warn',
+      'info',
       'Bailing out of job notifications service since flag "banks.konnector-alerts" is not set'
     )
     return

--- a/src/targets/services/konnectorAlerts/createTriggerAt.js
+++ b/src/targets/services/konnectorAlerts/createTriggerAt.js
@@ -12,7 +12,7 @@ const createTriggerAt = async ({ client, date, konnectorTriggerId }) => {
       // If the date is in the past or too close to the current execution of the
       // service, we don't create a trigger.
       logger(
-        'warn',
+        'info',
         '@at trigger not created: this konnector trigger would be too close to this execution (less than 2 days)'
       )
       return
@@ -31,7 +31,7 @@ const createTriggerAt = async ({ client, date, konnectorTriggerId }) => {
       }
     })
     logger(
-      'warn',
+      'info',
       `⭐ Created: new @at trigger at ${date.toISOString().split('T')[0]}`
     )
   } catch (error) {
@@ -48,13 +48,13 @@ export const createScheduledTrigger = async client => {
 
   for (const [id, triggerStates] of Object.entries(settingTriggerStates)) {
     logger(
-      'warn',
+      'info',
       `⌛ Try to create @at triggers for konnectorTriggerId: ${id}...`
     )
 
     if (triggerStates?.shouldNotify?.ok !== true) {
       logger(
-        'warn',
+        'info',
         `@at triggers not created: this konnector trigger doesn't sent any notification`
       )
       continue
@@ -64,7 +64,7 @@ export const createScheduledTrigger = async client => {
 
     if (relatedFuturAtTriggers.length > 0) {
       logger(
-        'warn',
+        'info',
         `@at triggers not created: @at triggers already existing in the future for this konnector trigger`
       )
       continue

--- a/src/targets/services/konnectorAlerts/sendTriggerNotifications.js
+++ b/src/targets/services/konnectorAlerts/sendTriggerNotifications.js
@@ -30,7 +30,7 @@ export const sendTriggerNotifications = async client => {
       worker: 'konnector'
     })
   )
-  logger('warn', `${cronKonnectorTriggers.length} konnector triggers`)
+  logger('info', `${cronKonnectorTriggers.length} konnector triggers`)
 
   const triggerStatesDoc = await fetchTriggerStates(client)
   const previousStates = get(triggerStatesDoc, 'triggerStates', {})
@@ -56,11 +56,11 @@ export const sendTriggerNotifications = async client => {
   const willBeNotifiedTriggers = cronKonnectorTriggersAndNotifsInfo.filter(
     ({ trigger, shouldNotify }) => {
       if (shouldNotify.ok || ignoredErrors.has(shouldNotify.reason)) {
-        logger('warn', `Will notify trigger for ${getKonnectorSlug(trigger)}`)
+        logger('info', `Will notify trigger for ${getKonnectorSlug(trigger)}`)
         return true
       } else {
         logger(
-          'warn',
+          'info',
           `Will not notify trigger for ${getKonnectorSlug(trigger)} because ${
             shouldNotify.reason
           }`

--- a/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
+++ b/src/targets/services/konnectorAlerts/sendTriggerNotifications.spec.js
@@ -295,7 +295,7 @@ describe('sendTriggerNotifications', () => {
       }
 
       expect(logger).toHaveBeenCalledWith(
-        'warn',
+        'info',
         `Will not notify trigger for ${result.konnectorSlug} because ${result.state}`
       )
     }

--- a/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
+++ b/src/targets/services/konnectorAlerts/setIgnoredErrorsFlag.js
@@ -9,7 +9,7 @@ export const setIgnoredErrorsFlag = async client => {
   const jobId = process.env.COZY_JOB_ID?.split('/').pop()
 
   logger(
-    'warn',
+    'info',
     `Executing job notifications service by trigger: ${triggerId}, job: ${jobId}...`
   )
 
@@ -22,11 +22,11 @@ export const setIgnoredErrorsFlag = async client => {
     if (forcedIgnoredErrors) {
       flag('banks.konnector-alerts.ignored-errors', forcedIgnoredErrors)
       logger(
-        'warn',
+        'info',
         `Forced flag banks.konnector-alerts.ignored-errors to: ${forcedIgnoredErrors}`
       )
     } else {
-      logger('warn', 'Flag banks.konnector-alerts.ignored-errors not forced')
+      logger('info', 'Flag banks.konnector-alerts.ignored-errors not forced')
     }
   } catch (e) {
     logger(


### PR DESCRIPTION
because of too many logs

```
### 🔧 Tech

* Use info log instead of warn for konnectorAlerts service. Sending notification log are still warning
```