### PR TITLE
perf: Optimize lookup of in-progress export jobs

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "cozy-authentication": "^2.12.1",
     "cozy-bar": "^8.14.0",
     "cozy-ci": "0.4.1",
-    "cozy-client": "35.3.1",
+    "cozy-client": "35.6.0",
     "cozy-device-helper": "^2.6.0",
     "cozy-doctypes": "1.82.2",
     "cozy-flags": "^2.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5223,16 +5223,16 @@ cozy-client-js@^0.19.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@35.3.1, cozy-client@^35.3.1:
-  version "35.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.3.1.tgz#06b1e0309d29ac37686bd4f49d8b977090875f4c"
-  integrity sha512-aXRA4Nw/hdrLVHk3Zd1K0yMw416Zt6DTtgSCzsq75gUgtd9m+fTw65a5Tk4eiPM3NDfHgrwIPyCOmuqxiqnr1g==
+cozy-client@35.6.0:
+  version "35.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.6.0.tgz#f052a020f9f3bf19a85448d72c38d182c08e8da3"
+  integrity sha512-kDmUXWC9tV+vgqixhKigpnb8AmNUzZLgP6tF8SW5O50/TlORHLVvNlLg63m40ApDSMK1TaCFe+zSkYnF6/ojMQ==
   dependencies:
     "@cozy/minilog" "1.0.0"
     "@types/jest" "^26.0.20"
     "@types/lodash" "^4.14.170"
     btoa "^1.2.1"
-    cozy-stack-client "^35.3.1"
+    cozy-stack-client "^35.6.0"
     date-fns "2.29.3"
     json-stable-stringify "^1.0.1"
     lodash "^4.17.13"
@@ -5273,6 +5273,31 @@ cozy-client@^23.18.0:
     server-destroy "^1.0.1"
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
+
+cozy-client@^35.3.1:
+  version "35.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.3.1.tgz#06b1e0309d29ac37686bd4f49d8b977090875f4c"
+  integrity sha512-aXRA4Nw/hdrLVHk3Zd1K0yMw416Zt6DTtgSCzsq75gUgtd9m+fTw65a5Tk4eiPM3NDfHgrwIPyCOmuqxiqnr1g==
+  dependencies:
+    "@cozy/minilog" "1.0.0"
+    "@types/jest" "^26.0.20"
+    "@types/lodash" "^4.14.170"
+    btoa "^1.2.1"
+    cozy-stack-client "^35.3.1"
+    date-fns "2.29.3"
+    json-stable-stringify "^1.0.1"
+    lodash "^4.17.13"
+    microee "^0.0.6"
+    node-fetch "^2.6.1"
+    node-polyglot "2.4.2"
+    open "7.4.2"
+    prop-types "^15.6.2"
+    react-redux "^7.2.0"
+    redux "3 || 4"
+    redux-thunk "^2.3.0"
+    server-destroy "^1.0.1"
+    sift "^6.0.0"
+    url-search-params-polyfill "^8.0.0"
 
 cozy-client@^6.58.0:
   version "6.66.0"
@@ -5671,6 +5696,15 @@ cozy-stack-client@^23.19.0:
   integrity sha512-oq7/ERKy/Gg3jnxSi0rs3upvBccsGmmfdMiIa9hhJcw/Vxl7NMmjUM2itPnfmBNAMfBax6VlB8HWI1LY87fLuw==
   dependencies:
     cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^35.6.0:
+  version "35.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-35.6.0.tgz#9d650adc7f3661e2328780cacab87b7060f8ef4c"
+  integrity sha512-EVnRHemYHv9NXFeVP003QQ04OpHrcQIp8RQk4zAyS5Qm8dASagF5hZed4K6C+Fs4Z7qSYmP1GRM2zmqiqU3RfQ==
+  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"


### PR DESCRIPTION
Backport of https://github.com/cozy/cozy-banks/pull/2620

The query used by cozy-stack to fetch queued and in-progress jobs is
sub-optimal and can timeout when there are lots of jobs.

We by-pass this route and use a mango query with a partial filter to
improve performances and avoid timeouts.

```
### 🔧 Tech

* Improve performances of in-progress export jobs lookup
```
