### PR TITLE
feat: edit transaction label in list and modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ yarn-error.log
 
 # Build
 build/
+db/
+storage/
 
 
 # OS generated files
@@ -26,6 +28,7 @@ desktop.ini
 # Editors / IDEs
 .floo
 .flooignore
+.vscode
 
 
 # Default

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "arrowParens": "avoid"
+}

--- a/src/ducks/search/SearchPage.jsx
+++ b/src/ducks/search/SearchPage.jsx
@@ -61,7 +61,7 @@ const SearchPage = () => {
 
   const fuse = useMemo(() => {
     const fuse = new Fuse(transactions || [], {
-      keys: ['label'],
+      keys: ['label', 'manualLabel'],
       ignoreLocation: true,
       includeScore: true,
       includeMatches: true,

--- a/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.jsx
+++ b/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.jsx
@@ -5,11 +5,16 @@ import { getLabel } from 'ducks/transactions'
 import Icon from 'cozy-ui/transpiled/react/Icon'
 import MagnifierIcon from 'cozy-ui/transpiled/react/Icons/Magnifier'
 
-const SearchForTransactionIcon = ({ transaction }) => {
-  const label = getLabel(transaction)
+import styles from 'ducks/transactions/TransactionModal/SearchForTransactionIcon.styl'
+
+const SearchForTransactionIcon = ({ transaction, ignoreManual = false }) => {
+  const label = getLabel(transaction, ignoreManual)
   return (
-    <a href={`#/search/${encodeURIComponent(label)}`}>
-      <Icon className="u-ml-half u-coolGrey" icon={MagnifierIcon} />
+    <a
+      className={styles.SearchForTransactionIcon}
+      href={`#/search/${encodeURIComponent(label)}`}
+    >
+      <Icon className="u-coolGrey" icon={MagnifierIcon} />
     </a>
   )
 }

--- a/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.styl
+++ b/src/ducks/transactions/TransactionModal/SearchForTransactionIcon.styl
@@ -1,0 +1,4 @@
+.SearchForTransactionIcon
+    align-self center
+    line-height 0
+    margin-left 8px

--- a/src/ducks/transactions/TransactionModal/TransactionLabel.jsx
+++ b/src/ducks/transactions/TransactionModal/TransactionLabel.jsx
@@ -2,28 +2,28 @@ import React from 'react'
 
 import Typography from 'cozy-ui/transpiled/react/Typography'
 
-import { getLabel } from 'ducks/transactions'
+import { getLabel, isTransactionEditable } from 'ducks/transactions/helpers'
 import SearchForTransactionIcon from 'ducks/transactions/TransactionModal/SearchForTransactionIcon'
+import LabelField from 'ducks/transactions/TransactionRow/LabelField'
 
 const TransactionLabel = ({ transaction }) => {
   const label = getLabel(transaction)
 
   return (
-    <div className="u-flex">
-      <Typography
-        variant="h6"
-        gutterBottom
-        className="u-ellipsis"
-        title={label}
-      >
-        {label}
-      </Typography>
-      {
-        <>
-          {' '}
-          <SearchForTransactionIcon transaction={transaction} />
-        </>
-      }
+    <div className="u-flex u-mb-half">
+      {isTransactionEditable(transaction) ? (
+        <LabelField transaction={transaction} variant="h6" />
+      ) : (
+        <Typography
+          variant="h6"
+          gutterBottom
+          className="u-ellipsis"
+          title={label}
+        >
+          {label}
+        </Typography>
+      )}{' '}
+      <SearchForTransactionIcon transaction={transaction} />
     </div>
   )
 }

--- a/src/ducks/transactions/TransactionModal/TransactionModal.styl
+++ b/src/ducks/transactions/TransactionModal/TransactionModal.styl
@@ -4,6 +4,7 @@
     transform rotate(180deg)
 
 .TransactionInfo
+    display flex
     line-height 1.7
     font-size 14px
     color var(--primaryTextColor)

--- a/src/ducks/transactions/TransactionModal/TransactionModalInfoContent.jsx
+++ b/src/ducks/transactions/TransactionModal/TransactionModalInfoContent.jsx
@@ -24,14 +24,17 @@ import {
 } from 'ducks/account/helpers'
 import {
   getCategoryId,
-  updateApplicationDate,
   getDate,
-  getApplicationDate
+  getApplicationDate,
+  getLabel,
+  hasEditedLabel,
+  updateApplicationDate
 } from 'ducks/transactions/helpers'
 import TransactionActions from 'ducks/transactions/TransactionActions'
 import { getCategoryName } from 'ducks/categories/categoriesMap'
 import CategoryIcon from 'ducks/categories/CategoryIcon'
 import { showAlertAfterApplicationDateUpdate } from 'ducks/transactions/TransactionModal/helpers'
+import SearchForTransactionIcon from 'ducks/transactions/TransactionModal/SearchForTransactionIcon'
 import TransactionLabel from 'ducks/transactions/TransactionModal/TransactionLabel'
 import TransactionInfos from 'ducks/transactions/TransactionModal/TransactionInfos'
 import RecurrenceRow from 'ducks/transactions/TransactionModal/RecurrenceRow'
@@ -120,6 +123,20 @@ const TransactionModalInfoContent = props => {
           <TransactionLabel transaction={transaction} />
           <TransactionInfos
             infos={[
+              {
+                label: t('Transactions.infos.originalBankLabel'),
+                value: hasEditedLabel(transaction) ? (
+                  <>
+                    {getLabel(transaction, true)}{' '}
+                    <SearchForTransactionIcon
+                      transaction={transaction}
+                      ignoreManual
+                    />
+                  </>
+                ) : (
+                  false
+                )
+              },
               {
                 label: t('Transactions.infos.account'),
                 value: getAccountLabel(account, t)

--- a/src/ducks/transactions/TransactionRow/LabelField.jsx
+++ b/src/ducks/transactions/TransactionRow/LabelField.jsx
@@ -1,0 +1,130 @@
+import { useClient } from 'cozy-client'
+import React, { useCallback, useRef, useState } from 'react'
+
+import Icon from 'cozy-ui/transpiled/react/Icon'
+import IconButton from 'cozy-ui/transpiled/react/IconButton'
+import CrossCircleOutlineIcon from 'cozy-ui/transpiled/react/Icons/CrossCircleOutline'
+import RestoreIcon from 'cozy-ui/transpiled/react/Icons/Restore'
+import PenIcon from 'cozy-ui/transpiled/react/Icons/Pen'
+import { CircularProgress } from 'cozy-ui/transpiled/react/Progress'
+import TextField from 'cozy-ui/transpiled/react/TextField'
+import Typography from 'cozy-ui/transpiled/react/Typography'
+import {
+  getLabel,
+  hasEditedLabel,
+  setTransactionLabel
+} from 'ducks/transactions/helpers'
+
+import styles from 'ducks/transactions/TransactionRow/LabelField.styl'
+
+export default function LabelField({ transaction, variant = 'body1' }) {
+  const client = useClient()
+  const [isEditing, setIsEditing] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const inputRef = useRef()
+  const containerRef = useRef()
+
+  const saveAndClose = useCallback(
+    async label => {
+      if (
+        label !== transaction.manualLabel &&
+        label !== getLabel(transaction, true)
+      ) {
+        const sanitized = label?.trim()
+        try {
+          setIsSaving(true)
+          await client.save(
+            setTransactionLabel(
+              transaction,
+              sanitized?.length ? sanitized : null
+            )
+          )
+        } finally {
+          setIsSaving(false)
+        }
+      }
+      setIsEditing(false)
+    },
+    [client, setIsEditing, setIsSaving, transaction]
+  )
+
+  const handleEdit = useCallback(
+    event => {
+      event.stopPropagation()
+      setIsEditing(true)
+    },
+    [setIsEditing]
+  )
+
+  const handleClose = useCallback(
+    () => saveAndClose(inputRef.current.value),
+    [saveAndClose]
+  )
+
+  const handleRestore = useCallback(() => {
+    saveAndClose(null)
+  }, [saveAndClose])
+
+  const handleKeyDown = useCallback(
+    ({ key }) => {
+      if (key === 'Enter') {
+        handleClose()
+      } else if (key === 'Escape') {
+        setIsEditing(false)
+      }
+    },
+    [handleClose, setIsEditing]
+  )
+
+  const handleBlur = useCallback(
+    ({ relatedTarget }) => {
+      if (containerRef.current?.contains(relatedTarget)) {
+        // do not close when focused element is inside the component
+        return
+      }
+      saveAndClose(inputRef.current.value)
+    },
+    [saveAndClose]
+  )
+
+  return isEditing ? (
+    <div
+      onBlur={handleBlur}
+      ref={containerRef}
+      onClick={e => e.stopPropagation()}
+    >
+      <TextField
+        autoFocus
+        fullWidth
+        defaultValue={getLabel(transaction)}
+        className={styles.EditableLabel}
+        inputRef={inputRef}
+        onKeyDown={handleKeyDown}
+        variant="outlined"
+        InputProps={{
+          endAdornment: isSaving ? (
+            <CircularProgress size={24} />
+          ) : (
+            <>
+              <IconButton size="small" onClick={handleClose}>
+                <Icon icon={CrossCircleOutlineIcon} size={14} />
+              </IconButton>
+              {hasEditedLabel(transaction) ? (
+                <IconButton size="small" onClick={handleRestore}>
+                  <Icon icon={RestoreIcon} size={14} />
+                </IconButton>
+              ) : null}
+            </>
+          )
+        }}
+      />
+    </div>
+  ) : (
+    <div className={styles.FixedLabel}>
+      <Typography variant={variant}>{getLabel(transaction)}</Typography>
+      <IconButton size="small" onClick={handleEdit}>
+        <Icon icon={PenIcon} color="var(--coolGrey)" size={14} />
+      </IconButton>
+    </div>
+  )
+}

--- a/src/ducks/transactions/TransactionRow/LabelField.styl
+++ b/src/ducks/transactions/TransactionRow/LabelField.styl
@@ -1,0 +1,17 @@
+.EditableLabel
+    // customize Mui styles to implement a small size
+    legend
+        display inherit
+
+    input
+        padding 8px
+        padding-right 4px
+
+    > div
+        padding-right 4px
+
+.FixedLabel
+    display flex
+    align-items center
+    gap 8px
+    

--- a/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowDesktop.jsx
@@ -17,7 +17,9 @@ import CategoryIcon from 'ducks/categories/CategoryIcon'
 import {
   getCategoryId,
   getLabel,
-  getApplicationDate
+  getApplicationDate,
+  hasEditedLabel,
+  isTransactionEditable
 } from 'ducks/transactions/helpers'
 import styles from 'ducks/transactions/Transactions.styl'
 import { getCurrencySymbol } from 'utils/currencySymbol'
@@ -28,6 +30,7 @@ import {
 } from 'ducks/transactions/TransactionRow'
 import ApplicationDateCaption from 'ducks/transactions/TransactionRow/ApplicationDateCaption'
 import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
+import LabelField from 'ducks/transactions/TransactionRow/LabelField'
 import TransactionDate from 'ducks/transactions/TransactionRow/TransactionDate'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
 import TagChips from 'components/Tag/TagChips'
@@ -106,8 +109,7 @@ const TransactionRowDesktop = ({
     [isSelectionModeActive, showTransactionModal, toggleSelection, transaction]
   )
 
-  // Virtual transactions, like those generated from recurrences, cannot be edited
-  const canEditTransaction = transaction._id
+  const canEditTransaction = isTransactionEditable(transaction)
 
   return (
     <>
@@ -158,7 +160,18 @@ const TransactionRowDesktop = ({
             </Img>
             <Bd className="u-pl-1">
               <ListItemText className="u-pv-half" disableTypography>
-                <Typography variant="body1">{getLabel(transaction)}</Typography>
+                {canEditTransaction ? (
+                  <LabelField transaction={transaction} />
+                ) : (
+                  <Typography variant="body1">
+                    {getLabel(transaction)}
+                  </Typography>
+                )}
+                {hasEditedLabel(transaction) ? (
+                  <Typography variant="caption" color="textSecondary">
+                    {getLabel(transaction, true)}
+                  </Typography>
+                ) : null}
                 {!filteringOnAccount && <AccountCaption account={account} />}
                 {applicationDate && (
                   <ApplicationDateCaption transaction={transaction} />

--- a/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
+++ b/src/ducks/transactions/TransactionRow/TransactionRowMobile.jsx
@@ -19,7 +19,9 @@ import CategoryIcon from 'ducks/categories/CategoryIcon'
 import {
   getCategoryId,
   getLabel,
-  getApplicationDate
+  getApplicationDate,
+  hasEditedLabel,
+  isTransactionEditable
 } from 'ducks/transactions/helpers'
 import styles from 'ducks/transactions/Transactions.styl'
 import { getCurrencySymbol } from 'utils/currencySymbol'
@@ -29,6 +31,7 @@ import {
 } from 'ducks/transactions/TransactionRow'
 import ApplicationDateCaption from 'ducks/transactions/TransactionRow/ApplicationDateCaption'
 import AccountCaption from 'ducks/transactions/TransactionRow/AccountCaption'
+import LabelField from 'ducks/transactions/TransactionRow/LabelField'
 import RecurrenceCaption from 'ducks/transactions/TransactionRow/RecurrenceCaption'
 import { useSelectionContext } from 'ducks/context/SelectionContext'
 import TransactionOpener from 'ducks/transactions/TransactionRow/TransactionOpener'
@@ -75,6 +78,8 @@ const TransactionRowMobile = ({
   const applicationDate = getApplicationDate(transaction)
   const recurrence = transaction.recurrence ? transaction.recurrence.data : null
 
+  const canEditTransaction = isTransactionEditable(transaction)
+
   return (
     <>
       <TransactionOpener
@@ -89,7 +94,7 @@ const TransactionRowMobile = ({
           className={cx({
             [styles['TransactionRow--selected']]: isSelected
           })}
-          button={!!transaction._id}
+          button={canEditTransaction}
         >
           <Media className="u-w-100">
             <RowCheckbox isSelected={isSelected} />
@@ -107,9 +112,18 @@ const TransactionRowMobile = ({
                 </Img>
                 <Bd className="u-mr-half">
                   <ListItemText disableTypography>
-                    <Typography className="u-ellipsis" variant="body1">
-                      {getLabel(transaction)}
-                    </Typography>
+                    {canEditTransaction ? (
+                      <LabelField transaction={transaction} />
+                    ) : (
+                      <Typography className="u-ellipsis" variant="body1">
+                        {getLabel(transaction)}
+                      </Typography>
+                    )}
+                    {hasEditedLabel(transaction) ? (
+                      <Typography variant="caption" color="textSecondary">
+                        {getLabel(transaction, true)}
+                      </Typography>
+                    ) : null}
                     {!filteringOnAccount && (
                       <AccountCaption account={account} />
                     )}

--- a/src/ducks/transactions/helpers.js
+++ b/src/ducks/transactions/helpers.js
@@ -40,7 +40,12 @@ const titleRx = /(?:^|\s)\S/g
 const titleCase = label =>
   label.toLowerCase().replace(titleRx, a => a.toUpperCase())
 
-export const getLabel = transaction => cleanLabel(titleCase(transaction.label))
+export const hasEditedLabel = transaction => Boolean(transaction.manualLabel)
+
+export const getLabel = (transaction, ignoreManual = false) =>
+  ignoreManual || !hasEditedLabel(transaction)
+    ? cleanLabel(titleCase(transaction.label))
+    : transaction.manualLabel
 
 export const getAccountType = transaction => {
   return get(transaction, 'account.data.type')
@@ -247,6 +252,18 @@ export const setTransactionCategory = (transaction, category) => {
     manualCategoryId: category.id
   }
   return newTransaction
+}
+
+export const setTransactionLabel = (transaction, label) => {
+  return {
+    ...transaction,
+    manualLabel: label
+  }
+}
+
+export const isTransactionEditable = transaction => {
+  // Virtual transactions, like those generated from recurrences, cannot be edited
+  return Boolean(transaction?._id)
 }
 
 export const updateTransactionRecurrence = async (


### PR DESCRIPTION
### ✨ What's in there?

Hi Cozy! As discussed [on the forum](https://forum.cozy.io/t/cozy-banks-categories-personnalisees-commentaires-texte/7016/9?u=feugy) this is an attempt to allow users editing their transaction labels.

![image](https://github.com/cozy/cozy-banks/assets/186268/1edb28a3-e538-40cd-9bfa-870d983c44bb)

After considering adding a new comments field, I've leveraged the existing `manualLabel` which is used in recurring transactions.

Users can now:
- edit their transaction labels in the transaction list (and search results). A new "pen" icon button turns the read-only cell into a text field (`LabelField` React component).
- edit their transaction labels in the transaction modal, in a similar fashion.
- see original labels, in case they changed some.
- reset to the original label, with a dedicated "restore" button in the text field.
- from the transaction modal, search for the manual or original label.
- take advantage of keyboard navigation: when entering edition mode, the text field grabs focus. While editing, `Enter` will close and save, `Escape` will close without saving. All icon are buttons which are in the tab cycle. 

### 🧪 How to test?

Here is a possible scenario:
1. Grab the code, locally, assuming you already have Cozy server set up and ready, with some fixtures install
1. Connect to http://banks.cozy.localhost:8080/#/balances/details
    > in the transaction list, you'll have new pen icons
1. Click on a pen icon
    > the label is replaced with a text field with the original label as value, focus, and a close button in it  
1. Change the value, and click on the close button/hit Escape key/click somewhere else
    > the manual value is saved, text field replaced with read-only value, and the original value is visible below.
1. Click on the transaction row
    > it opens the modal, with the manual and original labels, both followed by search icons
1. Click on the manual label pen icon
    > the manual field is editable, it has focus, close and restore icon
1. Hit Tab twice to focus on the restore icon, then Enter to trigger it
    > the manual label is discarded, text field replaced by read-only value. The original label row is gone, and the value in transaction list is also restored

There's plenty of other ways to test it, you can also try to search for manual labels.

### ❗ Notes to reviewers

This PR is draft, and I'd like to collect some feedback before adding automated tests.
In particular, I'd like to draw reviewers' attention on some tradeoffs:
1. the "pen" icon button are very small, which isn't convenient on mobile. However making them bigger makes the transaction row higher, which does not look good

1. the "close" button comes before "restore" button to make keyboard edition smoother.

1. the transaction is only saved when the text field is losing focus: no complicate throttle needed

1. I've styled the TextField so it looks like a Input field with "tiny" size, like in cozy-drive [FilenameInput](https://github.com/cozy/cozy-drive/blob/master/src/modules/filelist/FilenameInput.jsx) 

Finally it worth calling out the great dev material you made to ease contributions. The setup isn't too complicated, and it's easy for a React dev to contribute.
I couldn't make HMR work (despite running my cozy-app-dev docker container with `-e COZY_DISABLE_CSP=1`), but it's not too bad.

