### PR TITLE
fix: Wording of import success modal

### DIFF
--- a/src/ducks/settings/Import/ImportContents/ImportContentSuccess.jsx
+++ b/src/ducks/settings/Import/ImportContents/ImportContentSuccess.jsx
@@ -6,21 +6,22 @@ import { useI18n } from 'cozy-ui/transpiled/react/I18n'
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
 import successIllu from 'assets/icons/success-illu.svg'
-import { buildAppSettingsQuery } from 'ducks/settings/queries'
+import { buildAppSettingsConfigurationQuery } from 'ducks/settings/queries'
 
 const ImportContentSuccess = () => {
   const { t } = useI18n()
-  const appSettingsQuery = buildAppSettingsQuery()
-  const { data: appSettings, ...appSettingsQueryResult } = useQuery(
-    appSettingsQuery.definition,
-    appSettingsQuery.options
-  )
+  const appSettingsConfigurationQuery = buildAppSettingsConfigurationQuery()
+  const { data: appSettingsConfiguration, ...appSettingsQueryResult } =
+    useQuery(
+      appSettingsConfigurationQuery.definition,
+      appSettingsConfigurationQuery.options
+    )
   const isLoadingAppSettings =
     isQueryLoading(appSettingsQueryResult) || appSettingsQueryResult.hasMore
 
   const savedTransactionsCount =
     !isLoadingAppSettings &&
-    appSettings?.[0]?.lastImportSuccess?.savedTransactionsCount
+    appSettingsConfiguration?.lastImportSuccess?.savedTransactionsCount
 
   const text = savedTransactionsCount ? (
     <Typography component="span" className="u-mb-1 u-db u-spacellipsis">

--- a/src/ducks/settings/queries.js
+++ b/src/ducks/settings/queries.js
@@ -20,9 +20,10 @@ export const buildFilesQueryByNameAndDirId = (name, dirId) => ({
   }
 })
 
-export const buildAppSettingsQuery = () => ({
-  definition: () => Q(SETTINGS_DOCTYPE),
+export const buildAppSettingsConfigurationQuery = () => ({
+  definition: () => Q(SETTINGS_DOCTYPE).getById('configuration'),
   options: {
+    singleDocData: true,
     as: `${SETTINGS_DOCTYPE}`,
     fetchPolicy: defaultFetchPolicy
   }


### PR DESCRIPTION
The io.cozy.bank.settings doctype has several other entries in addition to the configuration.
It is therefore necessary to target this one specifically and not base it on the index of the overall result.