### PR TITLE
feat: Save imported transactions count

### DIFF
--- a/src/ducks/import/queries.js
+++ b/src/ducks/import/queries.js
@@ -5,8 +5,10 @@ import {
   FILES_DOCTYPE,
   RECURRENCE_DOCTYPE,
   TAGS_DOCTYPE,
-  TRANSACTION_DOCTYPE
+  TRANSACTION_DOCTYPE,
+  settingsConn
 } from 'doctypes'
+import { getDefaultedSettingsFromCollection } from 'ducks/settings/helpers'
 
 export const fetchContentToImport = async (client, fileId) => {
   return client.collection(FILES_DOCTYPE).fetchFileContentById(fileId)
@@ -46,4 +48,17 @@ export const saveAll = async (client, docs) => {
     return data
   }
   return []
+}
+
+export const saveSuccessData = async (client, { savedTransactions }) => {
+  const { query, ...options } = settingsConn
+  const settingsCollection = await client.query(query(), options)
+  const settings = getDefaultedSettingsFromCollection(settingsCollection)
+
+  await client.save({
+    ...settings,
+    lastImportSuccess: {
+      savedTransactionsCount: savedTransactions.length
+    }
+  })
 }

--- a/src/ducks/import/services.js
+++ b/src/ducks/import/services.js
@@ -414,10 +414,13 @@ export const saveMissingTransactions = async (
   // XXX: BankTransaction.reconciliate() does not return unchanged transactions
   // so we need to merge them with the updated ones to have a map of all
   // transactions.
-  return merge(
-    keyBy(existingTransactions, transactionId),
-    keyBy(savedTransactions, transactionId)
-  )
+  return {
+    existingTransactionsById: merge(
+      keyBy(existingTransactions, transactionId),
+      keyBy(savedTransactions, transactionId)
+    ),
+    savedTransactions
+  }
 }
 
 export const updateTagsRelationships = async (

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -635,7 +635,7 @@
       "title": {
         "text": "Importer mes données",
         "serviceInProgress": "Traitement des données",
-        "success": "Import réussie"
+        "success": "Import réussi"
       },
       "description": {
         "text": "Sélectionnez les données à importer\n(Format du fichier : .csv)",

--- a/src/targets/services/import.js
+++ b/src/targets/services/import.js
@@ -7,7 +7,8 @@ import {
   fetchExistingAccounts,
   fetchExistingRecurrences,
   fetchExistingTags,
-  fetchExistingTransactions
+  fetchExistingTransactions,
+  saveSuccessData
 } from 'ducks/import/queries'
 import {
   createParseStream,
@@ -85,15 +86,12 @@ const main = async ({ client }) => {
 
   logger('info', `Importing transactions...`)
   const existingTransactions = await fetchExistingTransactions(client)
-  const existingTransactionsById = await saveMissingTransactions(
-    client,
-    transactionsById,
-    {
+  const { existingTransactionsById, savedTransactions } =
+    await saveMissingTransactions(client, transactionsById, {
       existingAccountsById,
       existingRecurrencesById,
       existingTransactions
-    }
-  )
+    })
 
   logger('info', `Creating transactions-tags relationships...`)
   await updateTagsRelationships(client, transactionsById, {
@@ -101,7 +99,13 @@ const main = async ({ client }) => {
     existingTransactionsById
   })
 
-  logger('info', `Import success`)
+  logger('info', `Saving import success data`)
+  await saveSuccessData(client, { savedTransactions })
+
+  logger(
+    'info',
+    `Successfully imported ${savedTransactions.length} transactions`
+  )
 }
 
 if (require.main === module || process.env.NODE_ENV === 'production') {


### PR DESCRIPTION
We want to tell the user how many transactions were imported upon
success so they can verify everything they wanted to import was
actually imported (n.b. not importing any transaction is not
considered as a service failure since no errors were raised).

Since the service cannot communicate with the GUI via its
`io.cozy.jobs` document, we'll save this count into the
`io.cozy.bank.settings` document.

```
### ✨ Features

* Save imported transactions count in `io.cozy.bank.settings` document

### 🐛 Bug Fixes

* Fix typo in French import success title
```
