### PR TITLE
feat: Update cozy-bar from 8.13.0 to 8.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "classnames": "2.2.6",
     "cordova": "7.1.0",
     "cozy-authentication": "^2.12.1",
-    "cozy-bar": "^8.13.0",
+    "cozy-bar": "^8.13.1",
     "cozy-ci": "0.4.1",
     "cozy-client": "^34.5.0",
     "cozy-device-helper": "^2.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5143,10 +5143,10 @@ cozy-authentication@^2.12.1:
     snarkdown "1.2.2"
     url-polyfill "1.1.7"
 
-cozy-bar@^8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-8.13.0.tgz#b6ac42ba59b007ea1efde646356d6fe43e2823b4"
-  integrity sha512-hSW0A74sA6u4fTUbtCSyCC/4QKBk/N0D8LsdnTgtn3Hkp/SH3KW6DsllS3WkyEn+FlpeC1uHuVlctAL3A0G3EA==
+cozy-bar@^8.13.1:
+  version "8.13.1"
+  resolved "https://registry.yarnpkg.com/cozy-bar/-/cozy-bar-8.13.1.tgz#0d9c10807908a5a228f05597e55cb4fa2a20812e"
+  integrity sha512-AIkbuQ6YjvOZ2FyDhfyx8Utu33XdmlTcXKKjQQ4fcQSKvoP7ocxgXdtZk5p42A8rMdYkTj1L2o5c3yYdOsdyuA==
   dependencies:
     hammerjs "2.0.8"
     lodash.debounce "4.0.8"


### PR DESCRIPTION
This increase height for the support modal into cozy-bar to match the add of consent checkbox

```
### 🐛 Bug Fixes

* Increase support modal height to handle adding consent checkbox
```
