### PR TITLE
Backport "Use absolute links for analysis tabs"

### DIFF
--- a/src/ducks/analysis/AnalysisTabs.jsx
+++ b/src/ducks/analysis/AnalysisTabs.jsx
@@ -4,11 +4,6 @@ import { Tab, Tabs } from 'cozy-ui/transpiled/react/MuiTabs'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Header from 'components/Header'
 
-export const tabRoutes = {
-  categories: 'analysis/categories',
-  recurrence: 'analysis/recurrence'
-}
-
 export const activeTab = location =>
   location.pathname.includes('categories') ? 'categories' : 'recurrence'
 export const tabNames = ['categories', 'recurrence']
@@ -26,7 +21,7 @@ const AnalysisTabs = () => {
             label={t(`Nav.${tabName}`)}
             key={tabName}
             name={tabName}
-            onClick={() => navigate(tabRoutes[tabName])}
+            onClick={() => navigate(`/analysis/${tabName}`)}
           />
         ))}
       </Tabs>

--- a/src/ducks/settings/TabsHeader/index.jsx
+++ b/src/ducks/settings/TabsHeader/index.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
@@ -21,8 +21,6 @@ const TabsHeader = () => {
 
   if (tabNames.indexOf(defaultTab) === -1) defaultTab = 'configuration'
 
-  const goTo = useCallback(url => () => navigate(url), [navigate])
-
   return (
     <>
       <Padded className={isMobile ? 'u-p-0' : 'u-pb-half'}>
@@ -36,7 +34,7 @@ const TabsHeader = () => {
               classes={{ root: i === 0 && !isMobile ? 'u-ml-2' : 0 }}
               key={tabName}
               name={tabName}
-              onClick={goTo(`/settings/${tabName}`)}
+              onClick={() => navigate(`/settings/${tabName}`)}
               label={t(`Settings.${tabName}`)}
             />
           ))}


### PR DESCRIPTION
This backports #2596.

```
### 🐛 Bug Fixes

* Use absolute links for analysis tabs
```
