### PR TITLE
fix: Create proper in-progress export jobs query

### DIFF
--- a/src/ducks/export/helpers.js
+++ b/src/ducks/export/helpers.js
@@ -10,16 +10,16 @@ import { JOBS_DOCTYPE } from 'doctypes'
 export const isExportJobInProgress = async client => {
   const { data } = await client.query(
     Q(JOBS_DOCTYPE)
-      .where({
+      .partialIndex({
         worker: 'service',
         message: {
           slug: 'banks',
           name: 'export'
-        }
-      })
-      .partialIndex({
+        },
         $or: [{ state: 'queued' }, { state: 'running' }]
       })
+      .indexFields(['worker'])
+      .sortBy([{ worker: 'asc' }]) // XXX: forces CouchDB to require an index for the query
       .limitBy(1)
   )
 


### PR DESCRIPTION
We have 2 issues with the current in-progress export jobs query:
- not setting the indexed fields ourselves is not compatible with the 
  use of an `$or` operator (see 
  https://github.com/cozy/cozy-client/issues/1270)
- the index is not created if there are too many jobs in the db

Luckily these can be fixed by using the `indexFields()` and `sortBy()` 
method of `cozy-client`'s `QueryDefinition` object.
See the commits messages for more details.

```
### 🐛 Bug Fixes

* Create proper, optimized query for in-progress export jobs
```
