### PR TITLE
fix: Use the right API

### DIFF
--- a/src/ducks/categorization/services.js
+++ b/src/ducks/categorization/services.js
@@ -51,7 +51,7 @@ export const categorizeChunk = async (categorizer, chunk) => {
   const categorizedTransactions = categorizer.categorize(chunk)
   categorizedTransactions.forEach(t => (t.toCategorize = false))
 
-  await BankTransaction.bulkSave(categorizedTransactions, 30)
+  await BankTransaction.bulkSave(categorizedTransactions, { concurrency: 30 })
 
   const timeEnd = new Date()
   const timeElapsed = differenceInSeconds(timeEnd, timeStart)


### PR DESCRIPTION
In order to avoid warning



```
### ✨ Features

*

### 🐛 Bug Fixes

*

### 🔧 Tech

* Don't log any warning when launching the `categorization ` service (aka remove `Second argument of bulkSave is now an object, please use bulkSave(documents, { logProgress, concurrency })` lokg) 

```
