### PR TITLE
fix: Build configuration to be able to send notifications into a service

### DIFF
--- a/config/webpack.target.services.js
+++ b/config/webpack.target.services.js
@@ -48,7 +48,9 @@ module.exports = {
     exprContextRegExp: /$^/,
     exprContextCritical: false
   },
-
+  optimization: {
+    minimize: false
+  },
   resolve: {
     alias: {
       // We are building with target: node as webpack options. This causes webpack


### PR DESCRIPTION
The package `mjml` can not be minimized to fix `Element mj-head doesn't exist or is not registered ...` error
when sending a notification at runtime after a build (cf: https://github.com/cozy/cozy-libs/commit/dd7bbf4af452b51b4287cb145e48b0cba2280daf) 

```
### 🐛 Bug Fixes

* Build configuration to be able to send notifications into a service
```
