### PR TITLE
feat: Remove cozy-bar v7 assets

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -16,7 +16,7 @@
   <script src="cordova.js" defer></script>
   <% } else if (__STACK_ASSETS__) { %>
   {{.CozyClientJS}}
-  {{.CozyBar}}
+  {{.CozyFonts}}
   <% } else { %>
   <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">
   <% } %>


### PR DESCRIPTION
cozy-bar v7 assets were still imported in production mode. It became visible with recent cozy-bar releases where CSS was really different between v7 and v8.


```
### 🐛 Bug Fixes

* Fix bad display of settings menu
```

![Screenshot 2023-01-05 at 12 23 16](https://user-images.githubusercontent.com/10849491/210769078-048cc998-68b8-43a4-a856-44d19381d6c1.png)
