### PR TITLE
feat: Remove cozy-client-js assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,6 @@
     "cozy-bar": "^8.11.2",
     "cozy-ci": "0.4.1",
     "cozy-client": "^34.5.0",
-    "cozy-client-js": "0.16.4",
     "cozy-device-helper": "^2.6.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -15,7 +15,6 @@
   <meta name="format-detection" content="telephone=no">
   <script src="cordova.js" defer></script>
   <% } else if (__STACK_ASSETS__) { %>
-  {{.CozyClientJS}}
   {{.CozyFonts}}
   <% } else { %>
   <link rel="stylesheet" type="text/css" href="//{{.Domain}}/assets/fonts/fonts.css">


### PR DESCRIPTION
cozy-client-js is not used anymore in cozy-banks.

```
### 🔧 Tech

* Remove cozy-client-js assets
```
