### PR TITLE
fix: Email notification for balance greater wasn't using the right title

### DIFF
--- a/src/ducks/notifications/BalanceGreater/template.hbs
+++ b/src/ducks/notifications/BalanceGreater/template.hbs
@@ -1,7 +1,7 @@
 
 {{#extend "bank-layout"}}
   {{#content "emailTitle"}}
-    {{t 'Notifications.if-balance-lower.email.innerTitle'}}
+    {{t 'Notifications.if-balance-greater.email.innerTitle'}}
   {{/content}}
   {{#content "emailSubtitle"}}
     {{ formatDate date }}


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Email notification for balance greater wasn't using the right title

```