### PR TITLE
[VO-201] fix: Stop event propagation on action chip

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "cozy-realtime": "4.2.9",
     "cozy-scripts": "^8.3.0",
     "cozy-sharing": "3.12.2",
-    "cozy-ui": "^101.2.0",
+    "cozy-ui": "^103.1.1",
     "d3": "5.11.0",
     "date-fns": "1.30.1",
     "detect-node": "2.0.4",

--- a/src/ducks/transactions/actions/AppLinkAction.jsx
+++ b/src/ducks/transactions/actions/AppLinkAction.jsx
@@ -39,8 +39,9 @@ const Component = ({ transaction, actionProps: { urls }, isModalItem }) => {
   const url = urls[appName]
 
   const handleClick = useCallback(
-    ev => {
-      ev && ev.preventDefault()
+    evt => {
+      evt?.stopPropagation()
+      evt?.preventDefault()
       open(url)
     },
     [url]
@@ -63,7 +64,7 @@ const Component = ({ transaction, actionProps: { urls }, isModalItem }) => {
   }
 
   return (
-    <Chip size="small" variant="outlined" onClick={() => open(url)}>
+    <Chip size="small" variant="outlined" onClick={handleClick}>
       {label}
       <Chip.Separator />
       <Icon icon={OpenwithIcon} />

--- a/src/ducks/transactions/actions/HealthLinkAction.jsx
+++ b/src/ducks/transactions/actions/HealthLinkAction.jsx
@@ -21,8 +21,9 @@ const Component = ({ actionProps: { urls }, isModalItem }) => {
   const label = t(`Transactions.actions.${name}`)
 
   const handleClick = useCallback(
-    ev => {
-      ev && ev.preventDefault()
+    evt => {
+      evt?.stopPropagation()
+      evt?.preventDefault()
       open(url)
     },
     [url]
@@ -30,7 +31,7 @@ const Component = ({ actionProps: { urls }, isModalItem }) => {
 
   const handleModalClick = useCallback(
     ev => {
-      ev && ev.preventDefault()
+      ev & ev.preventDefault()
       open(url, '_blank')
     },
     [url]

--- a/src/ducks/transactions/actions/KonnectorAction/index.jsx
+++ b/src/ducks/transactions/actions/KonnectorAction/index.jsx
@@ -60,31 +60,35 @@ const Component = ({ fetchTriggers, isModalItem, transaction }) => {
     useState(false)
   const [showIntentModalState, setShowIntentModalState] = useState(false)
 
-  const showInformativeDialog = ev => {
-    ev?.preventDefault()
+  const showInformativeDialog = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     setShowInformativeDialogState(true)
   }
-  const hideInformativeDialog = ev => {
-    ev?.preventDefault()
+  const hideInformativeDialog = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     setShowInformativeDialogState(false)
   }
-  const showIntentModal = ev => {
-    ev?.preventDefault()
+  const showIntentModal = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     setShowIntentModalState(true)
   }
-  const hideIntentModal = ev => {
-    ev?.preventDefault()
+  const hideIntentModal = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     setDisableEnforceFocus?.(false)
     setShowIntentModalState(false)
   }
-  const onInformativeDialogConfirm = () => {
+  const onInformativeDialogConfirm = evt => {
     setDisableEnforceFocus?.(true)
     hideInformativeDialog()
-    showIntentModal()
+    showIntentModal(evt)
   }
-  const onIntentComplete = () => {
+  const onIntentComplete = evt => {
     fetchTriggers()
-    hideIntentModal()
+    hideIntentModal(evt)
   }
 
   if (!brand) return null

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusAction.jsx
@@ -92,21 +92,24 @@ export class DumbReimbursementStatusAction extends React.PureComponent {
     showModal: false
   }
 
-  showModal = ev => {
-    ev && ev.preventDefault()
+  showModal = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     this.setState({ showModal: true })
   }
 
-  hideModal = ev => {
-    ev && ev.preventDefault()
+  hideModal = evt => {
+    evt?.stopPropagation()
+    evt?.preventDefault()
     this.setState({ showModal: false })
   }
 
-  handleChange = async value => {
+  handleChange = async (evt, value) => {
+    evt?.stopPropagation()
     const { transaction, client, t } = this.props
     transaction.reimbursementStatus = value
 
-    this.hideModal()
+    this.hideModal(evt)
 
     try {
       await client.save(transaction)

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.jsx
@@ -41,9 +41,9 @@ const ReimbursementStatusModal = function ReimbursementStatusModal(props) {
     replaceLastPart(lastTracked, 'depense-remboursement')
   )
 
-  const handleClose = () => {
+  const handleClose = evt => {
     trackPage(lastTracked => replaceLastPart(lastTracked, 'depense'))
-    onClose()
+    onClose(evt)
   }
 
   return (
@@ -71,7 +71,7 @@ const ReimbursementStatusModal = function ReimbursementStatusModal(props) {
                   divider
                   button
                   disableRipple
-                  onClick={() => onChange(choice)}
+                  onClick={evt => onChange(evt, choice)}
                   key={choice}
                 >
                   <ListItemIcon>
@@ -82,7 +82,7 @@ const ReimbursementStatusModal = function ReimbursementStatusModal(props) {
                           key={choice}
                           name="reimbursementStatus"
                           checked={status === choice}
-                          onChange={ev => onChange(ev.target.value)}
+                          onChange={evt => onChange(evt, evt.target.value)}
                           className="u-ml-1"
                         />
                       }

--- a/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.spec.jsx
+++ b/src/ducks/transactions/actions/ReimbursementStatusAction/ReimbursementStatusModal.spec.jsx
@@ -18,14 +18,14 @@ describe('reimbursement status modal', () => {
     )
     const reimbursedRow = root.getByText('I have already been reimbursed')
     fireEvent.click(reimbursedRow)
-    expect(onChange).toHaveBeenCalledWith('reimbursed')
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'reimbursed')
 
     const notWaiting = root.getByText('I am not waiting for a reimbursement')
     fireEvent.click(notWaiting)
-    expect(onChange).toHaveBeenCalledWith('no-reimbursement')
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'no-reimbursement')
 
     const waiting = root.getByText('I am waiting for a reimbursement')
     fireEvent.click(waiting)
-    expect(onChange).toHaveBeenCalledWith('pending')
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'pending')
   })
 })

--- a/src/ducks/transactions/actions/UrlLinkAction.jsx
+++ b/src/ducks/transactions/actions/UrlLinkAction.jsx
@@ -18,8 +18,9 @@ const Component = ({ transaction, isModalItem }) => {
   const action = transaction.action
 
   const handleClick = useCallback(
-    ev => {
-      ev && ev.preventDefault()
+    evt => {
+      evt?.stopPropagation()
+      evt?.preventDefault()
       open(action.url, action.target)
     },
     [action.target, action.url]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,20 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@pdf-lib/standard-fonts@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz#8ba691c4421f71662ed07c9a0294b44528af2d7f"
+  integrity sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==
+  dependencies:
+    pako "^1.0.6"
+
+"@pdf-lib/upng@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@pdf-lib/upng/-/upng-1.0.1.tgz#7dc9c636271aca007a9df4deaf2dd7e7960280cb"
+  integrity sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==
+  dependencies:
+    pako "^1.0.10"
+
 "@popperjs/core@^2.4.4":
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.4.tgz#11d5db19bd178936ec89cd84519c4de439574398"
@@ -4850,11 +4864,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-text-to-clipboard@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz#0202b2d9bdae30a49a53f898626dcc3b49ad960b"
-  integrity sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==
-
 copy-text-to-clipboard@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.2.0.tgz#329dd6daf8c42034c763ace567418401764579ae"
@@ -5494,10 +5503,10 @@ cozy-stack-client@^6.66.0:
     mime "^2.4.0"
     qs "^6.7.0"
 
-cozy-ui@^101.2.0:
-  version "101.2.0"
-  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-101.2.0.tgz#42d15aaa28aeecb63b0eee8bdba4fb770168316c"
-  integrity sha512-J0R7gOfK13KOfjerHEWiEzwOizquPWKjnz3PnR9CsyYbEkWO03cqjJ/EFvXXhLmQKdXeD0fJgXfjSyVr1k2dbQ==
+cozy-ui@^103.1.1:
+  version "103.1.1"
+  resolved "https://registry.yarnpkg.com/cozy-ui/-/cozy-ui-103.1.1.tgz#9cd65adf83c575278d8923756c149b6e4385db4d"
+  integrity sha512-sYaxfXsG+EIKJxluHn2x2vIuXqDmf+onzFwn7/1bkIbBZKMKqYWWi6fHNEt2z0F2SBZOPIaQDPhqap6Hv1a8NQ==
   dependencies:
     "@babel/runtime" "^7.3.4"
     "@material-ui/core" "4.12.3"
@@ -5506,7 +5515,6 @@ cozy-ui@^101.2.0:
     bundlemon "^1.3.2"
     chart.js "3.7.1"
     classnames "^2.2.5"
-    copy-text-to-clipboard "3.2.0"
     cozy-interapp "^0.5.4"
     date-fns "^1.28.5"
     filesize "8.0.7"
@@ -5516,9 +5524,11 @@ cozy-ui@^101.2.0:
     mui-bottom-sheet "https://github.com/cozy/mui-bottom-sheet.git#v1.0.9"
     node-polyglot "^2.2.2"
     normalize.css "^8.0.0"
+    pdf-lib "1.17.1"
     piwik-react-router "0.12.1"
     react-chartjs-2 "4.1.0"
     react-markdown "^4.0.8"
+    react-middle-ellipsis "1.2.2"
     react-pdf "^5.7.2"
     react-popper "^2.2.3"
     react-remove-scroll "^2.4.0"
@@ -13127,9 +13137,9 @@ msgpack5@^4.0.2:
     readable-stream "^2.3.6"
     safe-buffer "^5.1.2"
 
-"mui-bottom-sheet@https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
+"mui-bottom-sheet@git+https://github.com/cozy/mui-bottom-sheet.git#v1.0.9":
   version "1.0.8"
-  resolved "https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
+  resolved "git+https://github.com/cozy/mui-bottom-sheet.git#3dc4c2a245ab39079bc2f73546bccf80847be14c"
   dependencies:
     "@juggle/resize-observer" "^3.1.3"
     jest-environment-jsdom-sixteen "^1.0.3"
@@ -14108,6 +14118,11 @@ pako@^1.0.10, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
+pako@^1.0.11, pako@^1.0.6:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 papaparse@^5.1.1:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.0.tgz#ab1702feb96e79ab4309652f36db9536563ad05a"
@@ -14359,6 +14374,16 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pdf-lib@1.17.1:
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/pdf-lib/-/pdf-lib-1.17.1.tgz#9e7dd21261a0c1fb17992580885b39e7d08f451f"
+  integrity sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==
+  dependencies:
+    "@pdf-lib/standard-fonts" "^1.0.0"
+    "@pdf-lib/upng" "^1.0.1"
+    pako "^1.0.11"
+    tslib "^1.11.1"
 
 pdfjs-dist@2.12.313:
   version "2.12.313"
@@ -15829,6 +15854,11 @@ react-markdown@4.2.2, react-markdown@^4.0.8, react-markdown@^4.2.2:
     unified "^6.1.5"
     unist-util-visit "^1.3.0"
     xtend "^4.0.1"
+
+react-middle-ellipsis@1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-middle-ellipsis/-/react-middle-ellipsis-1.2.2.tgz#e1676fe2fbc864ea7e2fc25bedc53db2635bb2a9"
+  integrity sha512-tTsyS/hOjT3C5WjpueAx1/WsYUVnNlUnDRCKSffGT1ns7b0NbSi6FGVVPDLTxn207B0sVjNTbMnk1HFGWd5hzA==
 
 react-pdf@^5.7.2:
   version "5.7.2"


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Show chip action instead transaction action

### 🔧 Tech

* Update cozy-ui from 101.2.0 to 103.1.0
```
The action chips are integrated into a ListItem in mobile. When the chip is clicked, the parent modal is shown to the user. This commit avoids this problem by stopping propagation at the chip  level.

<img width="445" alt="Capture d’écran 2024-02-09 à 10 22 37" src="https://github.com/cozy/cozy-banks/assets/7434420/eef97be0-ea81-4772-9466-76da656a0846">


**Related PRs:**
- https://github.com/cozy/cozy-ui/pull/2568
