### PR TITLE
chore: fix "sucessfuly" typo

### DIFF
--- a/src/ducks/notifications/HealthBillLinked/index.js
+++ b/src/ducks/notifications/HealthBillLinked/index.js
@@ -130,7 +130,7 @@ class HealthBillLinked extends NotificationView {
    * Saves last notification date to transactions for which there was
    * the notification.
    *
-   * Executed by `Notification` when the notification has been successfuly sent
+   * Executed by `Notification` when the notification has been successfully sent
    * See `Notification::sendNotification`
    */
   async onSuccess() {

--- a/src/ducks/notifications/HealthBillLinked/index.spec.js
+++ b/src/ducks/notifications/HealthBillLinked/index.spec.js
@@ -81,7 +81,7 @@ describe('HealthBillLinked', () => {
   })
 
   describe('onSuccess', () => {
-    it('should be called after successfuly sending notifications', async () => {
+    it('should be called after successfully sending notifications', async () => {
       jest.spyOn(Bill, 'getAll').mockResolvedValue(mockBills)
 
       const client = new CozyClient({

--- a/src/ducks/notifications/LateHealthReimbursement/index.js
+++ b/src/ducks/notifications/LateHealthReimbursement/index.js
@@ -206,13 +206,13 @@ class LateHealthReimbursement extends NotificationView {
    * Saves last notification date to transactions for which there was
    * the notification.
    *
-   * Executed by `Notification` when the notification has been successfuly sent
+   * Executed by `Notification` when the notification has been successfully sent
    * See `Notification::sendNotification`
    */
   async onSuccess() {
     log(
       'info',
-      '[🔔 notifications] LateHealthReimbursement: notification successfuly sent'
+      '[🔔 notifications] LateHealthReimbursement: notification successfully sent'
     )
 
     this.toNotify.forEach(transaction => {

--- a/src/ducks/notifications/TransactionGreater/index.js
+++ b/src/ducks/notifications/TransactionGreater/index.js
@@ -265,7 +265,7 @@ class TransactionGreater extends NotificationView {
    * Saves last notification date to transactions for which there was
    * the notification.
    *
-   * Executed by `Notification` when the notification has been successfuly sent
+   * Executed by `Notification` when the notification has been successfully sent
    * See `Notification::sendNotification`
    */
   async onSuccess() {

--- a/src/targets/services/categorization.js
+++ b/src/targets/services/categorization.js
@@ -54,7 +54,7 @@ const runCategorization = async client => {
     }
   }
 
-  log('info', 'All transactions have been successfuly categorized.')
+  log('info', 'All transactions have been successfully categorized.')
 
   log('info', 'Starting onOperationOrBillCreate service...')
   await startService(client, 'onOperationOrBillCreate')


### PR DESCRIPTION
### 🐛 Bug Fixes

* fixes a small typo `sucessfuly` -> `successfully`
