### PR TITLE
fix: Prevent fallback to existing jobs index

### DIFF
--- a/src/ducks/export/helpers.js
+++ b/src/ducks/export/helpers.js
@@ -18,8 +18,8 @@ export const isExportJobInProgress = async client => {
         },
         $or: [{ state: 'queued' }, { state: 'running' }]
       })
-      .indexFields(['worker'])
-      .sortBy([{ worker: 'asc' }]) // XXX: forces CouchDB to require an index for the query
+      .indexFields(['worker', 'message.slug'])
+      .sortBy([{ worker: 'asc' }, { 'message.slug': 'asc' }]) // XXX: forces CouchDB to require an index for the query
       .limitBy(1)
   )
 


### PR DESCRIPTION
Backport of #2644 

The in-progress jobs query for the export feature relies on the
presence of a very specific index to be fast on cozies with a lot of
`io.cozy.jobs` documents.

To make sure the index presence detection goes well, we forced a sort
on the `worker` attribute.
However, since `cozy-stack` uses an index on `worker` and `state`
only, CouchDB fallbacks to this index instead of detecting the index
we want does not exist and runs the slow `$or` query in-memory.
See https://github.com/apache/couchdb/issues/4511 for more details on
this issue.

To prevent this fallback we will sort on a second attribute not present
in the existing `cozy-stack` index: `message.slug`.

```
### 🐛 Bug Fixes

* Prevent fallback on sub-optimal index for in-progress jobs query.
```