### PR TITLE
feat: Add devtools notification content for flagship redirection

### DIFF
--- a/src/ducks/devtools/Notifications.jsx
+++ b/src/ducks/devtools/Notifications.jsx
@@ -46,7 +46,10 @@ const sendNotification = async (
           content: 'This is a test notification text content',
           content_html: 'This is a test notification HTML content',
           data: {
-            route: notificationRoute
+            route: notificationRoute,
+            url: notificationRoute,
+            appName: 'banks',
+            pathname: '/'
           }
         }
       }


### PR DESCRIPTION
Banks devtool is one of our simpliest way to try notifications. I added three properties used by the flagship app to redirect to an app instead of the home after opening the notification to try this new feature.

```
### 🔧 Tech

* Add devtools notification content for flagship redirection
```
