### PR TITLE
deps: Remove cozy-stack-client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "cozy-konnector-libs": "4.44.0",
     "cozy-logger": "^1.9.0",
     "cozy-notifications": "0.12.0",
-    "cozy-pouch-link": "35.3.1",
+    "cozy-pouch-link": "35.6.0",
     "cozy-realtime": "4.2.9",
     "cozy-scripts": "6.3.0",
     "cozy-sharing": "3.12.2",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
     "cozy-realtime": "4.2.9",
     "cozy-scripts": "6.3.0",
     "cozy-sharing": "3.12.2",
-    "cozy-stack-client": "35.3.1",
     "cozy-ui": "^79.0.0",
     "d3": "5.11.0",
     "date-fns": "1.30.1",

--- a/renovate.json
+++ b/renovate.json
@@ -20,8 +20,7 @@
     {
       "packagePatterns": [
           "cozy-client",
-          "cozy-pouch-link",
-          "cozy-stack-client"
+          "cozy-pouch-link"
       ],
       "groupName": "cozy-client packages"
     },

--- a/src/ducks/account/services.spec.js
+++ b/src/ducks/account/services.spec.js
@@ -1,5 +1,5 @@
+import { createMockClient } from 'cozy-client'
 import { linkMyselfToAccounts, unlinkMyselfFromAccounts } from './services'
-import { createClientWithData } from 'test/client'
 import { ACCOUNT_DOCTYPE, CONTACT_DOCTYPE } from 'doctypes'
 import { fetchSettings } from 'ducks/settings/helpers'
 import get from 'lodash/get'
@@ -34,8 +34,8 @@ describe('linkMyselfToAccounts', () => {
         }
       ]
 
-      const client = createClientWithData({
-        data: {
+      const client = createMockClient({
+        remote: {
           [ACCOUNT_DOCTYPE]: accounts
         }
       })
@@ -62,8 +62,8 @@ describe('linkMyselfToAccounts', () => {
         }
       ]
 
-      const client = createClientWithData({
-        data: {
+      const client = createMockClient({
+        remote: {
           [ACCOUNT_DOCTYPE]: accounts
         }
       })
@@ -100,8 +100,8 @@ describe('unlinkMyselfToAccounts', () => {
       }
     ]
 
-    const client = createClientWithData({
-      data: {
+    const client = createMockClient({
+      remote: {
         [ACCOUNT_DOCTYPE]: accounts
       }
     })
@@ -136,8 +136,8 @@ describe('unlinkMyselfToAccounts', () => {
         }
       ]
 
-      const client = createClientWithData({
-        data: {
+      const client = createMockClient({
+        remote: {
           [ACCOUNT_DOCTYPE]: accounts
         }
       })

--- a/src/ducks/budgetAlerts/service.spec.js
+++ b/src/ducks/budgetAlerts/service.spec.js
@@ -1,5 +1,5 @@
-import CozyClient from 'cozy-client'
-import { createClientWithData } from 'test/client'
+import CozyClient, { createMockClient } from 'cozy-client'
+import { TRANSACTION_DOCTYPE } from 'doctypes'
 import fixture from 'test/fixtures/unit-tests.json'
 import { runCategoryBudgetService } from './service'
 import {
@@ -42,9 +42,9 @@ beforeEach(() => {
 describe('service', () => {
   const setup = ({ budgetAlerts, expenses }) => {
     fetchCategoryAlerts.mockReturnValue(budgetAlerts)
-    const client = createClientWithData({
-      data: {
-        'io.cozy.bank.operations': expenses
+    const client = createMockClient({
+      remote: {
+        [TRANSACTION_DOCTYPE]: expenses
       },
       clientOptions: {
         uri: 'https://test.mycozy.cloud'

--- a/src/ducks/filters/index.spec.js
+++ b/src/ducks/filters/index.spec.js
@@ -206,7 +206,7 @@ describe('filter selectors', () => {
     getTransactions.mockReturnValue(docStore['io.cozy.bank.operations'])
     getAccounts.mockReturnValue(docStore[ACCOUNT_DOCTYPE])
     getAllGroups.mockReturnValue(docStore['io.cozy.bank.groups'])
-    // TODO use createClientWithData instead of mocked selectors
+    // TODO use createMockClient instead of mocked selectors
     getGroupsById.mockReturnValue(keyBy(docStore['io.cozy.bank.groups'], '_id'))
     getAccountsById.mockReturnValue(
       keyBy(docStore['io.cozy.bank.accounts'], '_id')

--- a/src/ducks/groups/services.spec.js
+++ b/src/ducks/groups/services.spec.js
@@ -1,14 +1,14 @@
 import { createAutoGroups, removeDuplicateAccountsFromGroups } from './services'
-import { createClientWithData } from 'test/client'
+import { createMockClient } from 'cozy-client'
 import { GROUP_DOCTYPE, ACCOUNT_DOCTYPE, schema } from 'doctypes'
 import { fetchSettings } from 'ducks/settings/helpers'
 
 jest.mock('ducks/settings/helpers')
 
 describe('createAutoGroups', () => {
-  const setup = ({ data, processedAccounts }) => {
-    const client = createClientWithData({
-      data,
+  const setup = ({ remote, processedAccounts }) => {
+    const client = createMockClient({
+      remote,
       clientOptions: { schema }
     })
 
@@ -27,7 +27,7 @@ describe('createAutoGroups', () => {
   describe('when the automatic group does not exist', () => {
     it('should create a new automatic group', async () => {
       const { client, settings } = setup({
-        data: {
+        remote: {
           [ACCOUNT_DOCTYPE]: [{ _id: 'a1', type: 'Checkings' }]
         },
         processedAccounts: []
@@ -51,7 +51,7 @@ describe('createAutoGroups', () => {
   describe('when the automatic group already exists', () => {
     it('should add accounts to the existing group', async () => {
       const { client, settings } = setup({
-        data: {
+        remote: {
           [GROUP_DOCTYPE]: [
             {
               _id: 'checkings_auto',
@@ -85,7 +85,7 @@ describe('createAutoGroups', () => {
   describe('duplicate accounts removal', () => {
     it('should remove duplicate accounts from an existing group', async () => {
       const { client } = setup({
-        data: {
+        remote: {
           [GROUP_DOCTYPE]: [
             {
               _id: 'checkings_auto',

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertCard.spec.jsx
@@ -1,7 +1,7 @@
 import { mount } from 'enzyme'
 import React from 'react'
+import { createMockClient } from 'cozy-client'
 import AppLike from 'test/AppLike'
-import { createClientWithData } from 'test/client'
 import CategoryAlertCard from './CategoryAlertCard'
 import getClient from 'selectors/getClient'
 import { GROUP_DOCTYPE } from 'doctypes'
@@ -18,7 +18,7 @@ describe('category alert card', () => {
         _id: 'group1337'
       }
     }
-    const client = createClientWithData({
+    const client = createMockClient({
       queries: {
         groups: {
           doctype: GROUP_DOCTYPE,

--- a/src/ducks/settings/CategoryAlerts/CategoryAlertEditModal.spec.jsx
+++ b/src/ducks/settings/CategoryAlerts/CategoryAlertEditModal.spec.jsx
@@ -1,10 +1,10 @@
 import { mount } from 'enzyme'
 import React from 'react'
+import { createMockClient } from 'cozy-client'
 import CategoryAlertEditModal from './CategoryAlertEditModal'
 import AccountIcon from 'components/AccountIcon'
 import fixtures from 'test/fixtures/unit-tests.json'
 import getClient from 'selectors/getClient'
-import { createClientWithData } from 'test/client'
 import Input from 'cozy-ui/transpiled/react/Input'
 import { ACCOUNT_DOCTYPE } from 'doctypes'
 import AppLike from 'test/AppLike'
@@ -16,7 +16,7 @@ jest.mock('components/AccountIcon', () => () => null)
 describe('category alert edition modal', () => {
   let client
   beforeEach(() => {
-    client = createClientWithData({
+    client = createMockClient({
       queries: {
         accounts: {
           data: fixtures[ACCOUNT_DOCTYPE],

--- a/src/ducks/settings/helpers.spec.jsx
+++ b/src/ducks/settings/helpers.spec.jsx
@@ -3,8 +3,7 @@ import { mount } from 'enzyme'
 import fixtures from 'test/fixtures/unit-tests.json'
 import { ACCOUNT_DOCTYPE, GROUP_DOCTYPE, SETTINGS_DOCTYPE } from 'doctypes'
 import AppLike from 'test/AppLike'
-import CozyClient from 'cozy-client'
-import { createClientWithData } from 'test/client'
+import CozyClient, { createMockClient } from 'cozy-client'
 
 import {
   fetchSettings,
@@ -44,7 +43,7 @@ describe('defaulted settings', () => {
 
 describe('withAccountOrGroupLabeller', () => {
   const setup = ({ accountOrGroup }) => {
-    const client = createClientWithData({
+    const client = createMockClient({
       queries: {
         groups: {
           doctype: GROUP_DOCTYPE,

--- a/src/ducks/transactions/TransactionModal/TransactionModal.spec.jsx
+++ b/src/ducks/transactions/TransactionModal/TransactionModal.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { render, fireEvent, within } from '@testing-library/react'
 import Alerter from 'cozy-ui/transpiled/react/Alerter'
 import { format } from 'date-fns'
+import { createMockClient } from 'cozy-client'
 
 import AppLike from 'test/AppLike'
-import { createClientWithData } from 'test/client'
 import { ACCOUNT_DOCTYPE, TRANSACTION_DOCTYPE } from 'doctypes'
 import { TrackerProvider, trackPage } from 'ducks/tracking/browser'
 import { getTracker } from 'ducks/tracking/tracker'
@@ -44,7 +44,7 @@ jest.mock('ducks/transactions/helpers', () => ({
 describe('transaction modal', () => {
   let client
   beforeEach(() => {
-    client = createClientWithData({
+    client = createMockClient({
       queries: {
         transactions: {
           doctype: TRANSACTION_DOCTYPE,

--- a/src/ducks/transactions/helpers.spec.js
+++ b/src/ducks/transactions/helpers.spec.js
@@ -21,10 +21,9 @@ import {
   schema
 } from 'doctypes'
 import MockDate from 'mockdate'
-import CozyClient from 'cozy-client'
+import CozyClient, { createMockClient } from 'cozy-client'
 import logger from 'cozy-client/dist/logger'
 
-import { createClientWithData } from 'test/client'
 import { getCategoryIdFromName } from 'ducks/categories/helpers'
 
 // eslint-disable-next-line no-console
@@ -55,7 +54,7 @@ describe('reimbursements', () => {
     transaction.reimbursements.data[0].bill
 
   beforeEach(() => {
-    client = createClientWithData({
+    client = createMockClient({
       queries: {
         bills: {
           doctype: BILLS_DOCTYPE,

--- a/test/client.js
+++ b/test/client.js
@@ -1,7 +1,5 @@
-import CozyClient, { Q } from 'cozy-client'
+import CozyClient from 'cozy-client'
 import { schema } from 'doctypes'
-import { receiveQueryResult, initQuery } from 'cozy-client/dist/store'
-import { normalizeDoc } from 'cozy-stack-client/dist/DocumentCollection'
 
 const defaultOptions = {
   uri: 'http://cozy.works:8080',
@@ -30,35 +28,6 @@ export const getClient = ({ uri, token, fetchJSONReturn } = defaultOptions) => {
     }
   }
   client.chain = mkFakeChain()
-  return client
-}
-
-export const createClientWithData = ({ queries, data, clientOptions }) => {
-  const client = new CozyClient(clientOptions || {})
-  client.ensureStore()
-  for (let [queryName, queryOptions] of Object.entries(queries || {})) {
-    client.store.dispatch(
-      initQuery(queryName, queryOptions.definition || Q(queryOptions.doctype))
-    )
-    client.store.dispatch(
-      receiveQueryResult(queryName, {
-        data: queryOptions.data.map(doc =>
-          normalizeDoc(doc, queryOptions.doctype)
-        )
-      })
-    )
-  }
-  client.query = jest.fn().mockImplementation(qdef => {
-    if (data[qdef.doctype]) {
-      return { data: data[qdef.doctype] }
-    } else {
-      return { data: [] }
-    }
-  })
-
-  client.save = jest.fn()
-  client.stackClient.fetchJSON = jest.fn()
-
   return client
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5223,7 +5223,7 @@ cozy-client-js@^0.19.0:
     pouchdb-browser "7.0.0"
     pouchdb-find "7.0.0"
 
-cozy-client@35.6.0:
+cozy-client@35.6.0, cozy-client@^35.6.0:
   version "35.6.0"
   resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.6.0.tgz#f052a020f9f3bf19a85448d72c38d182c08e8da3"
   integrity sha512-kDmUXWC9tV+vgqixhKigpnb8AmNUzZLgP6tF8SW5O50/TlORHLVvNlLg63m40ApDSMK1TaCFe+zSkYnF6/ojMQ==
@@ -5273,31 +5273,6 @@ cozy-client@^23.18.0:
     server-destroy "^1.0.1"
     sift "^6.0.0"
     url-search-params-polyfill "^7.0.0"
-
-cozy-client@^35.3.1:
-  version "35.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-client/-/cozy-client-35.3.1.tgz#06b1e0309d29ac37686bd4f49d8b977090875f4c"
-  integrity sha512-aXRA4Nw/hdrLVHk3Zd1K0yMw416Zt6DTtgSCzsq75gUgtd9m+fTw65a5Tk4eiPM3NDfHgrwIPyCOmuqxiqnr1g==
-  dependencies:
-    "@cozy/minilog" "1.0.0"
-    "@types/jest" "^26.0.20"
-    "@types/lodash" "^4.14.170"
-    btoa "^1.2.1"
-    cozy-stack-client "^35.3.1"
-    date-fns "2.29.3"
-    json-stable-stringify "^1.0.1"
-    lodash "^4.17.13"
-    microee "^0.0.6"
-    node-fetch "^2.6.1"
-    node-polyglot "2.4.2"
-    open "7.4.2"
-    prop-types "^15.6.2"
-    react-redux "^7.2.0"
-    redux "3 || 4"
-    redux-thunk "^2.3.0"
-    server-destroy "^1.0.1"
-    sift "^6.0.0"
-    url-search-params-polyfill "^8.0.0"
 
 cozy-client@^6.58.0:
   version "6.66.0"
@@ -5582,12 +5557,12 @@ cozy-notifications@0.12.0:
     mjml "4.3.1"
     word-wrap "^1.2.3"
 
-cozy-pouch-link@35.3.1:
-  version "35.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-35.3.1.tgz#c2020b466a4c5fb76c07ca56db24f9c6d7f7a0cb"
-  integrity sha512-CcJriGt9L1OeAnlfJ6FDKMauJ3e5yq6OhTxg5G/fjxscqZgYweK/MCpAVOtTb+550DkeeU3VC9aM+k3eS/aZuQ==
+cozy-pouch-link@35.6.0:
+  version "35.6.0"
+  resolved "https://registry.yarnpkg.com/cozy-pouch-link/-/cozy-pouch-link-35.6.0.tgz#ea271d14c2f71b3ef5e1e53afce524c2ff1e1095"
+  integrity sha512-V7LIA1oH2PIITDePczs55iKS19ypGH/XgCYka1KhhKu6cmX+yXluFbq6l6+DT2Z9Eg4EO+Hug/xq4snm6K+p9w==
   dependencies:
-    cozy-client "^35.3.1"
+    cozy-client "^35.6.0"
     pouchdb-browser "^7.2.2"
     pouchdb-find "^7.2.2"
 
@@ -5687,15 +5662,6 @@ cozy-stack-client@^23.19.0:
   integrity sha512-oq7/ERKy/Gg3jnxSi0rs3upvBccsGmmfdMiIa9hhJcw/Vxl7NMmjUM2itPnfmBNAMfBax6VlB8HWI1LY87fLuw==
   dependencies:
     cozy-flags "2.7.1"
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
-cozy-stack-client@^35.3.1:
-  version "35.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-35.3.1.tgz#9eecb60ffea54c5106f5fd9be1832eb9007164ac"
-  integrity sha512-bHTXhufKuWDSH6jTpRynek+REOuYJjVd4QSxNwVcsbk6bHGvSGnpIFQaKRNKep9lbemRLA9SObCLGzE/7rl7YA==
-  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5681,21 +5681,21 @@ cozy-sharing@3.12.2:
     react-tooltip "^3.11.1"
     snarkdown "^2.0.0"
 
-cozy-stack-client@35.3.1, cozy-stack-client@^35.3.1:
-  version "35.3.1"
-  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-35.3.1.tgz#9eecb60ffea54c5106f5fd9be1832eb9007164ac"
-  integrity sha512-bHTXhufKuWDSH6jTpRynek+REOuYJjVd4QSxNwVcsbk6bHGvSGnpIFQaKRNKep9lbemRLA9SObCLGzE/7rl7YA==
-  dependencies:
-    detect-node "^2.0.4"
-    mime "^2.4.0"
-    qs "^6.7.0"
-
 cozy-stack-client@^23.19.0:
   version "23.19.0"
   resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-23.19.0.tgz#2972c3dcc151b13c0f65749f341a6349170fe1d3"
   integrity sha512-oq7/ERKy/Gg3jnxSi0rs3upvBccsGmmfdMiIa9hhJcw/Vxl7NMmjUM2itPnfmBNAMfBax6VlB8HWI1LY87fLuw==
   dependencies:
     cozy-flags "2.7.1"
+    detect-node "^2.0.4"
+    mime "^2.4.0"
+    qs "^6.7.0"
+
+cozy-stack-client@^35.3.1:
+  version "35.3.1"
+  resolved "https://registry.yarnpkg.com/cozy-stack-client/-/cozy-stack-client-35.3.1.tgz#9eecb60ffea54c5106f5fd9be1832eb9007164ac"
+  integrity sha512-bHTXhufKuWDSH6jTpRynek+REOuYJjVd4QSxNwVcsbk6bHGvSGnpIFQaKRNKep9lbemRLA9SObCLGzE/7rl7YA==
+  dependencies:
     detect-node "^2.0.4"
     mime "^2.4.0"
     qs "^6.7.0"


### PR DESCRIPTION
`cozy-stack-client` comes with `cozy-client` and declaring a direct
dependency to it means we need to keep it up-to-date with
`cozy-client`.
Removing this dependency simplifies `cozy-client` upgrades.

To this end, we need to remove all direct usage of `cozy-stack-client`
so we replace our own `createClientWithData` with `createMockClient`
from `cozy-client` as they serve the same purpose.

We take the opportunity to bump `cozy-pouch-link` to keep it up-to-date
and remove outdated versions of `cozy-client` and `cozy-stack-client`
from the bundle.

This should also fix an issue in the export page which requires 
`cozy-stack-client` v35.6.0.

```
### 🐛 Bug Fixes

* The export page can now request queued and running export service jobs

### 🔧 Tech

* Remove direct dependency to `cozy-stack-client`
* Bump `cozy-stack-client` from 35.3.1 to 35.6.0
* Bump `cozy-pouch-link` from 35.3.1 to 35.6.0
```