### PR TITLE
feat: Upgrade cozy-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
     "cozy-notifications": "0.12.0",
     "cozy-pouch-link": "35.6.0",
     "cozy-realtime": "4.2.9",
-    "cozy-scripts": "6.3.0",
+    "cozy-scripts": "^8.0.3",
     "cozy-sharing": "3.12.2",
     "cozy-ui": "^79.0.0",
     "d3": "5.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5671,10 +5671,10 @@ cozy-release@1.10.0:
   dependencies:
     exec-sh "0.3.2"
 
-cozy-scripts@6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-6.3.0.tgz#7365f1af997ec18a907df0ce7f9c51f5c64e332e"
-  integrity sha512-ChHOGJS9XKRSw/t1deTfPbNAYk4GkJBgDS618z0n3MNcvDy8430EUnhRt10R6+FXLRSu3js8paMDd9UBT6ZluQ==
+cozy-scripts@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/cozy-scripts/-/cozy-scripts-8.0.3.tgz#261ef860c2656fb13f0e22171c640bfcf2277914"
+  integrity sha512-IV/2zeHRSkco3qsw63Ckxntw1d1J/DwgzfXl9r/qmWgC44T482OoXWspLL5NnHpKu10syOT5lxnhd+4bP8lbxA==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/polyfill" "^7.10.4"


### PR DESCRIPTION
The main goal of this update was to update https://github.com/cozy/cozy-libs/tree/master/packages/babel-preset-cozy-app to benefit from the node 16 target in order to have a more readable output for service watches.

However, the latest version of cozy-scripts does not include version 2 of babel-preset-cozy-app. I did try to update it by directly adding the library as a dependency, but I got a lot of subsequent babel errors: "Parsing error: [BABEL] /cozy-banks/src/utils/mergeSets.js: Cannot find module '@babel/helper-string-parser'". This update will have to wait for the next one.

No BC to apply here since we manualy use the cozy-scripts webpack config



```

### 🔧 Tech

* Upgrade cozy-scripts 
```
