### PR TITLE
fix: Wording export title

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -620,7 +620,7 @@
       "in-maintenance": "En maintenance"
     },
     "export": {
-      "title": "Exportation des données",
+      "title": "Export des données",
       "description": {
         "ready": "Vos données sont prêtes :",
         "waiting": "Vos données sont en cours de préparation. Merci de patientez quelques instants"


### PR DESCRIPTION
Backport #2637 

```
### 🐛 Bug Fixes

* Wording on Export page
```
