### PR TITLE
fix: Do not create AppSuggestion for non stable konnector

### DIFF
--- a/src/ducks/brandDictionary/brandsReducer.js
+++ b/src/ducks/brandDictionary/brandsReducer.js
@@ -51,6 +51,23 @@ export const makeBrands = async (client, dispatch, inService) => {
     type: 'konnector'
   })
 
+  /*
+    Even if we specify channel "stable", we can get a konnector that doesn't have
+    a stable version. We can have published konnector with no stable version, for
+    instance a konnector that have only dev or beta version. The 
+    ```
+    fetchApps({
+      limit: 1000,
+      channel: 'stable',
+      type: 'konnector'
+    })
+    ```
+    will return it. The channel filter is only applied on version & latest_version. 
+    So in order to only use konnector with a stable version, we filter them here.
+  */
+  const filteredKonnector = allRegistryKonnectors.filter(
+    konnector => konnector.latest_version
+  )
   const triggerWithoutCurrentStateQuery = buildTriggerWithoutCurrentStateQuery()
   const triggers = await client.queryAll(
     triggerWithoutCurrentStateQuery.definition,
@@ -60,8 +77,7 @@ export const makeBrands = async (client, dispatch, inService) => {
   const configuredKonnectorsSlugs = triggers
     ? triggers.map(getKonnectorSlug).filter(Boolean)
     : []
-
-  const allBrands = allRegistryKonnectors.reduce(
+  const allBrands = filteredKonnector.reduce(
     (allBrands, data) => [
       ...allBrands,
       makeBrand(data, brands, configuredKonnectorsSlugs)

--- a/src/ducks/brandDictionary/brandsReducer.spec.js
+++ b/src/ducks/brandDictionary/brandsReducer.spec.js
@@ -32,6 +32,9 @@ describe('makeBrands', () => {
           banksTransactionRegExp: '\\bameli\\b'
         }
       }
+    },
+    {
+      slug: 'fnac'
     }
   ])
   const mockClient = new CozyClient({
@@ -102,7 +105,6 @@ describe('makeBrands', () => {
   describe('target service', () => {
     it('Should make brands with just necessary informations and dispatch', async () => {
       const brands = await makeBrands(mockClient, undefined, true)
-
       act(() => {
         expect(brands).toEqual([
           {


### PR DESCRIPTION




```

### 🐛 Bug Fixes

* We need to check the `latest_version` attribute to know if there is a stable version or not.
Before the fix, we created app suggestion even for beta or dev konnectors.
```
