### PR TITLE
fix: Pass appMetadata to client in services CLI

### DIFF
--- a/src/ducks/settings/AccountsListSettings.jsx
+++ b/src/ducks/settings/AccountsListSettings.jsx
@@ -19,6 +19,9 @@ import { transformJobsToFakeAccounts } from './helpers/jobs'
 
 const { utils } = models
 
+const wasImportedByBanks = account =>
+  account?.metadata?.dateImport != null && account?.metadata?.vendor === 'cozy'
+
 /**
  * Returns the connection id of an account
  *
@@ -34,7 +37,9 @@ const { utils } = models
 const getConnectionIdFromAccount = account => {
   return account.connection && account.connection.raw
     ? account.connection.raw._id
-    : utils.getCreatedByApp(account) || getAccountInstitutionLabel(account)
+    : wasImportedByBanks(account)
+    ? getAccountInstitutionLabel(account)
+    : utils.getCreatedByApp(account)
 }
 
 const AccountsListSettings = ({

--- a/src/services/cli.js
+++ b/src/services/cli.js
@@ -6,6 +6,7 @@ import path from 'path'
 import { ArgumentParser } from 'argparse'
 import { createClientInteractive } from 'cozy-client/dist/cli'
 import { schema } from 'doctypes'
+import appMetadata from 'ducks/client/appMetadata'
 import runExportService from '../targets/services/export'
 import runImportService from '../targets/services/import'
 import runRecurrenceService from '../ducks/recurrence/service'
@@ -48,6 +49,7 @@ const main = async () => {
     uri: args.url,
     scope: getScope(manifest),
     schema,
+    appMetadata,
     oauth: {
       softwareID: 'banks.service-cli'
     }


### PR DESCRIPTION
Backport of https://github.com/cozy/cozy-banks/pull/2639

```
### 🐛 Bug Fixes

* Bank accounts imported via the import service are grouped by their institution label in the Settings > Accounts tab

### 🔧 Tech

* Services launched via the CLI use a `CozyClient` instance with  `appMetadata`
```
