### PR TITLE
fix: Don't crash service if there is no database

### DIFF
--- a/src/targets/services/onOperationOrBillCreate.js
+++ b/src/targets/services/onOperationOrBillCreate.js
@@ -34,11 +34,22 @@ const onOperationOrBillCreate = async (client, options) => {
   // may be missed by `TransactionGreater` because their `_rev` don't start with `1`
   const notifLastSeq = setting.notifications.lastSeq
   log('info', '⌛ Fetching transaction changes...')
-  const notifChanges = await fetchChangesOrAll(
-    client,
-    TRANSACTION_DOCTYPE,
-    notifLastSeq
-  )
+  let notifChanges
+  try {
+    notifChanges = await fetchChangesOrAll(
+      client,
+      TRANSACTION_DOCTYPE,
+      notifLastSeq
+    )
+  } catch (e) {
+    if (!/Database does not exist/.test(e)) {
+      throw e
+    } else {
+      log('info', 'No transaction database so early exit')
+      process.exit(0)
+    }
+  }
+
   log('info', '✅ Transaction changes fetched')
   const brands = await makeBrands(client, undefined, true)
 

--- a/src/targets/services/onOperationOrBillCreateHelpers.js
+++ b/src/targets/services/onOperationOrBillCreateHelpers.js
@@ -56,8 +56,12 @@ export const doBillsMatching = async (
       logResult(result)
     }
   } catch (e) {
-    log('error', `❗ [Bills matching service] ${e}`)
-    throw e
+    if (!/Database does not exist/.test(e)) {
+      log('error', `❗ [Bills matching service] ${e}`)
+      throw e
+    } else {
+      log('info', `⚠️ [Bills matching no database]`)
+    }
   }
 }
 
@@ -104,8 +108,12 @@ export const doTransactionsMatching = async (
       logResult(result)
     }
   } catch (e) {
-    log('error', `❗ [Transactions matching service] ${e}`)
-    throw e
+    if (!/Database does not exist/.test(e)) {
+      log('error', `❗ [Transactions matching service] ${e}`)
+      throw e
+    } else {
+      log('info', `⚠️ [Transactions matching service no database]`)
+    }
   }
 }
 


### PR DESCRIPTION
Now, each errors are thrown... So if there is no database because there is no bills for instance, the service was crashing.

So I took this commit https://github.com/cozy/cozy-banks/commit/7a8a8a33ad353a59d88334076d54bcf9cf80be6c and test if the error is because there is no database before throwing.

=> Already reviewed & merged on the beta branch 