### PR TITLE
feat: Rework renderExtraRoutesWithoutLayout method

### DIFF
--- a/src/components/AppRoute.jsx
+++ b/src/components/AppRoute.jsx
@@ -29,197 +29,207 @@ import SetFilterAndRedirect from 'ducks/balance/SetFilterAndRedirect'
 import TagPage from 'ducks/tags/TagPage'
 import Export from 'ducks/settings/Export'
 
-// Use a function to delay instantation and have access to AppRoute.renderExtraRoutes
-const AppRoute = () => (
-  <Routes>
-    <Route element={<UserActionRequired />}>
-      {AppRoute.renderExtraRoutesWithoutLayout()}
-      <Route path="/" element={<App />}>
-        {isWebApp() && (
-          <Route index element={<Navigate to="balances" replace />} />
-        )}
-        <Route path="balances">
-          <Route
-            index
-            element={
-              <ScrollToTopOnMountWrapper>
-                <Balance />
-              </ScrollToTopOnMountWrapper>
-            }
-          />
-          <Route
-            path="details"
-            element={
-              <ScrollToTopOnMountWrapper>
-                <BalanceDetailsPage />
-              </ScrollToTopOnMountWrapper>
-            }
-          />
-          <Route
-            path="future"
-            element={
-              <ScrollToTopOnMountWrapper>
-                <PlannedTransactionsPage />
-              </ScrollToTopOnMountWrapper>
-            }
-          />
-          <Route
-            path=":accountOrGroupId/:page"
-            element={<SetFilterAndRedirect />}
-          />
-        </Route>
-        <Route
-          path="categories/*"
-          element={<Navigate to="../analysis/categories" replace />}
-        ></Route>
-        <Route
-          path="recurrence/*"
-          element={<Navigate to="../analysis/recurrence" replace />}
-        ></Route>
-        <Route
-          path="analysis"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <AnalysisPage />
-            </ScrollToTopOnMountWrapper>
-          }
-        >
-          <Route path="categories">
+// Use a function to delay instantation and have access to AppRoute methods
+const AppRoute = () => {
+  const { routes, condition } = AppRoute.renderExtraRoutesOnly()
+  if (condition) {
+    return (
+      <Routes>
+        <Route element={<UserActionRequired />}>{routes}</Route>
+      </Routes>
+    )
+  }
+
+  return (
+    <Routes>
+      <Route element={<UserActionRequired />}>
+        <Route path="/" element={<App />}>
+          {isWebApp() && (
+            <Route index element={<Navigate to="balances" replace />} />
+          )}
+          <Route path="balances">
             <Route
               index
               element={
                 <ScrollToTopOnMountWrapper>
-                  <CategoriesPage />
+                  <Balance />
                 </ScrollToTopOnMountWrapper>
               }
             />
             <Route
-              path=":categoryName"
+              path="details"
               element={
                 <ScrollToTopOnMountWrapper>
-                  <CategoriesPage />
+                  <BalanceDetailsPage />
                 </ScrollToTopOnMountWrapper>
               }
             />
             <Route
-              path=":categoryName/:subcategoryName"
+              path="future"
               element={
                 <ScrollToTopOnMountWrapper>
-                  <CategoriesPage />
+                  <PlannedTransactionsPage />
                 </ScrollToTopOnMountWrapper>
               }
+            />
+            <Route
+              path=":accountOrGroupId/:page"
+              element={<SetFilterAndRedirect />}
             />
           </Route>
-          <Route path="recurrence">
-            <Route
-              index
-              element={
-                <ScrollToTopOnMountWrapper>
-                  <RecurrencesPage />
-                </ScrollToTopOnMountWrapper>
-              }
-            />
-            <Route
-              path=":bundleId"
-              element={
-                <ScrollToTopOnMountWrapper>
-                  <RecurrencePage />
-                </ScrollToTopOnMountWrapper>
-              }
-            />
-          </Route>
-        </Route>
-        <Route path="settings">
           <Route
-            path="configuration/export"
-            element={<Navigate to="../export" replace />}
-          />
-          <Route path="export" element={<Export />} />
+            path="categories/*"
+            element={<Navigate to="../analysis/categories" replace />}
+          ></Route>
           <Route
+            path="recurrence/*"
+            element={<Navigate to="../analysis/recurrence" replace />}
+          ></Route>
+          <Route
+            path="analysis"
             element={
               <ScrollToTopOnMountWrapper>
-                <Settings />
+                <AnalysisPage />
               </ScrollToTopOnMountWrapper>
             }
           >
-            <Route index element={<Configuration />} />
-            <Route path="accounts" element={<AccountsSettings />} />
-            <Route path="groups" element={<GroupsSettings />} />
-            <Route path="tags" element={<TagsSettings />} />
-            <Route path="configuration" element={<Configuration />} />
+            <Route path="categories">
+              <Route
+                index
+                element={
+                  <ScrollToTopOnMountWrapper>
+                    <CategoriesPage />
+                  </ScrollToTopOnMountWrapper>
+                }
+              />
+              <Route
+                path=":categoryName"
+                element={
+                  <ScrollToTopOnMountWrapper>
+                    <CategoriesPage />
+                  </ScrollToTopOnMountWrapper>
+                }
+              />
+              <Route
+                path=":categoryName/:subcategoryName"
+                element={
+                  <ScrollToTopOnMountWrapper>
+                    <CategoriesPage />
+                  </ScrollToTopOnMountWrapper>
+                }
+              />
+            </Route>
+            <Route path="recurrence">
+              <Route
+                index
+                element={
+                  <ScrollToTopOnMountWrapper>
+                    <RecurrencesPage />
+                  </ScrollToTopOnMountWrapper>
+                }
+              />
+              <Route
+                path=":bundleId"
+                element={
+                  <ScrollToTopOnMountWrapper>
+                    <RecurrencePage />
+                  </ScrollToTopOnMountWrapper>
+                }
+              />
+            </Route>
+          </Route>
+          <Route path="settings">
+            <Route
+              path="configuration/export"
+              element={<Navigate to="../export" replace />}
+            />
+            <Route path="export" element={<Export />} />
+            <Route
+              element={
+                <ScrollToTopOnMountWrapper>
+                  <Settings />
+                </ScrollToTopOnMountWrapper>
+              }
+            >
+              <Route index element={<Configuration />} />
+              <Route path="accounts" element={<AccountsSettings />} />
+              <Route path="groups" element={<GroupsSettings />} />
+              <Route path="tags" element={<TagsSettings />} />
+              <Route path="configuration" element={<Configuration />} />
+            </Route>
+            <Route
+              path="groups/new"
+              element={
+                <ScrollToTopOnMountWrapper>
+                  <NewGroupSettings />
+                </ScrollToTopOnMountWrapper>
+              }
+            />
+            <Route
+              path="groups/:groupId"
+              element={
+                <ScrollToTopOnMountWrapper>
+                  <ExistingGroupSettings />
+                </ScrollToTopOnMountWrapper>
+              }
+            />
+            <Route
+              path="accounts/:accountId"
+              element={<Navigate to="../accounts" replace />}
+            />
           </Route>
           <Route
-            path="groups/new"
+            path="tag/:tagId"
             element={
               <ScrollToTopOnMountWrapper>
-                <NewGroupSettings />
+                <TagPage />
               </ScrollToTopOnMountWrapper>
             }
           />
           <Route
-            path="groups/:groupId"
+            path="transfers"
             element={
               <ScrollToTopOnMountWrapper>
-                <ExistingGroupSettings />
+                <TransferPage />
               </ScrollToTopOnMountWrapper>
             }
           />
           <Route
-            path="accounts/:accountId"
-            element={<Navigate to="../accounts" replace />}
+            path="search"
+            element={
+              <ScrollToTopOnMountWrapper>
+                <SearchPage />
+              </ScrollToTopOnMountWrapper>
+            }
           />
+          <Route
+            path="search/:search"
+            element={
+              <ScrollToTopOnMountWrapper>
+                <SearchPage />
+              </ScrollToTopOnMountWrapper>
+            }
+          />
+          <Route
+            path="recurrencedebug"
+            element={
+              <ScrollToTopOnMountWrapper>
+                <DebugRecurrencePage />
+              </ScrollToTopOnMountWrapper>
+            }
+          />
+          {AppRoute.renderExtraRoutes()}
+          {isWebApp() && (
+            <Route path="*" element={<Navigate to="balances" replace />} />
+          )}
         </Route>
-        <Route
-          path="tag/:tagId"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <TagPage />
-            </ScrollToTopOnMountWrapper>
-          }
-        />
-        <Route
-          path="transfers"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <TransferPage />
-            </ScrollToTopOnMountWrapper>
-          }
-        />
-        <Route
-          path="search"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <SearchPage />
-            </ScrollToTopOnMountWrapper>
-          }
-        />
-        <Route
-          path="search/:search"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <SearchPage />
-            </ScrollToTopOnMountWrapper>
-          }
-        />
-        <Route
-          path="recurrencedebug"
-          element={
-            <ScrollToTopOnMountWrapper>
-              <DebugRecurrencePage />
-            </ScrollToTopOnMountWrapper>
-          }
-        />
-        {AppRoute.renderExtraRoutes()}
-        {isWebApp() && (
-          <Route path="*" element={<Navigate to="balances" replace />} />
-        )}
       </Route>
-    </Route>
-  </Routes>
-)
+    </Routes>
+  )
+}
 
 // Ability to overrides easily
 AppRoute.renderExtraRoutes = () => null
-AppRoute.renderExtraRoutesWithoutLayout = () => null
+AppRoute.renderExtraRoutesOnly = () => ({ routes: [], conditon: false })
 
 export default AppRoute

--- a/src/components/AppRoute.spec.jsx
+++ b/src/components/AppRoute.spec.jsx
@@ -30,4 +30,22 @@ describe('App route', () => {
     const route = AppRoute()
     expect(route).toMatchSnapshot()
   })
+
+  it('should have renderExtraRoutesOnly if condition is true', () => {
+    jest.spyOn(AppRoute, 'renderExtraRoutesOnly').mockReturnValue({
+      routes: <Route element={<NewComponent />} path="extra-route-only" />,
+      condition: true
+    })
+    const route = AppRoute()
+    expect(route).toMatchSnapshot()
+  })
+
+  it('should not have renderExtraRoutesOnly if condition is false', () => {
+    jest.spyOn(AppRoute, 'renderExtraRoutesOnly').mockReturnValue({
+      routes: <Route element={<NewComponent />} path="extra-route-only" />,
+      condition: false
+    })
+    const route = AppRoute()
+    expect(route).toMatchSnapshot()
+  })
 })

--- a/src/components/__snapshots__/AppRoute.spec.jsx.snap
+++ b/src/components/__snapshots__/AppRoute.spec.jsx.snap
@@ -509,3 +509,269 @@ exports[`App route should have renderExtraRoutes 1`] = `
   </Route>
 </Routes>
 `;
+
+exports[`App route should have renderExtraRoutesOnly if condition is true 1`] = `
+<Routes>
+  <Route
+    element={<withClient(UserActionRequired) />}
+  >
+    <Route
+      element={<NewComponent />}
+      path="extra-route-only"
+    />
+  </Route>
+</Routes>
+`;
+
+exports[`App route should not have renderExtraRoutesOnly if condition is false 1`] = `
+<Routes>
+  <Route
+    element={<withClient(UserActionRequired) />}
+  >
+    <Route
+      element={<withQuery(App) />}
+      path="/"
+    >
+      <Route
+        element={
+          <Navigate
+            replace={true}
+            to="balances"
+          />
+        }
+        index={true}
+      />
+      <Route
+        path="balances"
+      >
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <BalanceWithBanksJobs />
+            </ScrollToTopOnMountWrapper>
+          }
+          index={true}
+        />
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <Memo(Connect(RawBalanceDetailsPage)) />
+            </ScrollToTopOnMountWrapper>
+          }
+          path="details"
+        />
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <PlannedTransactionsPage
+                emptyIcon="cozy"
+              />
+            </ScrollToTopOnMountWrapper>
+          }
+          path="future"
+        />
+        <Route
+          element={<SetFilterAndRedirect />}
+          path=":accountOrGroupId/:page"
+        />
+      </Route>
+      <Route
+        element={
+          <Navigate
+            replace={true}
+            to="../analysis/categories"
+          />
+        }
+        path="categories/*"
+      />
+      <Route
+        element={
+          <Navigate
+            replace={true}
+            to="../analysis/recurrence"
+          />
+        }
+        path="recurrence/*"
+      />
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <AnalysisPage />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="analysis"
+      >
+        <Route
+          path="categories"
+        >
+          <Route
+            element={
+              <ScrollToTopOnMountWrapper>
+                <Unknown />
+              </ScrollToTopOnMountWrapper>
+            }
+            index={true}
+          />
+          <Route
+            element={
+              <ScrollToTopOnMountWrapper>
+                <Unknown />
+              </ScrollToTopOnMountWrapper>
+            }
+            path=":categoryName"
+          />
+          <Route
+            element={
+              <ScrollToTopOnMountWrapper>
+                <Unknown />
+              </ScrollToTopOnMountWrapper>
+            }
+            path=":categoryName/:subcategoryName"
+          />
+        </Route>
+        <Route
+          path="recurrence"
+        >
+          <Route
+            element={
+              <ScrollToTopOnMountWrapper>
+                <withError(RecurrencesPage) />
+              </ScrollToTopOnMountWrapper>
+            }
+            index={true}
+          />
+          <Route
+            element={
+              <ScrollToTopOnMountWrapper>
+                <RecurrencePage />
+              </ScrollToTopOnMountWrapper>
+            }
+            path=":bundleId"
+          />
+        </Route>
+      </Route>
+      <Route
+        path="settings"
+      >
+        <Route
+          element={
+            <Navigate
+              replace={true}
+              to="../export"
+            />
+          }
+          path="configuration/export"
+        />
+        <Route
+          element={<Export />}
+          path="export"
+        />
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <Settings
+                delayContent={0}
+              />
+            </ScrollToTopOnMountWrapper>
+          }
+        >
+          <Route
+            element={<Unknown />}
+            index={true}
+          />
+          <Route
+            element={<Memo(AccountsSettings) />}
+            path="accounts"
+          />
+          <Route
+            element={<withQuery(withQuery(Groups)) />}
+            path="groups"
+          />
+          <Route
+            element={<TagsSettings />}
+            path="tags"
+          />
+          <Route
+            element={<Unknown />}
+            path="configuration"
+          />
+        </Route>
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <Memo(NewGroupSettings) />
+            </ScrollToTopOnMountWrapper>
+          }
+          path="groups/new"
+        />
+        <Route
+          element={
+            <ScrollToTopOnMountWrapper>
+              <Memo(ExistingGroupSettings) />
+            </ScrollToTopOnMountWrapper>
+          }
+          path="groups/:groupId"
+        />
+        <Route
+          element={
+            <Navigate
+              replace={true}
+              to="../accounts"
+            />
+          }
+          path="accounts/:accountId"
+        />
+      </Route>
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <TagPage />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="tag/:tagId"
+      />
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <Unknown />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="transfers"
+      />
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <SearchPage />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="search"
+      />
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <SearchPage />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="search/:search"
+      />
+      <Route
+        element={
+          <ScrollToTopOnMountWrapper>
+            <DebugRecurrencePage />
+          </ScrollToTopOnMountWrapper>
+        }
+        path="recurrencedebug"
+      />
+      <Route
+        element={
+          <Navigate
+            replace={true}
+            to="balances"
+          />
+        }
+        path="*"
+      />
+    </Route>
+  </Route>
+</Routes>
+`;


### PR DESCRIPTION
The best approach for this new method is the following, because we don't want to access the original routes and we want to be able to render a component on a url that could conflict with original routes

First implementation: https://github.com/cozy/cozy-banks/pull/2618/commits/9fe4166fc0f5919a9fbb0d6a49e8a08fa2e5280e
