### PR TITLE
docs: Update services documentation after cozy-scripts migration

### DIFF
--- a/docs/services.md
+++ b/docs/services.md
@@ -19,15 +19,10 @@ You can manually create an app token and launch the built service.
 
 ```bash
 # Watch services
-$ yarn watch:services:prod
-# If you want to watch only 1 service, you can use the WEBPACK_ENTRYPOINT
-# env variable with the name of the name of the entrypoint. If this var
-# is set, only the corresponding entrypoint will be used.
-# env WEBPACK_ENTRYPOINT=recurrence yarn watch:services
-# In another terminal
-$ export COZY_URL='http://cozy.tools:8080'
-$ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.tools:8080 banks)
-$ node build/budgetAlerts.js
+$ yarn watch
+$ export COZY_URL='http://cozy.localhost:8080'
+$ export COZY_CREDENTIALS=$(cozy-stack instances token-app cozy.localhost:8080 banks)
+$ node build/services/budgetAlerts/banks.js
 ```
 
 


### PR DESCRIPTION

```
### 🔧 Tech

* Update services documentation after cozy-scripts migration
```
