### PR TITLE
[VO-400] fix: Show konnector error on transaction list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # General code owners
-*      @JF-Cozy @Merkur39
+* @cballevre

--- a/src/ducks/transactions/TransactionPageErrors/TransactionPageErrors.jsx
+++ b/src/ducks/transactions/TransactionPageErrors/TransactionPageErrors.jsx
@@ -12,14 +12,21 @@ import { konnectorTriggersConn } from 'doctypes'
 import Carrousel from 'components/Carrousel'
 import flag from 'cozy-flags'
 import { getTransactionPageErrors } from 'ducks/transactions/TransactionPageErrors/errors'
-import withBankingSlugs from 'hoc/withBankingSlugs'
+import { useBanksContext } from 'ducks/context/BanksContext'
 
 /**
  * Shows connection errors for the currently filtered bank accounts.
  * If there is more than 1 error, a carrousel wraps the errors.
  */
-export const TransactionPageErrors = props => {
-  const errors = getTransactionPageErrors(props)
+export const TransactionPageErrors = ({ triggerCol, accounts }) => {
+  const { isBankTrigger } = useBanksContext()
+
+  const errors = getTransactionPageErrors({
+    triggerCol,
+    accounts,
+    isBankTrigger
+  })
+
   const count = errors.length
   const Wrapper = count > 1 ? Carrousel : React.Fragment
   const wrapperProps =
@@ -74,6 +81,5 @@ export default compose(
       fetchPolicy: CozyClient.fetchPolicies.noFetch
     }
   }),
-  React.memo,
-  withBankingSlugs
+  React.memo
 )(TransactionPageErrors)

--- a/src/ducks/transactions/TransactionPageErrors/TransactionPageErrors.spec.jsx
+++ b/src/ducks/transactions/TransactionPageErrors/TransactionPageErrors.spec.jsx
@@ -21,6 +21,13 @@ describe('get derived data', () => {
   })
 })
 
+jest.mock('ducks/context/BanksContext', () => ({
+  ...jest.requireActual('ducks/context/BanksContext'),
+  useBanksContext: () => ({
+    isBankTrigger: () => true
+  })
+}))
+
 describe('transaction page errors', () => {
   const setup = ({
     triggers = DEFAULT_TRIGGERS,
@@ -30,7 +37,6 @@ describe('transaction page errors', () => {
       <TransactionPageErrors
         accounts={accounts}
         triggerCol={{ data: triggers }}
-        isBankTrigger={() => true}
       />
     )
     return {

--- a/src/hooks/useBankingSlugs.jsx
+++ b/src/hooks/useBankingSlugs.jsx
@@ -31,8 +31,9 @@ const useBankingSlugs = () => {
     load()
   }, [client])
 
-  const isBankTrigger = trigger =>
-    bankingSlugs.includes(trigger?.message?.konnector)
+  const isBankTrigger = trigger => {
+    return bankingSlugs.includes(trigger?.message?.konnector)
+  }
 
   const isBankKonnector = job => {
     return bankingSlugs.includes(job?.konnector)


### PR DESCRIPTION
```
### 🐛 Bug Fixes

* Show konnector error on transaction list
```

`isBankTrigger` didn't have the `bankingSlug` when it was run with the HOC. As the function with `bankingSlug` is also exposed via a context, so I chose this way. There's also the advantage of having one less request because you don't have to execute the hook several times.