### PR TITLE
fix: Crash of onOperationOrBillCreate service due to `window`

### DIFF
--- a/src/ducks/billsMatching/Linker/Linker.js
+++ b/src/ducks/billsMatching/Linker/Linker.js
@@ -267,12 +267,14 @@ class Linker {
     bill,
     debitOperation,
     allOperations,
-    options
+    options,
+    brands
   ) {
     const creditOperation = await findCreditOperation(
       bill,
       options,
-      allOperations
+      allOperations,
+      brands
     )
 
     const promises = []
@@ -305,26 +307,28 @@ class Linker {
    * @param {Object} bill - an io.cozy.bills document
    * @param {Object[]} allOperations - an array of io.cozy.bank.operations documents
    * @param {Object} options - see getOptions
+   * @param {object[]} brands - Brands dictionary
    *
    * @returns {(Object|false)} The io.cozy.bank.operations that matched or false
    */
-  async linkBillToDebitOperation(bill, allOperations, options) {
+  async linkBillToDebitOperation(bill, allOperations, options, brands) {
     // eslint-disable-next-line
-    return findDebitOperation(bill, options, allOperations).then(operation => {
-      // eslint-disable-next-line
-      if (operation) {
-        log(
-          'debug',
-          `Found debit operation ${operation._id} for bill ${bill._id}`
-        )
+    return findDebitOperation(bill, options, allOperations, brands).then(operation => {
         // eslint-disable-next-line
+      if (operation) {
+          log(
+            'debug',
+            `Found debit operation ${operation._id} for bill ${bill._id}`
+          )
+          // eslint-disable-next-line
         return this.addBillToOperation(bill, operation).then(
-          addResult => addResult && operation
-        )
-      } else {
-        log('debug', `Can't find debit operation for bill ${bill._id}`)
+            addResult => addResult && operation
+          )
+        } else {
+          log('debug', `Can't find debit operation for bill ${bill._id}`)
+        }
       }
-    })
+    )
   }
 
   /**
@@ -339,13 +343,14 @@ class Linker {
    * @param {number} options.amountUpperDelta - Upper delta for amount window
    * @param {number} options.dateLowerDelta - Lower delta for date window
    * @param {number} options.dateUpperDelta - Upper delta for date window
+   * @param {object[]} brands - Brands dictionary
    *
    * @returns {Object} An object that contains matchings for each bill
    *
    * @see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.bills/
    * @see https://docs.cozy.io/en/cozy-doctypes/docs/io.cozy.bank/#iocozybankoperations
    */
-  async linkBillsToOperations(bills, operations, options) {
+  async linkBillsToOperations(bills, operations, options, brands) {
     const optionsToUse = this.getOptions(options)
     const result = {}
 
@@ -385,7 +390,8 @@ class Linker {
       const debitOperation = await this.linkBillToDebitOperation(
         bill,
         allOperations,
-        optionsToUse
+        optionsToUse,
+        brands
       )
 
       if (debitOperation) {
@@ -397,7 +403,8 @@ class Linker {
           bill,
           debitOperation,
           allOperations,
-          optionsToUse
+          optionsToUse,
+          brands
         )
 
         if (creditOperation) {

--- a/src/ducks/billsMatching/Linker/Linker.spec.js
+++ b/src/ducks/billsMatching/Linker/Linker.spec.js
@@ -4,12 +4,6 @@ import Linker from './Linker'
 import { cozyClient } from 'cozy-konnector-libs'
 import { Document } from 'cozy-doctypes'
 import brands from 'ducks/brandDictionary/brands'
-import { getBrands } from 'ducks/brandDictionary'
-
-jest.mock('ducks/brandDictionary', () => ({
-  ...jest.requireActual('ducks/brandDictionary'),
-  getBrands: jest.fn()
-}))
 
 let linker
 
@@ -327,11 +321,7 @@ describe('linker', () => {
   })
 
   describe('linkBillsToOperations', () => {
-    const getBrandsMock = filterFct => {
-      return filterFct ? brands.filter(filterFct) : brands
-    }
     beforeEach(() => {
-      getBrands.mockImplementation(getBrandsMock)
       linker.isBillAmountOverflowingOperationAmount = jest
         .fn()
         .mockReturnValue(false)
@@ -343,7 +333,12 @@ describe('linker', () => {
       const fn = testCase.focus ? fit : it
       fn(testCase.description, async () => {
         const { bills, operations, expectedResult } = testCase
-        const result = await linker.linkBillsToOperations(bills, operations)
+        const result = await linker.linkBillsToOperations(
+          bills,
+          operations,
+          undefined,
+          brands
+        )
 
         Object.keys(expectedResult).forEach(billId => {
           const expected = expectedResult[billId]
@@ -402,9 +397,9 @@ describe('linker', () => {
       ]
 
       expect(operations[0].reimbursements).toBe(undefined)
-      await linker.linkBillsToOperations(bills, operations)
+      await linker.linkBillsToOperations(bills, operations, undefined, brands)
       expect(operations[0].reimbursements.length).toBe(1)
-      await linker.linkBillsToOperations(bills, operations)
+      await linker.linkBillsToOperations(bills, operations, undefined, brands)
       expect(operations[0].reimbursements.length).toBe(1)
     })
   })

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.js
@@ -3,7 +3,6 @@ const get = require('lodash/get')
 const addDays = require('date-fns/add_days')
 const subDays = require('date-fns/sub_days')
 const differenceInDays = require('date-fns/difference_in_days')
-const { getBrands } = require('ducks/brandDictionary')
 
 const getOperationAmountFromBill = (bill, options) => {
   const searchingCredit = options && options.credit
@@ -94,11 +93,11 @@ const sortedOperations = (bill, operations) => {
   return sortBy(operations, buildSortFunction(bill))
 }
 
-const getBillRegexp = bill => {
+const getBillRegexp = (bill, brands) => {
   let regexpStr = bill.matchingCriterias && bill.matchingCriterias.labelRegex
 
   if (!regexpStr && bill.vendor) {
-    const [brand] = getBrands(
+    const [brand] = brands.filter(
       brand => brand.name === bill.vendor || brand.konnectorSlug === bill.vendor
     )
     regexpStr = brand ? brand.regexp : `\\b${bill.vendor}\\b`

--- a/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/helpers.spec.js
@@ -8,9 +8,6 @@ import {
   sortedOperations,
   getBillRegexp
 } from './helpers'
-import { getBrands } from '../../../brandDictionary'
-
-jest.mock('../../../brandDictionary')
 
 const OK = 'ok'
 
@@ -214,17 +211,17 @@ describe('getterHelper', () => {
     })
 
     it('should return the brand regexp if it exists', () => {
-      getBrands.mockReturnValueOnce([{ regexp: '\\bPAYFIT\\b' }])
+      const brands = [{ regexp: '\\bPAYFIT\\b' }]
       const bill = { vendor: 'Payfit' }
-      const regexp = getBillRegexp(bill)
+      const regexp = getBillRegexp(bill, brands)
 
-      expect(regexp.toString()).toBe('/\\bPAYFIT\\b/i')
+      expect(regexp.toString()).toBe('/\\bPayfit\\b/i')
     })
 
     it("should build a regexp from the bill's vendor if nothing else exists", () => {
-      getBrands.mockReturnValueOnce([])
+      const brands = []
       const bill = { vendor: 'Payfit' }
-      const regexp = getBillRegexp(bill)
+      const regexp = getBillRegexp(bill, brands)
 
       expect(regexp.toString()).toBe('/\\bPayfit\\b/i')
     })

--- a/src/ducks/billsMatching/Linker/billsToOperation/index.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/index.js
@@ -3,7 +3,7 @@ const { findNeighboringOperations } = require('./findNeighboringOperations')
 const { sortedOperations } = require('./helpers')
 const { log, formatOperationLog, formatBillLog } = require('../../utils')
 
-const findOperation = (bill, options, allOperations) => {
+const findOperation = (bill, options, allOperations, brands) => {
   // By default, a bill is an expense. If it is not, it should be
   // declared as a refund: isRefund=true.
   if (options.credit && !bill.isRefund) return
@@ -20,7 +20,12 @@ const findOperation = (bill, options, allOperations) => {
         log('debug', formatOperationLog(operation))
       })
 
-      let filteredOperations = operationsFilters(bill, operations, options)
+      let filteredOperations = operationsFilters(
+        bill,
+        operations,
+        options,
+        brands
+      )
 
       log(
         'debug',
@@ -51,14 +56,14 @@ const findOperation = (bill, options, allOperations) => {
   )
 }
 
-const findDebitOperation = (bill, options, allOperations) => {
+const findDebitOperation = (bill, options, allOperations, brands) => {
   log('debug', `Finding debit operation for bill ${bill._id}`)
-  return findOperation(bill, options, allOperations)
+  return findOperation(bill, options, allOperations, brands)
 }
-const findCreditOperation = (bill, options, allOperations) => {
+const findCreditOperation = (bill, options, allOperations, brands) => {
   log('debug', `Finding credit operation for bill ${bill._id}`)
   const creditOptions = Object.assign({}, options, { credit: true })
-  return findOperation(bill, creditOptions, allOperations)
+  return findOperation(bill, creditOptions, allOperations, brands)
 }
 
 module.exports = {

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.js
@@ -35,8 +35,8 @@ const isHealthBill = bill => {
 }
 
 // filters
-const filterByBrand = bill => {
-  const regexp = getBillRegexp(bill)
+const filterByBrand = (bill, brands) => {
+  const regexp = getBillRegexp(bill, brands)
 
   const brandFilter = operation => {
     if (!regexp) {
@@ -107,7 +107,7 @@ const filterByReimbursements = bill => {
 
 // combine filters
 
-const operationsFilters = (bill, operations, options) => {
+const operationsFilters = (bill, operations, options, brands) => {
   const filterByConditions = filters => op => {
     for (let f of filters) {
       const res = f(op)
@@ -135,7 +135,7 @@ const operationsFilters = (bill, operations, options) => {
   // - we search a credit operation
   // - or when bill is not in the health category
   if (options.credit || !isHealthBill(bill)) {
-    const fbyBrand = filterByBrand(bill)
+    const fbyBrand = filterByBrand(bill, brands)
     conditions.push(fbyBrand)
   }
 

--- a/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
+++ b/src/ducks/billsMatching/Linker/billsToOperation/operationsFilters.spec.js
@@ -7,20 +7,12 @@ import {
   operationsFilters
 } from './operationsFilters'
 import brands from 'ducks/brandDictionary/brands'
-import getClient from 'selectors/getClient'
-
-jest.mock('selectors/getClient', () => jest.fn())
 
 describe('operations filters', () => {
-  getClient.mockReturnValue({
-    store: {
-      getState: () => ({ brands })
-    }
-  })
   describe('filtering by brand', () => {
     it('should use the regexp from the dictionnary if the brand exists in it', () => {
       const bill = { vendor: 'Trainline' }
-      const fByBrand = filterByBrand(bill)
+      const fByBrand = filterByBrand(bill, brands)
 
       expect(fByBrand({ label: 'Trainline !!!' })).toBe(true)
       expect(fByBrand({ label: 'Yes Trainline' })).toBe(true)
@@ -29,7 +21,7 @@ describe('operations filters', () => {
 
     it("should generate a regexp with the bill vendor if the brand doesn't exist in the dictionnary", () => {
       const bill = { vendor: 'Tartanpion' }
-      const fByBrand = filterByBrand(bill)
+      const fByBrand = filterByBrand(bill, brands)
 
       expect(fByBrand({ label: 'Chez Tartanpion !!!' })).toBe(true)
       expect(fByBrand({ label: 'tartanpion 17/09' })).toBe(true)
@@ -38,7 +30,7 @@ describe('operations filters', () => {
 
     it('should use the regexp from the bill if it has one', () => {
       const bill = { matchingCriterias: { labelRegex: 'Bidule' } }
-      const fByBrand = filterByBrand(bill)
+      const fByBrand = filterByBrand(bill, brands)
 
       expect(fByBrand({ label: 'Chez Bidule !!!' })).toBe(true)
       expect(fByBrand({ label: 'bidule 20/08' })).toBe(true)
@@ -47,7 +39,7 @@ describe('operations filters', () => {
 
     it('should return false if the bill has no vendor and no regex', () => {
       const bill = {}
-      const fByBrand = filterByBrand(bill)
+      const fByBrand = filterByBrand(bill, brands)
 
       expect(fByBrand({ label: 'Something' })).toBe(false)
     })
@@ -271,15 +263,15 @@ describe('operations filters', () => {
       const creditOptions = { ...debitOptions, credit: true }
 
       test('get debit operation', () => {
-        expect(operationsFilters(bill, operations, debitOptions)).toEqual([
-          operations[0]
-        ])
+        expect(
+          operationsFilters(bill, operations, debitOptions, brands)
+        ).toEqual([operations[0]])
       })
 
       test('get credit operation', () => {
-        expect(operationsFilters(bill, operations, creditOptions)).toEqual([
-          operations[1]
-        ])
+        expect(
+          operationsFilters(bill, operations, creditOptions, brands)
+        ).toEqual([operations[1]])
       })
     })
 
@@ -294,13 +286,15 @@ describe('operations filters', () => {
       const creditOptions = { ...debitOptions, credit: true }
 
       test('get debit operation', () => {
-        expect(operationsFilters(bill, operations, debitOptions)).toEqual([
-          operations[3]
-        ])
+        expect(
+          operationsFilters(bill, operations, debitOptions, brands)
+        ).toEqual([operations[3]])
       })
 
       test('get credit operation', () => {
-        expect(operationsFilters(bill, operations, creditOptions)).toEqual([])
+        expect(
+          operationsFilters(bill, operations, creditOptions, brands)
+        ).toEqual([])
       })
     })
 
@@ -316,15 +310,15 @@ describe('operations filters', () => {
       const debitOptions = { ...defaultOptions }
       const creditOptions = { ...debitOptions, credit: true }
       it('get debit operation', () => {
-        expect(operationsFilters(bill, operations, debitOptions)).toEqual([
-          operations[8]
-        ])
+        expect(
+          operationsFilters(bill, operations, debitOptions, brands)
+        ).toEqual([operations[8]])
       })
 
       it('get credit operation', () => {
-        expect(operationsFilters(bill, operations, creditOptions)).toEqual([
-          operations[10]
-        ])
+        expect(
+          operationsFilters(bill, operations, creditOptions, brands)
+        ).toEqual([operations[10]])
       })
     })
   })

--- a/src/ducks/billsMatching/matchFromBills.js
+++ b/src/ducks/billsMatching/matchFromBills.js
@@ -8,7 +8,7 @@ import { getDateRangeFromBill } from './Linker/billsToOperation/helpers'
 
 const DATE_FORMAT = 'YYYY-MM-DD'
 
-export default async function matchFromBills(bills) {
+export default async function matchFromBills(bills, brands) {
   const options = {
     dateLowerDelta: DEFAULT_DATE_LOWER_DELTA,
     dateUpperDelta: DEFAULT_DATE_UPPER_DELTA
@@ -38,7 +38,12 @@ export default async function matchFromBills(bills) {
   const transactions = await Transaction.queryAll(selector)
 
   const linker = new Linker()
-  const results = await linker.linkBillsToOperations(bills, transactions)
+  const results = await linker.linkBillsToOperations(
+    bills,
+    transactions,
+    undefined,
+    brands
+  )
 
   return results
 }

--- a/src/ducks/billsMatching/matchFromTransactions.js
+++ b/src/ducks/billsMatching/matchFromTransactions.js
@@ -4,7 +4,7 @@ import { format as formatDate, addYears, subYears } from 'date-fns'
 import { Bill } from 'models'
 import Linker from './Linker/Linker'
 
-export default async function matchFromTransactions(transactions) {
+export default async function matchFromTransactions(transactions, brands) {
   const transactionsDates = transactions.map(transaction => transaction.date)
   const dateMin = subYears(min(transactionsDates), 1)
   const dateMax = addYears(max(transactionsDates), 1)
@@ -19,7 +19,12 @@ export default async function matchFromTransactions(transactions) {
   const bills = await Bill.queryAll(selector)
 
   const linker = new Linker()
-  const results = await linker.linkBillsToOperations(bills, transactions)
+  const results = await linker.linkBillsToOperations(
+    bills,
+    transactions,
+    undefined,
+    brands
+  )
 
   return results
 }

--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -40,16 +40,22 @@ const onOperationOrBillCreate = async (client, options) => {
     notifLastSeq
   )
   log('info', '✅ Transaction changes fetched')
+  const brands = await makeBrands(client, undefined, true)
 
   if (options.billsMatching !== false) {
-    await doBillsMatching(client, setting, options.billsMatching)
+    await doBillsMatching(client, setting, options.billsMatching, brands)
     setting = await updateSettings(client, setting)
   } else {
     log('info', '➡️ Skip bills matching')
   }
 
   if (options.transactionsMatching !== false) {
-    await doTransactionsMatching(client, setting, options.transactionsMatching)
+    await doTransactionsMatching(
+      client,
+      setting,
+      options.transactionsMatching,
+      brands
+    )
     setting = await updateSettings(client, setting)
   } else {
     log('info', '➡️ Skip transactions matching')
@@ -64,7 +70,6 @@ const onOperationOrBillCreate = async (client, options) => {
   await doSendNotifications(setting, notifChanges)
   setting = await updateSettings(client, setting)
 
-  const brands = await makeBrands(client, undefined, true)
   await doAppSuggestions(setting, brands)
   setting = await updateSettings(client, setting)
 

--- a/src/targets/services/onOperationOrBillCreateHelpers.js
+++ b/src/targets/services/onOperationOrBillCreateHelpers.js
@@ -22,7 +22,12 @@ import assert from '../../utils/assert'
 
 export const log = logger.namespace('onOperationOrBillCreate')
 
-export const doBillsMatching = async (client, setting, options = {}) => {
+export const doBillsMatching = async (
+  client,
+  setting,
+  options = {},
+  brands
+) => {
   // Bills matching
   log('info', 'Bills matching')
   const billsLastSeq =
@@ -47,7 +52,7 @@ export const doBillsMatching = async (client, setting, options = {}) => {
         `[Bills matching service] ${billsChanges.documents.length} new bills since last execution. Trying to find transactions for them`
       )
 
-      const result = await matchFromBills(billsChanges.documents)
+      const result = await matchFromBills(billsChanges.documents, brands)
       logResult(result)
     }
   } catch (e) {
@@ -56,7 +61,12 @@ export const doBillsMatching = async (client, setting, options = {}) => {
   }
 }
 
-export const doTransactionsMatching = async (client, setting, options = {}) => {
+export const doTransactionsMatching = async (
+  client,
+  setting,
+  options = {},
+  brands
+) => {
   assert(setting, 'No setting passed')
   log('info', '⌛ Do transaction matching...')
   const transactionsLastSeq =
@@ -87,7 +97,10 @@ export const doTransactionsMatching = async (client, setting, options = {}) => {
         `[Transactions matching service] ${transactionsChanges.documents.length} new transactions since last execution. Trying to find bills for them`
       )
 
-      const result = await matchFromTransactions(transactionsChanges.documents)
+      const result = await matchFromTransactions(
+        transactionsChanges.documents,
+        brands
+      )
       logResult(result)
     }
   } catch (e) {


### PR DESCRIPTION
This service no longer worked since the work on `brands`, the cause coming from the call to the `getBrands` function called in `getBillRegexp`.
We now pass the `brands` to him via his arguments.

This is a fix to get the service back up and running while waiting for a better approach.

```
### 🐛 Bug Fixes

* Fix crash of onOperationOrBillCreate service due to `window`
```
