### PR TITLE
fix: Remove logs with sensitive data

### DIFF
--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -21,10 +21,6 @@ import {
 } from './onOperationOrBillCreateHelpers'
 
 const onOperationOrBillCreate = async (client, options) => {
-  log('info', `COZY_CREDENTIALS: ${process.env.COZY_CREDENTIALS}`)
-  log('info', `COZY_URL: ${process.env.COZY_URL}`)
-  log('info', `COZY_JOB_ID: ${process.env.COZY_JOB_ID}`)
-
   log('info', '⌛ Fetching settings...')
   let setting = await fetchSettings(client)
   log('info', '✅ Settings fetched')


### PR DESCRIPTION
The Cozy credentials of a webapp service should remain as secret as
possible, even in ours logs.
The Cozy URL and the job id are already part of the log attributes and
as such, unnecessary.

```
### 🔧 Tech

* Remove logs with unnecessary or sensitive data
```
