### PR TITLE
fix: Throw error when there is an error catch

### DIFF
--- a/src/targets/services/onOperationOrBillCreateHelpers.js
+++ b/src/targets/services/onOperationOrBillCreateHelpers.js
@@ -52,6 +52,7 @@ export const doBillsMatching = async (client, setting, options = {}) => {
     }
   } catch (e) {
     log('error', `❗ [Bills matching service] ${e}`)
+    throw e
   }
 }
 
@@ -91,6 +92,7 @@ export const doTransactionsMatching = async (client, setting, options = {}) => {
     }
   } catch (e) {
     log('error', `❗ [Transactions matching service] ${e}`)
+    throw e
   }
 }
 


### PR DESCRIPTION
We catch the error, but don't throw them after that. Resulting that services were considered OK...



```
### ✨ Features

*

### 🐛 Bug Fixes

* Make the services failed if they... failed.

### 🔧 Tech

*
```
