### PR TITLE
Modify AddAccountLink to force using a specific route of Store

### DIFF
--- a/src/ducks/balance/AccountsImporting.spec.jsx
+++ b/src/ducks/balance/AccountsImporting.spec.jsx
@@ -17,6 +17,12 @@ jest.mock('cozy-flags', () => flagName => {
   return flagName === 'balance.no-delay-groups'
 })
 
+jest.mock('cozy-client', () => ({
+  __esModule: true,
+  ...jest.requireActual('cozy-client'),
+  generateWebLink: jest.fn().mockReturnValue('http://')
+}))
+
 const konnectorInfos = [
   {
     konnector: 'konnector',

--- a/src/ducks/balance/BalancePanels.jsx
+++ b/src/ducks/balance/BalancePanels.jsx
@@ -1,16 +1,16 @@
 import React, { useCallback } from 'react'
-import { useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
-import GroupPanel from 'ducks/balance/GroupPanel'
+import { useNavigate } from 'react-router-dom'
 
+import flag from 'cozy-flags'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Button from 'cozy-ui/transpiled/react/Button'
-import flag from 'cozy-flags'
 
+import Delayed from 'components/Delayed'
 import AddAccountLink from 'ducks/settings/AddAccountLink'
+import GroupPanel from 'ducks/balance/GroupPanel'
 import { translateAndSortGroups } from 'ducks/groups/helpers'
 import styles from 'ducks/balance/BalancePanels.styl'
-import Delayed from 'components/Delayed'
 
 const GROUP_PANEL_RENDER_DELAY = 150
 

--- a/src/ducks/settings/AccountsSettings.jsx
+++ b/src/ducks/settings/AccountsSettings.jsx
@@ -1,20 +1,17 @@
 import React, { memo } from 'react'
-
 import groupBy from 'lodash/groupBy'
 import sortBy from 'lodash/sortBy'
 
+import { hasQueryBeenLoaded, isQueryLoading, useQuery } from 'cozy-client'
 import { useI18n } from 'cozy-ui/transpiled/react/I18n'
-import Button from 'cozy-ui/transpiled/react/MuiCozyTheme/Buttons'
+import Button from 'cozy-ui/transpiled/react/Buttons'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import PlusIcon from 'cozy-ui/transpiled/react/Icons/Plus'
-import { hasQueryBeenLoaded, isQueryLoading, useQuery } from 'cozy-client'
-
-import Loading from 'components/Loading'
-
-import AddAccountLink from 'ducks/settings/AddAccountLink'
-import { useTrackPage } from 'ducks/tracking/browser'
 
 import { accountsConn } from 'doctypes'
+import Loading from 'components/Loading'
+import { useTrackPage } from 'ducks/tracking/browser'
+import AddAccountLink from 'ducks/settings/AddAccountLink'
 import { useBanksContext } from 'ducks/context/BanksContext'
 import AccountsListSettings from 'ducks/settings/AccountsListSettings'
 
@@ -54,10 +51,11 @@ const AccountsSettings = () => {
         <p>{t('Accounts.no-accounts')}</p>
       )}
       <AddAccountLink>
-        <Button color="primary">
-          <Icon icon={PlusIcon} className="u-mr-half" />{' '}
-          {t('Accounts.add-bank')}
-        </Button>
+        <Button
+          variant="text"
+          startIcon={<Icon icon={PlusIcon} />}
+          label={t('Accounts.add-bank')}
+        />
       </AddAccountLink>
     </>
   )

--- a/src/ducks/settings/AccountsSettings.spec.jsx
+++ b/src/ducks/settings/AccountsSettings.spec.jsx
@@ -19,7 +19,8 @@ jest.mock('hooks/useRedirectionURL', () => {
 
 jest.mock('cozy-client', () => ({
   ...jest.requireActual('cozy-client'),
-  useAppsInMaintenance: jest.fn().mockReturnValue([{ slug: 'banking-slug' }])
+  useAppsInMaintenance: jest.fn().mockReturnValue([{ slug: 'banking-slug' }]),
+  generateWebLink: jest.fn().mockReturnValue('http://')
 }))
 
 const BreakContext = () => {

--- a/src/ducks/settings/AddAccountLink.jsx
+++ b/src/ducks/settings/AddAccountLink.jsx
@@ -1,11 +1,34 @@
 import React from 'react'
-import StoreLink from 'components/StoreLink'
+
+import { useClient, generateWebLink } from 'cozy-client'
+import AppLinker from 'cozy-ui/transpiled/react/AppLinker'
+import Link from 'cozy-ui/transpiled/react/Link'
 
 const AddAccountLink = props => {
+  const client = useClient()
+
   return (
-    <StoreLink type="konnector" category="banking">
-      {props.children}
-    </StoreLink>
+    <AppLinker
+      app={{ slug: 'store' }}
+      href={generateWebLink({
+        slug: 'store',
+        cozyUrl: client.getStackClient().uri,
+        subDomainType: client.getInstanceOptions().subdomain,
+        pathname: '/',
+        hash: 'discover?type=konnector&category=banking'
+      })}
+    >
+      {({ onClick, href }) => (
+        <Link
+          style={{ display: 'contents' }}
+          underline="none"
+          href={href}
+          onClick={onClick}
+        >
+          {props.children}
+        </Link>
+      )}
+    </AppLinker>
   )
 }
 


### PR DESCRIPTION
Lorsqu'on avait un connecteur bancaire qui nécessitait une mise à jour, les liens de redirection d'ajout de connecteur bancaire filtrait la page du store sur les connecteurs à mettre à jour.

On force maintenant en dur l'url avec un utilisation classique de AppLinker.

```
### 🐛 Bug Fixes

* When a connector needs to be updated, it no longer impacts the add bank connector buttons.

```