### PR TITLE
fix: Import accounts with a normalized number

### DIFF
--- a/src/ducks/import/services.js
+++ b/src/ducks/import/services.js
@@ -45,9 +45,11 @@ const buildAccount = (
     vendorAccountId
   }
 ) => {
+  const number = BankAccount.normalizeAccountNumber(accountNumber, accountIban)
+
   const id = accountId({
     institutionLabel,
-    number: accountNumber,
+    number,
     label: accountName,
     type: accountType
   })
@@ -58,7 +60,7 @@ const buildAccount = (
       institutionLabel,
       label: accountName,
       shortLabel: accountCustomName,
-      number: accountNumber,
+      number,
       originalNumber: accountOriginalNumber,
       type: accountType,
       currency,


### PR DESCRIPTION
In the import service, we need to index accounts (imported and
existing) so we can associate them with transactions.

We used the account number as key but saved accounts numbers are
normalized by `cozy-doctype`'s `BankAccount.reconciliate()` function
and are not necessarily equal to the originally imported number.

To prevent these differences and make sure accounts are found in the
index, we'll use the normalized form from the very beginning.

```
### 🐛 Bug Fixes

* Import accounts with a normalized number
```
