### PR TITLE
feat: Add CSV import service

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -107,8 +107,12 @@
     "export": {
       "type": "node",
       "file": "export.js",
-      "comment": "This service must be called programmatically from Banks.",
-      "debounce": "5m"
+      "comment": "This service must be called programmatically from Banks."
+    },
+    "import": {
+      "type": "node",
+      "file": "import.js",
+      "comment": "This service must be called programmatically from Banks."
     }
   },
   "notifications": {

--- a/src/ducks/import/helpers.js
+++ b/src/ducks/import/helpers.js
@@ -1,0 +1,61 @@
+import get from 'lodash/get'
+import isEqual from 'lodash/isEqual'
+import keyBy from 'lodash/keyBy'
+import merge from 'lodash/merge'
+import set from 'lodash/set'
+import uniqWith from 'lodash/uniqWith'
+
+export const fullDateStr = dateStr => (dateStr ? `${dateStr}T12:00:00Z` : '')
+
+export const withExistingDocIds = (
+  docsToSave,
+  { existingDocs, matchingProperty }
+) => {
+  return docsToSave.map(doc => {
+    const existingDoc = existingDocs.find(
+      existingDoc => existingDoc[matchingProperty] === doc[matchingProperty]
+    )
+    if (existingDoc) {
+      return { ...doc, _id: existingDoc._id, _rev: existingDoc._rev }
+    }
+    return doc
+  })
+}
+
+export const reconciliate = (newDocs, existingDocs, idFn) => {
+  const reconciliatedById = keyBy(existingDocs, idFn)
+
+  for (const attributes of newDocs) {
+    const id = idFn(attributes)
+    reconciliatedById[id] = merge(reconciliatedById[id], attributes)
+  }
+
+  return Object.values(reconciliatedById)
+}
+
+export const addRelationship = (doc, relationshipName, definition) => {
+  const isArray = Array.isArray(definition)
+  const relationship = ['relationships', relationshipName, 'data']
+
+  const existingRelationship = get(doc, relationship, [])
+  const newRelationship = isArray
+    ? uniqWith(
+        existingRelationship.concat(
+          definition.map(({ _id, _type }) => ({ _id, _type }))
+        ),
+        isEqual
+      )
+    : { _id: definition._id, _type: definition._type }
+
+  set(doc, relationship, newRelationship)
+}
+
+const TODAY = new Date().toISOString()
+
+const ensureMetadata = doc =>
+  doc.metadata
+    ? doc
+    : { ...doc, metadata: { dateImport: TODAY, vendor: 'cozy' } }
+
+export const withMetadata = client => doc =>
+  ensureMetadata(client.ensureCozyMetadata(doc))

--- a/src/ducks/import/queries.js
+++ b/src/ducks/import/queries.js
@@ -1,0 +1,49 @@
+import { Q } from 'cozy-client'
+
+import {
+  ACCOUNT_DOCTYPE,
+  FILES_DOCTYPE,
+  RECURRENCE_DOCTYPE,
+  TAGS_DOCTYPE,
+  TRANSACTION_DOCTYPE
+} from 'doctypes'
+
+export const fetchContentToImport = async (client, fileId) => {
+  return client.collection(FILES_DOCTYPE).fetchFileContentById(fileId)
+}
+
+/**
+ * Fetch all transactions and associated data.
+ *
+ * @param {CozyClient} client A CozyClient instance
+ *
+ * @return {Promise<Array<BankTransaction>>} Promise that resolves with an array of io.cozy.bank.operations documents
+ */
+export const fetchExistingTransactions = async client => {
+  const transactions = await client.queryAll(
+    Q(TRANSACTION_DOCTYPE)
+      .include(['account', 'recurrence', 'tags'])
+      .limitBy(1000)
+  )
+  return client.hydrateDocuments(TRANSACTION_DOCTYPE, transactions)
+}
+
+export const fetchExistingAccounts = async client => {
+  return client.queryAll(Q(ACCOUNT_DOCTYPE).limitBy(1000))
+}
+
+export const fetchExistingRecurrences = async client => {
+  return client.queryAll(Q(RECURRENCE_DOCTYPE).limitBy(1000))
+}
+
+export const fetchExistingTags = async client => {
+  return client.queryAll(Q(TAGS_DOCTYPE).limitBy(1000))
+}
+
+export const saveAll = async (client, docs) => {
+  if (docs.length > 0) {
+    const { data } = await client.saveAll(docs)
+    return data
+  }
+  return []
+}

--- a/src/ducks/import/services.js
+++ b/src/ducks/import/services.js
@@ -1,0 +1,464 @@
+import { parse } from '@fast-csv/parse'
+import compact from 'lodash/compact'
+import keyBy from 'lodash/keyBy'
+import merge from 'lodash/merge'
+import uniq from 'lodash/uniq'
+import { BankAccount, BankTransaction } from 'cozy-doctypes'
+
+import {
+  ACCOUNT_DOCTYPE,
+  RECURRENCE_DOCTYPE,
+  TAGS_DOCTYPE,
+  TRANSACTION_DOCTYPE
+} from 'doctypes'
+import { NOT_RECURRENT_ID } from 'ducks/recurrence/constants'
+import { getCategoryIdFromName } from 'ducks/categories/categoriesMap'
+import { getLabel as getTransactionLabel } from 'ducks/transactions/helpers'
+import {
+  addRelationship,
+  fullDateStr,
+  reconciliate,
+  withExistingDocIds,
+  withMetadata
+} from './helpers'
+import { saveAll } from './queries'
+
+/* ------ CSV Parsing ------ */
+
+const accountId = ({ institutionLabel, number, label, type }) =>
+  number || `${institutionLabel}/${label}/${type}`
+
+const buildAccount = (
+  accountsById,
+  {
+    accountBalance,
+    accountComingBalance,
+    accountCustomName,
+    accountIban,
+    accountName,
+    accountNumber,
+    accountOriginalNumber,
+    accountType,
+    accountVendorDeleted,
+    currency,
+    institutionLabel,
+    vendorAccountId
+  }
+) => {
+  const id = accountId({
+    institutionLabel,
+    number: accountNumber,
+    label: accountName,
+    type: accountType
+  })
+
+  if (accountsById[id] == null) {
+    accountsById[id] = {
+      _type: ACCOUNT_DOCTYPE,
+      institutionLabel,
+      label: accountName,
+      shortLabel: accountCustomName,
+      number: accountNumber,
+      originalNumber: accountOriginalNumber,
+      type: accountType,
+      currency,
+      balance: Number(accountBalance),
+      comingBalance: Number(accountComingBalance),
+      iban: accountIban,
+      vendorDeleted: accountVendorDeleted,
+      vendorId: vendorAccountId
+    }
+  }
+
+  return accountsById[id]
+}
+
+const recurrenceId = ({ automaticLabel, manualLabel }) =>
+  manualLabel || automaticLabel
+
+const buildReccurence = (
+  recurrencesById,
+  {
+    amount,
+    categoryName,
+    date,
+    label,
+    recurrent,
+    recurrenceName,
+    recurrenceFrequency,
+    recurrenceStatus
+  },
+  { account }
+) => {
+  if (recurrent === 'yes') {
+    const associatedAccountId = accountId(account)
+    const automaticLabel = getTransactionLabel({ label })
+    const manualLabel = recurrenceName
+    const id = recurrenceId({ automaticLabel, manualLabel })
+
+    if (recurrencesById[id] == null) {
+      recurrencesById[id] = {
+        _type: RECURRENCE_DOCTYPE,
+        status: recurrenceStatus,
+        categoryIds: [getCategoryIdFromName(categoryName)],
+        accounts: [], // XXX: Will be populated after accounts have been saved
+        amounts: [amount],
+        automaticLabel: automaticLabel,
+        manualLabel: automaticLabel !== manualLabel ? manualLabel : undefined,
+        latestDate: fullDateStr(date),
+        latestAmount: amount,
+        stats: {
+          deltas: { median: Number(recurrenceFrequency) || 0 }
+        },
+        accountIds: [associatedAccountId]
+      }
+    } else {
+      const recurrence = recurrencesById[id]
+
+      recurrence.categoryIds = uniq(
+        recurrence.categoryIds.concat(getCategoryIdFromName(categoryName))
+      )
+      recurrence.amounts = uniq(recurrence.amounts.concat(amount))
+      recurrence.accountIds = uniq(
+        recurrence.accountIds.concat(associatedAccountId)
+      )
+
+      const { latestDate } = recurrence
+      const dateStr = fullDateStr(date)
+
+      if (latestDate < dateStr) {
+        recurrence.latestAmount = amount
+        recurrence.latestDate = dateStr
+      }
+    }
+
+    return recurrencesById[id]
+  } else if (recurrent === 'no') {
+    return {
+      _id: NOT_RECURRENT_ID,
+      _type: RECURRENCE_DOCTYPE
+    }
+  }
+
+  return
+}
+
+const tagId = tag => tag.label
+
+const buildTags = (tagsById, tagList) => {
+  return tagList.map(label => {
+    const id = tagId({ label })
+
+    if (tagsById[id] == null) {
+      tagsById[id] = {
+        _type: TAGS_DOCTYPE,
+        label
+      }
+    }
+
+    return tagsById[id]
+  })
+}
+
+const transactionId = ({ linxoId, vendorId }) => vendorId || linxoId
+
+const buildTransaction = (
+  transactionsById,
+  data,
+  { account, recurrence, tags }
+) => {
+  const {
+    amount,
+    applicationDate,
+    categoryName,
+    currency,
+    date,
+    isComing,
+    label,
+    originalBankLabel,
+    realisationDate,
+    reimbursementStatus,
+    type,
+    valueDate,
+    vendorTransactionId,
+    vendorAccountId
+  } = data
+
+  const id = transactionId({ vendorId: vendorTransactionId })
+
+  if (transactionsById[id] == null) {
+    const categoryId = getCategoryIdFromName(categoryName)
+    transactionsById[id] = {
+      _type: TRANSACTION_DOCTYPE,
+      date: fullDateStr(date),
+      realisationDate: fullDateStr(realisationDate),
+      applicationDate: fullDateStr(applicationDate),
+      valueDate: fullDateStr(valueDate),
+      isComing: isComing === 'yes',
+      label,
+      originalBankLabel,
+      cozyCategoryId: categoryId,
+      automaticCategoryId: categoryId,
+      amount: Number(amount),
+      currency,
+      type,
+      reimbursementStatus,
+      accountId: account ? accountId(account) : '',
+      recurrenceId: recurrence ? recurrenceId(recurrence) : '',
+      tagIds: tags ? tags.map(tag => tagId(tag)) : [],
+      vendorId: vendorTransactionId,
+      vendorAccountId
+    }
+  }
+
+  return transactionsById[id]
+}
+
+const transformCSV =
+  ({ transactionsById, accountsById, recurrencesById, tagsById }) =>
+  data => {
+    // Filter lines containing only account information
+    if (data.label == '') {
+      return
+    }
+
+    const { tag1, tag2, tag3, tag4, tag5 } = data
+    const tagList = [tag1, tag2, tag3, tag4, tag5].filter(Boolean)
+
+    const account = buildAccount(accountsById, data)
+    const recurrence = buildReccurence(recurrencesById, data, { account })
+    const tags = buildTags(tagsById, tagList)
+    buildTransaction(transactionsById, data, { account, recurrence, tags })
+  }
+
+export const createParseStream = ({
+  transactionsById,
+  accountsById,
+  recurrencesById,
+  tagsById
+}) => {
+  return parse({
+    delimiter: ';',
+    trim: true,
+    ignoreEmpty: true,
+    discardUnmappedColumns: true,
+    renameHeaders: true,
+    headers: [
+      'date', // 'Date'
+      'realisationDate', // 'Realisation date'
+      'applicationDate', // 'Assigned date'
+      'label', // 'Label'
+      'originalBankLabel', // 'Original bank label'
+      'categoryName', // 'Category name'
+      'amount', // 'Amount'
+      'currency', // 'Currency'
+      'type', // 'Type'
+      'isComing', // 'Expected?'
+      'valueDate', // 'Expected debit date'
+      'reimbursementStatus', // 'Reimbursement status'
+      'institutionLabel', // 'Bank name'
+      'accountName', // 'Account name'
+      'accountCustomName', // 'Custom account name'
+      'accountNumber', // 'Account number'
+      'accountOriginalNumber', // 'Account originalNumber'
+      'accountType', // 'Account type'
+      'accountBalance', // 'Account balance'
+      'accountComingBalance', // 'Account coming balance'
+      'accountIban', // Account IBAN
+      'accountVendorDeleted', // 'Account vendorDeleted'
+      'recurrent', // Recurrent?
+      'recurrenceName', // 'Recurrence name'
+      'recurrenceStatus', // 'Recurrence status'
+      'recurrenceFrequency', // 'Recurrence frequency'
+      'tag1', // 'Tag 1'
+      'tag2', // 'Tag 2'
+      'tag3', // 'Tag 3'
+      'tag4', // 'Tag 4'
+      'tag5', // 'Tag 5'
+      'vendorTransactionId', // 'Unique ID'
+      'vendorAccountId' // 'Unique account ID'
+    ]
+  }).transform(
+    transformCSV({
+      transactionsById,
+      accountsById,
+      recurrencesById,
+      tagsById
+    })
+  )
+}
+
+/* ------ Data reconciliation, transformation and saving ------ */
+
+export const saveMissingAccounts = async (
+  client,
+  accountsById,
+  { existingAccounts }
+) => {
+  const accounts = Object.values(accountsById)
+
+  const reconciliatedAccounts = BankAccount.reconciliate(
+    accounts,
+    existingAccounts
+  )
+
+  const accountsToSave = withExistingDocIds(reconciliatedAccounts, {
+    existingDocs: existingAccounts,
+    matchingProperty: '_id'
+  }).map(withMetadata(client))
+
+  const savedAccounts = await saveAll(client, accountsToSave)
+
+  return keyBy(savedAccounts, accountId)
+}
+
+const withSavedAccounts = (recurrence, { existingAccountsById }) => {
+  const { accounts, accountIds, ...data } = recurrence
+
+  if (!accountIds || accountIds?.length === 0) {
+    return recurrence
+  }
+
+  const newAccounts = compact(
+    accountIds.map(id => existingAccountsById[id]?._id)
+  )
+
+  return {
+    ...data,
+    accounts: uniq(accounts.concat(newAccounts))
+  }
+}
+
+export const saveMissingRecurrences = async (
+  client,
+  recurrencesById,
+  { existingAccountsById, existingRecurrences }
+) => {
+  const recurrences = Object.values(recurrencesById)
+
+  const reconciliatedRecurrences = reconciliate(
+    recurrences,
+    existingRecurrences,
+    recurrenceId
+  )
+
+  // XXX: no need to call withExistingDocIds here since existing recurrences'
+  // `_id` and `_rev` are preserved by `reconciliate()`.
+  const recurrencesToSave = reconciliatedRecurrences.map(recurrence => {
+    if (recurrence._id === NOT_RECURRENT_ID) {
+      return recurrence
+    }
+
+    return withMetadata(client)(
+      withSavedAccounts(recurrence, { existingAccountsById })
+    )
+  })
+
+  const savedRecurrences = await saveAll(client, recurrencesToSave)
+
+  return keyBy(savedRecurrences, recurrenceId)
+}
+
+export const saveMissingTags = async (client, tagsById, { existingTags }) => {
+  const tags = Object.values(tagsById)
+
+  const reconciliatedTags = reconciliate(tags, existingTags, tagId)
+
+  // XXX: no need to call withExistingDocIds here since existing tags' `_id` and
+  // `_rev` are preserved by `reconciliate()`.
+  const tagsToSave = reconciliatedTags.map(withMetadata(client))
+
+  const savedTags = await saveAll(client, tagsToSave)
+
+  return keyBy(savedTags, tagId)
+}
+
+export const saveMissingTransactions = async (
+  client,
+  transactionsById,
+  { existingAccountsById, existingRecurrencesById, existingTransactions }
+) => {
+  const transactions = Object.values(transactionsById)
+
+  const reconciliatedTransactions = BankTransaction.reconciliate(
+    transactions,
+    existingTransactions
+  )
+
+  const transactionsToSave = withExistingDocIds(reconciliatedTransactions, {
+    existingDocs: existingTransactions,
+    matchingProperty: 'vendorId'
+  }).map(
+    // eslint-disable-next-line no-unused-vars
+    ({ accountId, recurrenceId, tagIds, ...data }) => {
+      const account = existingAccountsById[accountId]
+      const recurrence = existingRecurrencesById[recurrenceId]
+
+      const transaction = {
+        ...data,
+        account: account._id
+      }
+
+      if (recurrence) {
+        addRelationship(transaction, 'recurrence', recurrence)
+      }
+
+      return withMetadata(client)(transaction)
+    }
+  )
+
+  const savedTransactions = await saveAll(client, transactionsToSave)
+
+  // XXX: BankTransaction.reconciliate() does not return unchanged transactions
+  // so we need to merge them with the updated ones to have a map of all
+  // transactions.
+  return merge(
+    keyBy(existingTransactions, transactionId),
+    keyBy(savedTransactions, transactionId)
+  )
+}
+
+export const updateTagsRelationships = async (
+  client,
+  transactionsById,
+  { existingTagsById, existingTransactionsById }
+) => {
+  const transactionsToUpdate = {}
+  const tagsToUpdate = {}
+
+  for (const [transactionId, { tagIds }] of Object.entries(transactionsById)) {
+    if (tagIds.length === 0) {
+      continue
+    }
+
+    const transaction = existingTransactionsById[transactionId]
+
+    for (const id of tagIds) {
+      const tag = existingTagsById[id]
+
+      addRelationship(transaction, 'tags', [tag])
+      addRelationship(tag, 'transactions', [transaction])
+
+      if (tagsToUpdate[id] == null) {
+        tagsToUpdate[id] = tag
+      }
+    }
+
+    if (transactionsToUpdate[transactionId] == null) {
+      transactionsToUpdate[transactionId] = transaction
+    }
+  }
+
+  const updatedTransactions = await saveAll(
+    client,
+    Object.values(transactionsToUpdate)
+  )
+  updatedTransactions.map(transaction => {
+    existingTransactionsById[transactionId(transaction)] = transaction
+  })
+
+  const updatedTags = await saveAll(client, Object.values(tagsToUpdate))
+  updatedTags.map(tag => {
+    existingTagsById[tagId(tag)] = tag
+  })
+}

--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -14,6 +14,7 @@ import LegalMention from 'ducks/legal/LegalMention'
 import UnlinkIcon from 'cozy-ui/transpiled/react/Icons/Unlink'
 import { cronKonnectorTriggersConn } from 'doctypes'
 import AccountListItem from 'ducks/settings/AccountListItem'
+import { getAccountInstitutionLabel } from 'ducks/account/helpers'
 import { transformJobsToFakeAccounts } from './helpers/jobs'
 
 const { utils } = models
@@ -33,7 +34,7 @@ const { utils } = models
 const getConnectionIdFromAccount = account => {
   return account.connection && account.connection.raw
     ? account.connection.raw._id
-    : utils.getCreatedByApp(account)
+    : utils.getCreatedByApp(account) || getAccountInstitutionLabel(account)
 }
 
 const AccountsListSettings = ({

--- a/src/services/cli.js
+++ b/src/services/cli.js
@@ -7,6 +7,7 @@ import { ArgumentParser } from 'argparse'
 import { createClientInteractive } from 'cozy-client/dist/cli'
 import { schema } from 'doctypes'
 import runExportService from '../targets/services/export'
+import runImportService from '../targets/services/import'
 import runRecurrenceService from '../ducks/recurrence/service'
 import runKonnectorAlertsService from '../targets/services/konnectorAlerts'
 
@@ -15,6 +16,7 @@ global.__DEV__ = false
 
 const serviceEntrypoints = {
   export: runExportService,
+  import: runImportService,
   recurrence: runRecurrenceService,
   konnectorAlerts: runKonnectorAlertsService
 }

--- a/src/targets/services/import.js
+++ b/src/targets/services/import.js
@@ -1,0 +1,111 @@
+import stream from 'stream'
+import util from 'util'
+import flag from 'cozy-flags'
+
+import {
+  fetchContentToImport,
+  fetchExistingAccounts,
+  fetchExistingRecurrences,
+  fetchExistingTags,
+  fetchExistingTransactions
+} from 'ducks/import/queries'
+import {
+  createParseStream,
+  saveMissingAccounts,
+  saveMissingRecurrences,
+  saveMissingTags,
+  saveMissingTransactions,
+  updateTagsRelationships
+} from 'ducks/import/services'
+import logger from 'ducks/export/logger'
+import { runService } from './service'
+
+const pipeline = util.promisify(stream.pipeline)
+
+const main = async ({ client }) => {
+  if (require.main !== module && process.env.NODE_ENV !== 'production') {
+    client.registerPlugin(flag.plugin)
+    await client.plugins.flags.refresh()
+  }
+  if (!flag('banks.services.export.enabled')) {
+    logger(
+      'info',
+      'Bailing out of import service since flag "banks.services.export.enabled" is not set to `true`'
+    )
+    return
+  }
+
+  const { fileId } = JSON.parse(process.env.COZY_FIELDS)
+
+  logger('info', `Fetching content of file \`${fileId}\`...`)
+  const resp = await fetchContentToImport(client, fileId)
+
+  if (resp.status === 404) {
+    throw new Error('Missing file to import')
+  }
+
+  // Transform the transactions into a CSV file
+  logger('info', `Creating transformation stream...`)
+  const accountsById = {}
+  const transactionsById = {}
+  const recurrencesById = {}
+  const tagsById = {}
+  const parse = createParseStream({
+    accountsById,
+    recurrencesById,
+    tagsById,
+    transactionsById
+  })
+
+  logger('info', `Transforming CSV to data...`)
+  await pipeline(resp.body, parse)
+
+  logger('info', `Importing accounts...`)
+  const existingAccounts = await fetchExistingAccounts(client)
+  const existingAccountsById = await saveMissingAccounts(client, accountsById, {
+    existingAccounts
+  })
+
+  logger('info', `Importing recurrences...`)
+  const existingRecurrences = await fetchExistingRecurrences(client)
+  const existingRecurrencesById = await saveMissingRecurrences(
+    client,
+    recurrencesById,
+    {
+      existingAccountsById,
+      existingRecurrences
+    }
+  )
+
+  logger('info', `Importing tags...`)
+  const existingTags = await fetchExistingTags(client)
+  const existingTagsById = await saveMissingTags(client, tagsById, {
+    existingTags
+  })
+
+  logger('info', `Importing transactions...`)
+  const existingTransactions = await fetchExistingTransactions(client)
+  const existingTransactionsById = await saveMissingTransactions(
+    client,
+    transactionsById,
+    {
+      existingAccountsById,
+      existingRecurrencesById,
+      existingTransactions
+    }
+  )
+
+  logger('info', `Creating transactions-tags relationships...`)
+  await updateTagsRelationships(client, transactionsById, {
+    existingTagsById,
+    existingTransactionsById
+  })
+
+  logger('info', `Import success`)
+}
+
+if (require.main === module || process.env.NODE_ENV === 'production') {
+  runService(main)
+}
+
+export default main


### PR DESCRIPTION
This service, invoked programmatically with a `fileId` field, will
fetch the `fileId` file from the Cozy, parse it according to our CSV
schema and import the transactions, accounts, tags and recurrences it
contains.

Accounts without transactions won't be imported though as they're of
questionnable use (they're stale data).

If the Cozy already contains banking data, we'll try our best to
reconciliate the existing and new data to avoid duplicates and
recreate missing relationships.

We use `cozy-doctypes`' `BankAccount` and `BankTransaction`
reconciliation algorithms to make any debbuging easier but we had to
come up with our own reconciliation algorithms for tags and
recurrences (they're really simple though).

```
### ✨ Features

* Add CSV import service
* Allow grouping bank accounts by institution labels in Settings
```
